### PR TITLE
Feature/remove bid locations

### DIFF
--- a/src/Components/BidTracker/BidTrackerCard/BidTrackerCard.jsx
+++ b/src/Components/BidTracker/BidTrackerCard/BidTrackerCard.jsx
@@ -27,6 +27,7 @@ const BidTrackerCard = ({ bid, acceptBid, declineBid, submitBid, deleteBid, user
       <div>
         <BidTrackerCardTop
           bid={bid}
+          deleteBid={deleteBid}
         />
         <div className={`usa-grid-full padded-container-inner bid-tracker-bid-steps-container ${draftClass}`}>
           <BidSteps bid={bid} />

--- a/src/Components/BidTracker/BidTrackerCard/BidTrackerCard.test.jsx
+++ b/src/Components/BidTracker/BidTrackerCard/BidTrackerCard.test.jsx
@@ -24,6 +24,16 @@ describe('BidTrackerCardComponent', () => {
     expect(wrapper).toBeDefined();
   });
 
+  it('draft bid has draft class', () => {
+    const newProps = { ...props };
+    newProps.bid.status = 'draft';
+    const wrapper = shallow(
+      <BidTrackerCard {...newProps} />,
+    );
+    expect(wrapper).toBeDefined();
+    expect(wrapper.find('bid-tracker-bid-steps-container--draft')).toBeDefined();
+  });
+
   it('matches snapshot', () => {
     const wrapper = shallow(
       <BidTrackerCard {...props} />,

--- a/src/Components/BidTracker/BidTrackerCard/__snapshots__/BidTrackerCard.test.jsx.snap
+++ b/src/Components/BidTracker/BidTrackerCard/__snapshots__/BidTrackerCard.test.jsx.snap
@@ -49,16 +49,17 @@ exports[`BidTrackerCardComponent matches snapshot 1`] = `
             "username": "woodwardw",
           },
           "scheduled_panel_date": "2017-12-20",
-          "status": "approved",
+          "status": "draft",
           "submitted_date": "2017-12-20",
           "update_date": "2017-12-20",
           "user": "rehmant",
         }
       }
+      deleteBid={[Function]}
       showQuestion={true}
     />
     <div
-      className="usa-grid-full padded-container-inner bid-tracker-bid-steps-container "
+      className="usa-grid-full padded-container-inner bid-tracker-bid-steps-container bid-tracker-bid-steps-container--draft"
     >
       <BidSteps
         bid={
@@ -104,7 +105,7 @@ exports[`BidTrackerCardComponent matches snapshot 1`] = `
               "username": "woodwardw",
             },
             "scheduled_panel_date": "2017-12-20",
-            "status": "approved",
+            "status": "draft",
             "submitted_date": "2017-12-20",
             "update_date": "2017-12-20",
             "user": "rehmant",
@@ -156,7 +157,7 @@ exports[`BidTrackerCardComponent matches snapshot 1`] = `
               "username": "woodwardw",
             },
             "scheduled_panel_date": "2017-12-20",
-            "status": "approved",
+            "status": "draft",
             "submitted_date": "2017-12-20",
             "update_date": "2017-12-20",
             "user": "rehmant",
@@ -165,80 +166,6 @@ exports[`BidTrackerCardComponent matches snapshot 1`] = `
         declineBid={[Function]}
         deleteBid={[Function]}
         submitBid={[Function]}
-      />
-    </div>
-  </div>
-  <div
-    className="usa-grid-full bid-tracker-card-bottom-container"
-  >
-    <div
-      className="padded-container-inner"
-    >
-      <BidTrackerCardBottom
-        bureau="(AF) BUREAU OF AFRICAN AFFAIRS"
-        reviewer={
-          Object {
-            "email": "woodwardw@state.gov",
-            "first_name": "Wendy",
-            "is_cdo": false,
-            "last_name": "Woodward",
-            "phone_number": "555-555-5555",
-            "username": "woodwardw",
-          }
-        }
-        userProfile={
-          Object {
-            "bid_statistics": Array [
-              Object {
-                "draft": 1,
-                "submitted": 1,
-              },
-            ],
-            "cdo": Object {
-              "email": "shadtrachl@state.gov",
-              "first_name": "Leah",
-              "initials": "LS",
-              "last_name": "Shadtrach",
-              "username": "shadtrachl",
-            },
-            "display_name": "John",
-            "favorite_positions": Array [
-              Object {
-                "id": 1,
-                "representation": "[00003026] OMS (COM) (Freetown, Sierra Leone)",
-              },
-              Object {
-                "id": 4,
-                "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
-              },
-            ],
-            "grade": "03",
-            "id": 1,
-            "initials": "JD",
-            "is_cdo": false,
-            "skills": Array [
-              Object {
-                "code": "6218",
-                "cone": null,
-                "description": "CONSTRUCTION ENGINEERING",
-                "id": 63,
-              },
-              Object {
-                "code": "6211",
-                "cone": null,
-                "description": "COMPUTER SCIENCE",
-                "id": 40,
-              },
-            ],
-            "user": Object {
-              "email": "doej@state.gov",
-              "first_name": "John",
-              "initials": "JD",
-              "last_name": "Doe",
-              "username": "jdoe",
-            },
-          }
-        }
       />
     </div>
   </div>

--- a/src/Components/BidTracker/BidTrackerCardContainer/BidTrackerCardContainer.jsx
+++ b/src/Components/BidTracker/BidTrackerCardContainer/BidTrackerCardContainer.jsx
@@ -40,7 +40,7 @@ submitBid, deleteBid }) => {
       cardComponent = (<IsPriority>{card}</IsPriority>);
       break;
     case STANDBY:
-      cardComponent = (<IsOnStandby bid={bid} />);
+      cardComponent = (<IsOnStandby bid={bid} deleteBid={deleteBid} />);
       break;
     default:
       cardComponent = card;

--- a/src/Components/BidTracker/BidTrackerCardContainer/__snapshots__/BidTrackerCardContainer.test.jsx.snap
+++ b/src/Components/BidTracker/BidTrackerCardContainer/__snapshots__/BidTrackerCardContainer.test.jsx.snap
@@ -169,6 +169,7 @@ exports[`BidTrackerCardContainerComponent matches snapshot when priorityExists i
         "user": "rehmant",
       }
     }
+    deleteBid={[Function]}
   />
 </div>
 `;

--- a/src/Components/BidTracker/BidTrackerCardTop/BidTrackerCardTop.jsx
+++ b/src/Components/BidTracker/BidTrackerCardTop/BidTrackerCardTop.jsx
@@ -5,7 +5,6 @@ import { get } from 'lodash';
 import { BID_OBJECT } from '../../../Constants/PropTypes';
 import BidTrackerCardTitle from '../BidTrackerCardTitle';
 import ConfirmLink from '../../ConfirmLink';
-import { canDeleteBid } from '../../../Constants/BidData';
 
 class BidTrackerCardTop extends Component {
   constructor(props) {
@@ -45,7 +44,7 @@ class BidTrackerCardTop extends Component {
                 </div>
             }
             <div className="bid-tracker-actions-container">
-              { canDeleteBid(bid.status) &&
+              { bid.can_delete &&
                 <ConfirmLink
                   className="remove-bid-link"
                   defaultText="Remove Bid"

--- a/src/Components/BidTracker/BidTrackerCardTop/BidTrackerCardTop.jsx
+++ b/src/Components/BidTracker/BidTrackerCardTop/BidTrackerCardTop.jsx
@@ -1,53 +1,70 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import FontAwesome from 'react-fontawesome';
 import { get } from 'lodash';
 import { BID_OBJECT } from '../../../Constants/PropTypes';
 import BidTrackerCardTitle from '../BidTrackerCardTitle';
-import ActionsDropdown from '../ActionsDropdown';
-import { getActionPermissions } from '../BidHelpers';
+import ConfirmLink from '../../ConfirmLink';
+import { canDeleteBid } from '../../../Constants/BidData';
 
-const BidTrackerCardTop = ({ bid, showQuestion }) => {
-  const actionPermissions = getActionPermissions(bid.status) || {};
-  const bidStatistics = get(bid, 'position.bid_statistics[0]', {});
-  const post = get(bid, 'position.post', {});
-  return (
-    <div className="usa-grid-full padded-container-inner bid-tracker-title-container">
-      <div className="bid-tracker-title-content-container">
-        <BidTrackerCardTitle
-          title={bid.position.title}
-          id={bid.position.id}
-          status={bid.status}
-          bidStatistics={bidStatistics}
-          post={post}
-        />
-      </div>
-      <div>
-        <div className="bid-tracker-card-title-container-right">
-          {
-            showQuestion &&
-              <div className="bid-tracker-question-text-container">
-                <FontAwesome name="question-circle" /> Why is it taking so long?
-              </div>
-          }
-          <div className="bid-tracker-actions-container">
-            <ActionsDropdown
-              showDelete={actionPermissions.showDelete}
-              disableDelete={actionPermissions.disableDelete}
-              showWithdraw={actionPermissions.showWithdraw}
-              disableWithdraw={actionPermissions.disableWithdraw}
-              positionId={bid.position.id}
-            />
+class BidTrackerCardTop extends Component {
+  constructor(props) {
+    super(props);
+    this.onDeleteBid = this.onDeleteBid.bind(this);
+    this.state = {
+      confirm: false,
+    };
+  }
+
+  onDeleteBid() {
+    const { deleteBid, bid } = this.props;
+    deleteBid(bid.position.id);
+  }
+
+  render() {
+    const { bid, showQuestion } = this.props;
+    const bidStatistics = get(bid, 'position.bid_statistics[0]', {});
+    const post = get(bid, 'position.post', {});
+    return (
+      <div className="usa-grid-full padded-container-inner bid-tracker-title-container">
+        <div className="bid-tracker-title-content-container">
+          <BidTrackerCardTitle
+            title={bid.position.title}
+            id={bid.position.id}
+            status={bid.status}
+            bidStatistics={bidStatistics}
+            post={post}
+          />
+        </div>
+        <div>
+          <div className="bid-tracker-card-title-container-right">
+            {
+              showQuestion &&
+                <div className="bid-tracker-question-text-container">
+                  <FontAwesome name="question-circle" /> Why is it taking so long?
+                </div>
+            }
+            <div className="bid-tracker-actions-container">
+              { canDeleteBid(bid.status) &&
+                <ConfirmLink
+                  className="remove-bid-link"
+                  defaultText="Remove Bid"
+                  role="link"
+                  onClick={this.onDeleteBid}
+                />
+              }
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+}
 
 BidTrackerCardTop.propTypes = {
   bid: BID_OBJECT.isRequired,
   showQuestion: PropTypes.bool, // Determine whether or not to show the question text
+  deleteBid: PropTypes.func.isRequired,
 };
 
 BidTrackerCardTop.defaultProps = {

--- a/src/Components/BidTracker/BidTrackerCardTop/BidTrackerCardTop.test.jsx
+++ b/src/Components/BidTracker/BidTrackerCardTop/BidTrackerCardTop.test.jsx
@@ -1,14 +1,17 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 import toJSON from 'enzyme-to-json';
+import sinon from 'sinon';
 import BidTrackerCardTop from './BidTrackerCardTop';
 import bidListObject from '../../../__mocks__/bidListObject';
 
 describe('BidTrackerCardTopComponent', () => {
   const bid = bidListObject.results[0];
+  const deleteBid = sinon.spy();
 
   const props = {
     bid,
+    deleteBid,
   };
 
   it('is defined', () => {
@@ -25,6 +28,25 @@ describe('BidTrackerCardTopComponent', () => {
       <BidTrackerCardTop {...props} bid={newBid} />,
     );
     expect(wrapper).toBeDefined();
+  });
+
+  it('shows the remove bid link when status is draft', () => {
+    const newBid = { ...props.bid };
+    newBid.status = 'draft';
+    const wrapper = shallow(
+      <BidTrackerCardTop {...props} bid={newBid} />,
+    );
+    expect(wrapper).toBeDefined();
+    expect(wrapper.find('remove-bid-link')).toBeDefined();
+  });
+
+  it('calls deleteBid', () => {
+    const wrapper = shallow(
+      <BidTrackerCardTop {...props} />,
+    );
+    expect(wrapper).toBeDefined();
+    wrapper.instance().onDeleteBid();
+    sinon.assert.calledOnce(props.deleteBid);
   });
 
   it('matches snapshot', () => {

--- a/src/Components/BidTracker/BidTrackerCardTop/BidTrackerCardTop.test.jsx
+++ b/src/Components/BidTracker/BidTrackerCardTop/BidTrackerCardTop.test.jsx
@@ -30,9 +30,9 @@ describe('BidTrackerCardTopComponent', () => {
     expect(wrapper).toBeDefined();
   });
 
-  it('shows the remove bid link when status is draft', () => {
+  it('shows the remove bid link when canDelete', () => {
     const newBid = { ...props.bid };
-    newBid.status = 'draft';
+    newBid.can_delete = true;
     const wrapper = shallow(
       <BidTrackerCardTop {...props} bid={newBid} />,
     );

--- a/src/Components/BidTracker/BidTrackerCardTop/__snapshots__/BidTrackerCardTop.test.jsx.snap
+++ b/src/Components/BidTracker/BidTrackerCardTop/__snapshots__/BidTrackerCardTop.test.jsx.snap
@@ -40,15 +40,7 @@ exports[`BidTrackerCardTopComponent matches snapshot 1`] = `
       </div>
       <div
         className="bid-tracker-actions-container"
-      >
-        <Connect(ActionsDropdown)
-          disableDelete={false}
-          disableWithdraw={true}
-          positionId={226}
-          showDelete={false}
-          showWithdraw={true}
-        />
-      </div>
+      />
     </div>
   </div>
 </div>

--- a/src/Components/BidTracker/PriorityCards/IsOnStandby/IsOnStandby.jsx
+++ b/src/Components/BidTracker/PriorityCards/IsOnStandby/IsOnStandby.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import FontAwesome from 'react-fontawesome';
 import { BID_OBJECT } from '../../../../Constants/PropTypes';
 import { getStatusProperty } from '../../../../Constants/BidStatuses';
 import { CLOSED_PROP, DECLINED_PROP } from '../../../../Constants/BidData';
 import BidTrackerCardTop from '../../BidTrackerCardTop';
 
-const IsOnStandby = ({ bid }) => {
+const IsOnStandby = ({ bid, deleteBid }) => {
   const bidStatus = getStatusProperty(bid.status, 'text');
   const statusIsClosed = bidStatus === CLOSED_PROP;
   const statusIsDeclined = bidStatus === DECLINED_PROP;
@@ -23,7 +24,7 @@ const IsOnStandby = ({ bid }) => {
         { !useDisabledClass && <div className="bid-tracker-standby-title-bottom">(on-hold)</div> }
       </div>
       <div className="bid-tracker-standby-content-container">
-        <BidTrackerCardTop showQuestion={false} bid={bid} />
+        <BidTrackerCardTop showQuestion={false} bid={bid} deleteBid={deleteBid} />
       </div>
     </div>
   );
@@ -31,6 +32,7 @@ const IsOnStandby = ({ bid }) => {
 
 IsOnStandby.propTypes = {
   bid: BID_OBJECT.isRequired,
+  deleteBid: PropTypes.func.isRequired,
 };
 
 export default IsOnStandby;

--- a/src/Components/BidTracker/PriorityCards/IsOnStandby/IsOnStandby.test.jsx
+++ b/src/Components/BidTracker/PriorityCards/IsOnStandby/IsOnStandby.test.jsx
@@ -6,9 +6,11 @@ import bidListObject from '../../../../__mocks__/bidListObject';
 
 describe('IsOnStandbyComponent', () => {
   const bid = bidListObject.results[0];
+  const deleteBid = () => {};
 
   const props = {
     bid,
+    deleteBid,
   };
 
   it('is defined', () => {

--- a/src/Components/BidTracker/PriorityCards/IsOnStandby/__snapshots__/IsOnStandby.test.jsx.snap
+++ b/src/Components/BidTracker/PriorityCards/IsOnStandby/__snapshots__/IsOnStandby.test.jsx.snap
@@ -72,6 +72,7 @@ exports[`IsOnStandbyComponent matches snapshot 1`] = `
           "user": "rehmant",
         }
       }
+      deleteBid={[Function]}
       showQuestion={false}
     />
   </div>

--- a/src/Components/ConfirmLink/ConfirmLink.jsx
+++ b/src/Components/ConfirmLink/ConfirmLink.jsx
@@ -1,0 +1,51 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import InteractiveElement from '../InteractiveElement';
+
+class ConfirmLink extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      confirm: false,
+    };
+    this.onClick = this.onClick.bind(this);
+  }
+
+  onClick() {
+    if (this.state.confirm) {
+      this.props.onClick();
+    } else {
+      this.setState({ confirm: true });
+    }
+  }
+
+  render() {
+    const { confirm } = this.state;
+    const { defaultText, className, role, type } = this.props;
+    return (
+      <InteractiveElement
+        className={className}
+        type={type}
+        role={role}
+        onClick={this.onClick}
+      >
+        { confirm ? 'Are you sure?' : defaultText }
+      </InteractiveElement>);
+  }
+}
+
+ConfirmLink.propTypes = {
+  className: PropTypes.string,
+  type: PropTypes.string,
+  role: PropTypes.string,
+  defaultText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  onClick: PropTypes.func.isRequired,
+};
+
+ConfirmLink.defaultProps = {
+  className: '',
+  type: 'div',
+  role: 'link',
+};
+
+export default ConfirmLink;

--- a/src/Components/ConfirmLink/ConfirmLink.test.jsx
+++ b/src/Components/ConfirmLink/ConfirmLink.test.jsx
@@ -1,0 +1,40 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import toJSON from 'enzyme-to-json';
+import sinon from 'sinon';
+import ConfirmLink from './ConfirmLink';
+
+describe('ConfirmLinkComponent', () => {
+  const props = {
+    defaultText: 'Remove',
+    onClick: sinon.spy(),
+  };
+
+  it('is defined', () => {
+    const wrapper = shallow(
+      <ConfirmLink {...props} />,
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it('calls onClick when clicked twice', () => {
+    const wrapper = shallow(
+      <ConfirmLink {...props} />,
+    );
+    expect(wrapper).toBeDefined();
+    const instance = wrapper.instance();
+    expect(wrapper.state().confirm).toBe(false);
+    instance.onClick();
+    sinon.assert.notCalled(props.onClick);
+    expect(wrapper.state().confirm).toBe(true);
+    instance.onClick();
+    sinon.assert.calledOnce(props.onClick);
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(
+      <ConfirmLink {...props} />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/ConfirmLink/__snapshots__/ConfirmLink.test.jsx.snap
+++ b/src/Components/ConfirmLink/__snapshots__/ConfirmLink.test.jsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConfirmLinkComponent matches snapshot 1`] = `
+<InteractiveElement
+  className=""
+  onClick={[Function]}
+  role="link"
+  type="div"
+>
+  Remove
+</InteractiveElement>
+`;

--- a/src/Components/ConfirmLink/index.js
+++ b/src/Components/ConfirmLink/index.js
@@ -1,0 +1,1 @@
+export { default } from './ConfirmLink';

--- a/src/Components/ResetFilters/ResetFilters.jsx
+++ b/src/Components/ResetFilters/ResetFilters.jsx
@@ -1,38 +1,28 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import FontAwesome from 'react-fontawesome';
-import InteractiveElement from '../InteractiveElement';
+import ConfirmLink from '../ConfirmLink';
 
 class ResetFilters extends Component {
   constructor(props) {
     super(props);
     this.resetFilters = this.resetFilters.bind(this);
-    this.state = {
-      confirm: false,
-    };
   }
 
   resetFilters() {
-    if (!this.state.confirm) {
-      this.setState({ confirm: true });
-    } else {
-      this.props.resetFilters();
-    }
+    this.props.resetFilters();
   }
 
   render() {
-    const { confirm } = this.state;
-    const text = confirm ? 'Are you sure?' : <span><FontAwesome name="times" />Clear Filters</span>;
     return (
       <div className="reset-filters-container">
-        <InteractiveElement
+        <ConfirmLink
           type="span"
           className="reset-filters"
           role="link"
+          defaultText={<span><FontAwesome name="times" />Clear Filters</span>}
           onClick={this.resetFilters}
-        >
-          {text}
-        </InteractiveElement>
+        />
       </div>
     );
   }

--- a/src/Components/ResetFilters/ResetFilters.test.jsx
+++ b/src/Components/ResetFilters/ResetFilters.test.jsx
@@ -15,10 +15,6 @@ describe('ResetFilters', () => {
     expect(resetButton).toBeDefined();
   });
 
-  it('can click on the button', () => {
-    const wrapper = shallow(<ResetFilters resetFilters={() => {}} />);
-    wrapper.find('InteractiveElement').simulate('click');
-  });
 
   it('can call resetFilters function', () => {
     const propSpy = sinon.spy();
@@ -30,9 +26,7 @@ describe('ResetFilters', () => {
     instance.resetFilters();
     // the instance resetFilters should be called once
     sinon.assert.calledOnce(handleUpdateSpy);
-    instance.resetFilters();
-    // The prop resetFilters should be called once, since it doesn't get called until the
-    // instance's resetFilters function is called twice.
+    // The prop resetFilters should be called once
     sinon.assert.calledOnce(propSpy);
   });
 });

--- a/src/Constants/BidData.js
+++ b/src/Constants/BidData.js
@@ -31,4 +31,6 @@ export const GET_PANEL_TITLE = () => ['Panel'];
 export const GET_APPROVAL_TITLE = () => ['Approval'];
 
 // A bid can be deleted until a handshake is accepted
-export const canDeleteBid = status => status === 'draft' || status === 'submitted';
+export const canDeleteBid = status => (
+  status === DRAFT_PROP || status === SUBMITTED_PROP || status === HAND_SHAKE_OFFERED_PROP
+);

--- a/src/Constants/BidData.js
+++ b/src/Constants/BidData.js
@@ -29,3 +29,6 @@ export const GET_HAND_SHAKE_OFFERED_TITLE = () => ['Handshake Offered'];
 export const GET_HAND_SHAKE_ACCEPTED_TITLE = () => ['Handshake Accepted'];
 export const GET_PANEL_TITLE = () => ['Panel'];
 export const GET_APPROVAL_TITLE = () => ['Approval'];
+
+// A bid can be deleted until a handshake is accepted
+export const canDeleteBid = status => status === 'draft' || status === 'submitted';

--- a/src/Constants/BidData.js
+++ b/src/Constants/BidData.js
@@ -29,8 +29,3 @@ export const GET_HAND_SHAKE_OFFERED_TITLE = () => ['Handshake Offered'];
 export const GET_HAND_SHAKE_ACCEPTED_TITLE = () => ['Handshake Accepted'];
 export const GET_PANEL_TITLE = () => ['Panel'];
 export const GET_APPROVAL_TITLE = () => ['Approval'];
-
-// A bid can be deleted until a handshake is accepted
-export const canDeleteBid = status => (
-  status === DRAFT_PROP || status === SUBMITTED_PROP || status === HAND_SHAKE_OFFERED_PROP
-);


### PR DESCRIPTION
Resolves TM-343.

An API change is required to enable the removal of a bid in anything other than the draft status. 

This will show the Remove Bid link in place of the actions drop down on the bid tracker when the bid is in draft, submitted or handshake offered statuses.

I also refactored the Are you Sure link into its own component since that is used on the clear filter control.