### PR TITLE
Default to true if can_delete property is not found

### DIFF
--- a/src/Components/BidListButton/BidListButton.jsx
+++ b/src/Components/BidListButton/BidListButton.jsx
@@ -18,7 +18,7 @@ class BidListButton extends Component {
     const exists = existsInNestedObject(id, compareArray);
     return {
       isSaved: exists,
-      canDelete: get(exists, 'can_delete', false),
+      canDelete: get(exists, 'can_delete', true),
     };
   }
 

--- a/src/Components/BidListButton/__snapshots__/BidListButton.test.jsx.snap
+++ b/src/Components/BidListButton/__snapshots__/BidListButton.test.jsx.snap
@@ -2,8 +2,8 @@
 
 exports[`BidListButtonComponent matches snapshot when the user can add the position 1`] = `
 <button
-  className="usa-button-disabled bid-list-button"
-  disabled={true}
+  className=" bid-list-button"
+  disabled={false}
   onClick={[Function]}
   style={
     Object {
@@ -26,8 +26,8 @@ exports[`BidListButtonComponent matches snapshot when the user can add the posit
 
 exports[`BidListButtonComponent matches snapshot when the user can remove the position 1`] = `
 <button
-  className="usa-button-disabled bid-list-button"
-  disabled={true}
+  className=" bid-list-button"
+  disabled={false}
   onClick={[Function]}
   style={
     Object {


### PR DESCRIPTION
Resolves an issue where if the bid is not in the user's bid list, they could not add it.