### PR TITLE
Update bid list due date to match site-wide format

### DIFF
--- a/src/Components/ProfileDashboard/BidList/BidListHeader/BidListHeader.jsx
+++ b/src/Components/ProfileDashboard/BidList/BidListHeader/BidListHeader.jsx
@@ -1,16 +1,27 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import FontAwesome from 'react-fontawesome';
+import dateFns from 'date-fns';
+import { formatDate } from '../../../../utilities';
 
 // Due date is static for now
-const BidListHeader = () => (
+const BidListHeader = ({ date }) => (
   <div className="usa-grid-full bid-list-header section-padded-inner-container-narrow">
     <div className="usa-width-two-thirds bid-list-header-text">
-      <FontAwesome name="clock-o" /> All bids are due 7.15.18
+      <FontAwesome name="clock-o" />{` All bids are due ${formatDate(date)}`}
     </div>
     <div className="usa-width-one-third bid-list-header-button-container">
       <button className="bid-list-header-button">More Info</button>
     </div>
   </div>
 );
+
+BidListHeader.propTypes = {
+  date: PropTypes.string,
+};
+
+BidListHeader.defaultProps = {
+  date: dateFns.format('07/15/2019', 'MM/DD/YYYY'),
+};
 
 export default BidListHeader;

--- a/src/Components/ProfileDashboard/BidList/BidListHeader/__snapshots__/BidListHeader.test.jsx.snap
+++ b/src/Components/ProfileDashboard/BidList/BidListHeader/__snapshots__/BidListHeader.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`BidListHeaderComponent matches snapshot 1`] = `
     <FontAwesome
       name="clock-o"
     />
-     All bids are due 7.15.18
+     All bids are due 07/15/2019
   </div>
   <div
     className="usa-width-one-third bid-list-header-button-container"

--- a/src/Components/ProfileDashboard/BidList/__snapshots__/BidList.test.jsx.snap
+++ b/src/Components/ProfileDashboard/BidList/__snapshots__/BidList.test.jsx.snap
@@ -5,7 +5,9 @@ exports[`BidListComponent matches snapshot 1`] = `
   className="usa-grid-full"
 >
   <Connect(StaticDevContent)>
-    <BidListHeader />
+    <BidListHeader
+      date="07/15/2019"
+    />
   </Connect(StaticDevContent)>
   <div
     className="usa-grid-full section-padded-inner-container"
@@ -214,7 +216,9 @@ exports[`BidListComponent matches snapshot when there are no bids 1`] = `
   className="usa-grid-full"
 >
   <Connect(StaticDevContent)>
-    <BidListHeader />
+    <BidListHeader
+      date="07/15/2019"
+    />
   </Connect(StaticDevContent)>
   <div
     className="usa-grid-full section-padded-inner-container"


### PR DESCRIPTION
Passes the bid list due date through our date formatter so that its format matches the rest of the site. (ex: 7.15.19 -> 07/11/19)