### PR TITLE
Add Bid Count to Bid Tracker cards

### DIFF
--- a/src/Components/BidTracker/BidTrackerCard/BidTrackerCard.jsx
+++ b/src/Components/BidTracker/BidTrackerCard/BidTrackerCard.jsx
@@ -25,7 +25,9 @@ const BidTrackerCard = ({ bid, acceptBid, declineBid, submitBid, deleteBid, user
   return (
     <div className="bid-tracker">
       <div>
-        <BidTrackerCardTop bid={bid} />
+        <BidTrackerCardTop
+          bid={bid}
+        />
         <div className={`usa-grid-full padded-container-inner bid-tracker-bid-steps-container ${draftClass}`}>
           <BidSteps bid={bid} />
           {

--- a/src/Components/BidTracker/BidTrackerCardTitle/BidTrackerCardTitle.jsx
+++ b/src/Components/BidTracker/BidTrackerCardTitle/BidTrackerCardTitle.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { BID_STATISTICS_OBJECT } from '../../../Constants/PropTypes';
+import { BID_STATISTICS_OBJECT, POST_DETAILS } from '../../../Constants/PropTypes';
 import BidCount from '../../BidCount';
 import { SUBMITTED_PROP } from '../../../Constants/BidData';
 import { getPostName } from '../../../utilities';
@@ -19,7 +19,9 @@ const BidTrackerCardTitle = ({ title, id, status, bidStatistics, post }) => (
         <div className="bid-tracker-card-title-bottom">
           <strong>Post:</strong> {getPostName(post)}
         </div>
-        <BidCount bidStatistics={bidStatistics} altStyle />
+        <span className="bid-stats">
+          <BidCount bidStatistics={bidStatistics} altStyle />
+        </span>
       </div>
     }
   </div>
@@ -30,7 +32,7 @@ BidTrackerCardTitle.propTypes = {
   id: PropTypes.string.isRequired,
   status: PropTypes.string.isRequired,
   bidStatistics: BID_STATISTICS_OBJECT.isRequired,
-  post: PropTypes.shape({}).isRequired,
+  post: POST_DETAILS.isRequired,
 };
 
 export default BidTrackerCardTitle;

--- a/src/Components/BidTracker/BidTrackerCardTitle/BidTrackerCardTitle.jsx
+++ b/src/Components/BidTracker/BidTrackerCardTitle/BidTrackerCardTitle.jsx
@@ -1,19 +1,36 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
+import { BID_STATISTICS_OBJECT } from '../../../Constants/PropTypes';
+import BidCount from '../../BidCount';
+import { SUBMITTED_PROP } from '../../../Constants/BidData';
+import { getPostName } from '../../../utilities';
 
-const BidTrackerCardTitle = ({ title, id }) => (
-  <div className="bid-tracker-card-title-container">
-    <div className="bid-tracker-card-title-text">{title}</div>
-    <div className="bid-tracker-card-title-link">
-      <Link to={`/details/${id}`}>View position</Link>
+const BidTrackerCardTitle = ({ title, id, status, bidStatistics, post }) => (
+  <div className="usa-grid-full">
+    <div className="usa-grid-full bid-tracker-card-title-container">
+      <div className="bid-tracker-card-title-text">{title}</div>
+      <div className="bid-tracker-card-title-link">
+        <Link to={`/details/${id}`}>View position</Link>
+      </div>
     </div>
+    {status === SUBMITTED_PROP &&
+      <div className="usa-grid-full">
+        <div className="bid-tracker-card-title-bottom">
+          <strong>Post:</strong> {getPostName(post)}
+        </div>
+        <BidCount bidStatistics={bidStatistics} altStyle />
+      </div>
+    }
   </div>
 );
 
 BidTrackerCardTitle.propTypes = {
   title: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
+  status: PropTypes.string.isRequired,
+  bidStatistics: BID_STATISTICS_OBJECT.isRequired,
+  post: PropTypes.shape({}).isRequired,
 };
 
 export default BidTrackerCardTitle;

--- a/src/Components/BidTracker/BidTrackerCardTitle/BidTrackerCardTitle.test.jsx
+++ b/src/Components/BidTracker/BidTrackerCardTitle/BidTrackerCardTitle.test.jsx
@@ -2,18 +2,57 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import toJSON from 'enzyme-to-json';
 import BidTrackerCardTitle from './BidTrackerCardTitle';
+import { DRAFT_PROP, SUBMITTED_PROP } from '../../../Constants/BidData';
+import bidStatistics from '../../../__mocks__/bidStatistics';
+import postObject from '../../../__mocks__/postObject';
+
+const props = {
+  title: 'Title',
+  id: 'a123',
+  status: DRAFT_PROP,
+  bidStatistics,
+  post: postObject,
+};
 
 describe('BidTrackerCardTitleComponent', () => {
   it('is defined', () => {
     const wrapper = shallow(
-      <BidTrackerCardTitle title="Title" id="a123" />,
+      <BidTrackerCardTitle {...props} />,
     );
     expect(wrapper).toBeDefined();
   });
 
-  it('matches snapshot', () => {
+  it('is defined when status is "submitted"', () => {
     const wrapper = shallow(
-      <BidTrackerCardTitle title="Title" id="a123" />,
+      <BidTrackerCardTitle {...props} status={SUBMITTED_PROP} />,
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it('it renders extra content when status is "submitted"', () => {
+    const wrapper = shallow(
+      <BidTrackerCardTitle {...props} status={SUBMITTED_PROP} />,
+    );
+    expect(wrapper.find('.bid-tracker-card-title-bottom').exists()).toBe(true);
+  });
+
+  it('it does not render extra content when status is not "submitted"', () => {
+    const wrapper = shallow(
+      <BidTrackerCardTitle {...props} status={DRAFT_PROP} />,
+    );
+    expect(wrapper.find('bid-tracker-card-title-bottom').exists()).toBe(false);
+  });
+
+  it('matches snapshot when status is not "submitted"', () => {
+    const wrapper = shallow(
+      <BidTrackerCardTitle {...props} status={DRAFT_PROP} />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
+  it('matches snapshot when status is "submitted"', () => {
+    const wrapper = shallow(
+      <BidTrackerCardTitle {...props} status={SUBMITTED_PROP} />,
     );
     expect(toJSON(wrapper)).toMatchSnapshot();
   });

--- a/src/Components/BidTracker/BidTrackerCardTitle/__snapshots__/BidTrackerCardTitle.test.jsx.snap
+++ b/src/Components/BidTracker/BidTrackerCardTitle/__snapshots__/BidTrackerCardTitle.test.jsx.snap
@@ -1,23 +1,89 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BidTrackerCardTitleComponent matches snapshot 1`] = `
+exports[`BidTrackerCardTitleComponent matches snapshot when status is "submitted" 1`] = `
 <div
-  className="bid-tracker-card-title-container"
+  className="usa-grid-full"
 >
   <div
-    className="bid-tracker-card-title-text"
+    className="usa-grid-full bid-tracker-card-title-container"
   >
-    Title
+    <div
+      className="bid-tracker-card-title-text"
+    >
+      Title
+    </div>
+    <div
+      className="bid-tracker-card-title-link"
+    >
+      <Link
+        replace={false}
+        to="/details/a123"
+      >
+        View position
+      </Link>
+    </div>
   </div>
   <div
-    className="bid-tracker-card-title-link"
+    className="usa-grid-full"
   >
-    <Link
-      replace={false}
-      to="/details/a123"
+    <div
+      className="bid-tracker-card-title-bottom"
     >
-      View position
-    </Link>
+      <strong>
+        Post:
+      </strong>
+       
+      Maseru, Lesotho
+    </div>
+    <BidCount
+      altStyle={true}
+      bidStatistics={
+        Object {
+          "approved_bidders": 1,
+          "available_domestic_positions": 81,
+          "available_international_positions": 159,
+          "available_positions": 240,
+          "bidding_days_remaining": 30,
+          "cycle_deadline_date": "2018-02-10T00:00:00Z",
+          "cycle_end_date": "2018-04-10T00:00:00Z",
+          "cycle_start_date": "2017-10-10T00:00:00Z",
+          "id": 1,
+          "in_panel_bidders": 0,
+          "name": "Demo BidCycle 2018-01-10 15:52:20.583434",
+          "total_bidders": 4,
+          "total_bids": 40,
+          "total_positions": 251,
+        }
+      }
+      hideLabel={false}
+      label="Bid Count:"
+    />
+  </div>
+</div>
+`;
+
+exports[`BidTrackerCardTitleComponent matches snapshot when status is not "submitted" 1`] = `
+<div
+  className="usa-grid-full"
+>
+  <div
+    className="usa-grid-full bid-tracker-card-title-container"
+  >
+    <div
+      className="bid-tracker-card-title-text"
+    >
+      Title
+    </div>
+    <div
+      className="bid-tracker-card-title-link"
+    >
+      <Link
+        replace={false}
+        to="/details/a123"
+      >
+        View position
+      </Link>
+    </div>
   </div>
 </div>
 `;

--- a/src/Components/BidTracker/BidTrackerCardTitle/__snapshots__/BidTrackerCardTitle.test.jsx.snap
+++ b/src/Components/BidTracker/BidTrackerCardTitle/__snapshots__/BidTrackerCardTitle.test.jsx.snap
@@ -35,29 +35,33 @@ exports[`BidTrackerCardTitleComponent matches snapshot when status is "submitted
        
       Maseru, Lesotho
     </div>
-    <BidCount
-      altStyle={true}
-      bidStatistics={
-        Object {
-          "approved_bidders": 1,
-          "available_domestic_positions": 81,
-          "available_international_positions": 159,
-          "available_positions": 240,
-          "bidding_days_remaining": 30,
-          "cycle_deadline_date": "2018-02-10T00:00:00Z",
-          "cycle_end_date": "2018-04-10T00:00:00Z",
-          "cycle_start_date": "2017-10-10T00:00:00Z",
-          "id": 1,
-          "in_panel_bidders": 0,
-          "name": "Demo BidCycle 2018-01-10 15:52:20.583434",
-          "total_bidders": 4,
-          "total_bids": 40,
-          "total_positions": 251,
+    <span
+      className="bid-stats"
+    >
+      <BidCount
+        altStyle={true}
+        bidStatistics={
+          Object {
+            "approved_bidders": 1,
+            "available_domestic_positions": 81,
+            "available_international_positions": 159,
+            "available_positions": 240,
+            "bidding_days_remaining": 30,
+            "cycle_deadline_date": "2018-02-10T00:00:00Z",
+            "cycle_end_date": "2018-04-10T00:00:00Z",
+            "cycle_start_date": "2017-10-10T00:00:00Z",
+            "id": 1,
+            "in_panel_bidders": 0,
+            "name": "Demo BidCycle 2018-01-10 15:52:20.583434",
+            "total_bidders": 4,
+            "total_bids": 40,
+            "total_positions": 251,
+          }
         }
-      }
-      hideLabel={false}
-      label="Bid Count:"
-    />
+        hideLabel={false}
+        label="Bid Count:"
+      />
+    </span>
   </div>
 </div>
 `;

--- a/src/Components/BidTracker/BidTrackerCardTop/BidTrackerCardTop.jsx
+++ b/src/Components/BidTracker/BidTrackerCardTop/BidTrackerCardTop.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import FontAwesome from 'react-fontawesome';
+import { get } from 'lodash';
 import { BID_OBJECT } from '../../../Constants/PropTypes';
 import BidTrackerCardTitle from '../BidTrackerCardTitle';
 import ActionsDropdown from '../ActionsDropdown';
@@ -8,10 +9,18 @@ import { getActionPermissions } from '../BidHelpers';
 
 const BidTrackerCardTop = ({ bid, showQuestion }) => {
   const actionPermissions = getActionPermissions(bid.status) || {};
+  const bidStatistics = get(bid, 'position.bid_statistics[0]', {});
+  const post = get(bid, 'position.post', {});
   return (
     <div className="usa-grid-full padded-container-inner bid-tracker-title-container">
       <div className="bid-tracker-title-content-container">
-        <BidTrackerCardTitle title={bid.position.title} id={bid.position.position_number} />
+        <BidTrackerCardTitle
+          title={bid.position.title}
+          id={bid.position.position_number}
+          status={bid.status}
+          bidStatistics={bidStatistics}
+          post={post}
+        />
       </div>
       <div>
         <div className="bid-tracker-card-title-container-right">

--- a/src/Components/BidTracker/BidTrackerCardTop/__snapshots__/BidTrackerCardTop.test.jsx.snap
+++ b/src/Components/BidTracker/BidTrackerCardTop/__snapshots__/BidTrackerCardTop.test.jsx.snap
@@ -8,7 +8,21 @@ exports[`BidTrackerCardTopComponent matches snapshot 1`] = `
     className="bid-tracker-title-content-container"
   >
     <BidTrackerCardTitle
+      bidStatistics={Object {}}
       id="10035561"
+      post={
+        Object {
+          "id": 199,
+          "location": Object {
+            "city": "Freetown",
+            "code": "00A",
+            "country": "Sierra Leone",
+            "id": 103,
+            "state": "",
+          },
+        }
+      }
+      status="approved"
       title="POLITICAL/ECONOMIC OFFICER"
     />
   </div>

--- a/src/sass/_bidTracker.scss
+++ b/src/sass/_bidTracker.scss
@@ -124,6 +124,14 @@ $draft-icon-offset: 120px;
   margin-bottom: 20px;
   min-width: $card-width;
 
+  .bid-count-container {
+    float: left;
+  }
+
+  .bid-count-label {
+    margin-top: .4em;
+  }
+
   .step-title-sub-text {
     color: $color-gray;
     font-size: 13px;
@@ -190,6 +198,12 @@ $draft-icon-offset: 120px;
     font-size: 19px;
     font-weight: bold;
     padding-right: 10px;
+  }
+
+  .bid-tracker-card-title-bottom {
+    float: left;
+    margin-right: .5em;
+    margin-top: .6em;
   }
 
   .bid-tracker-card-title-link {

--- a/src/sass/_bidTracker.scss
+++ b/src/sass/_bidTracker.scss
@@ -128,6 +128,12 @@ $draft-icon-offset: 120px;
     float: left;
   }
 
+  .bid-stats {
+    .bid-count-list {
+      font-size: 90%;
+    }
+  }
+
   .bid-count-label {
     margin-top: .4em;
   }


### PR DESCRIPTION
- Adds Bid Count to Bid Tracker cards that are in the "submitted" state
- Matches designs
- WIP as I'll wait on @rtirserio 's PR so that Bid Count styles match (Wait for #28 to be merged)