### PR TITLE
Update basic vs SAML auth handling on server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           name: Docker Build
           command: |
             docker login -u $DOCKER_USER -p $DOCKER_PASS
-            TAG=$CIRCLE_BRANCH-$CIRCLE_SHA1
+            TAG=${CIRCLE_BRANCH//\//-}-$CIRCLE_SHA1
             DOCKER_HUB_REPO=${CIRCLE_PROJECT_REPONAME,,}
             docker build -t talentmap/$DOCKER_HUB_REPO:$TAG .
             docker push talentmap/$DOCKER_HUB_REPO:$TAG
@@ -145,7 +145,7 @@ jobs:
       - run:
           name: Push Stable Docker Image
           command: |
-            TAG=$CIRCLE_BRANCH-$CIRCLE_SHA1
+            TAG=${CIRCLE_BRANCH//\//-}-$CIRCLE_SHA1
             DOCKER_HUB_REPO=${CIRCLE_PROJECT_REPONAME,,}
             docker login -u $DOCKER_USER -p $DOCKER_PASS
             docker pull talentmap/$DOCKER_HUB_REPO:$TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,8 @@ jobs:
           name: Docker Build
           command: |
             docker login -u $DOCKER_USER -p $DOCKER_PASS
-            TAG=${CIRCLE_BRANCH//\//-}-$CIRCLE_SHA1
+            BRANCH=${CIRCLE_BRANCH//\//-}
+            TAG=$BRANCH-$CIRCLE_SHA1
             DOCKER_HUB_REPO=${CIRCLE_PROJECT_REPONAME,,}
             docker build -t talentmap/$DOCKER_HUB_REPO:$TAG .
             docker push talentmap/$DOCKER_HUB_REPO:$TAG
@@ -145,12 +146,13 @@ jobs:
       - run:
           name: Push Stable Docker Image
           command: |
-            TAG=${CIRCLE_BRANCH//\//-}-$CIRCLE_SHA1
+            BRANCH=${CIRCLE_BRANCH//\//-}
+            TAG=$BRANCH-$CIRCLE_SHA1
             DOCKER_HUB_REPO=${CIRCLE_PROJECT_REPONAME,,}
             docker login -u $DOCKER_USER -p $DOCKER_PASS
             docker pull talentmap/$DOCKER_HUB_REPO:$TAG
-            docker tag talentmap/$DOCKER_HUB_REPO:$TAG talentmap/$DOCKER_HUB_REPO:$CIRCLE_BRANCH
-            docker push talentmap/$DOCKER_HUB_REPO:$CIRCLE_BRANCH
+            docker tag talentmap/$DOCKER_HUB_REPO:$TAG talentmap/$DOCKER_HUB_REPO:$BRANCH
+            docker push talentmap/$DOCKER_HUB_REPO:$BRANCH
 workflows:
   version: 2
   build_and_test:

--- a/src/server.js
+++ b/src/server.js
@@ -19,6 +19,9 @@ const API_ROOT = process.env.API_ROOT || 'http://localhost:8000';
 // define the prefix for the application
 const PUBLIC_URL = process.env.PUBLIC_URL || '/talentmap/';
 
+// auth mode
+const USE_BASIC_AUTH = process.env.LOGIN_MODE === 'basic';
+
 /* eslint-disable no-unused-vars */
 // Define the SAML login redirect
 let SAML_LOGIN = `${API_ROOT}/saml2/acs/`;
@@ -98,18 +101,24 @@ app.post(PUBLIC_URL, (request, response) => {
 });
 
 // saml2 login
-app.get(`${PUBLIC_URL}login`, (request, response) => {
-  // create handler
-  // eslint-disable-next-line no-unused-vars
-  const loginHandler = (err, loginUrl, requestId) => {
-    if (err) {
-      response.sendStatus(500);
-    } else {
-      response.redirect(loginUrl);
-    }
-  };
+app.get(`${PUBLIC_URL}login`, (request, response, next) => {
+  // check if using SAML auth mode
+  if (!USE_BASIC_AUTH) {
+    // create handler
+    // eslint-disable-next-line no-unused-vars
+    const loginHandler = (err, loginUrl, requestId) => {
+      if (err) {
+        response.sendStatus(500);
+      } else {
+        response.redirect(loginUrl);
+      }
+    };
 
-  login(loginHandler);
+    login(loginHandler);
+  } else {
+    // render from ROUTES
+    next();
+  }
 });
 
 


### PR DESCRIPTION
An issue we were having on the deployed site was that even when the front-end was built to use `LOGIN_MODE=basic` auth, the server would try to do all the SAML handling when the user hit `/login`. This PR adds a condition to the server's `/login` route to only perform SAML handling if `LOGIN_MODE !== basic`, and if not, to simply render `index.html`, where the `/login` will be passed to React and the user is greeted with the login screen.