### PR TITLE
Feature/comparison drawer

### DIFF
--- a/src/Components/CompareCheck/CompareCheck.jsx
+++ b/src/Components/CompareCheck/CompareCheck.jsx
@@ -10,6 +10,7 @@ class CompareCheck extends Component {
   constructor(props) {
     super(props);
     this.toggleSaved = this.toggleSaved.bind(this);
+    this.eventListener = this.eventListener.bind(this);
     this.state = {
       saved: false,
       localStorageKey: null,
@@ -20,10 +21,17 @@ class CompareCheck extends Component {
   componentWillMount() {
     const localStorageKey = this.props.type;
     this.setState({ localStorageKey });
+
+    // add listener on localStorage 'compare' key
+    window.addEventListener('compare-ls', this.eventListener);
   }
 
   componentDidMount() {
     this.getSaved();
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('compare-ls', this.eventListener);
   }
 
   onToggle() {
@@ -53,6 +61,10 @@ class CompareCheck extends Component {
       this.setState({ saved: !this.state.saved });
       this.onToggle();
     }
+  }
+
+  eventListener() {
+    this.getSaved();
   }
 
   render() {

--- a/src/Components/CompareDrawer/CompareDrawer.jsx
+++ b/src/Components/CompareDrawer/CompareDrawer.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FA from 'react-fontawesome';
+import shortid from 'shortid';
+import COMPARE_LIMIT from '../../Constants/Compare';
+import { getPostName } from '../../utilities';
+import {
+  NO_GRADE,
+  NO_POST,
+} from '../../Constants/SystemMessages';
+import CompareCheck from '../CompareCheck';
+import ViewComparisonLink from '../ViewComparisonLink/ViewComparisonLink';
+import ResetComparisons from '../ResetComparisons/ResetComparisons';
+import { COMPARE_LIST } from '../../Constants/PropTypes';
+
+const CompareDrawer = ({ comparisons, isHidden }) => {
+  const limit = 5;
+  const compareArray = (comparisons || []).slice(0, COMPARE_LIMIT);
+  const emptyArray = Array(limit - compareArray.length).fill();
+  return (
+    <div className={`compare-drawer ${isHidden ? 'drawer-hidden' : ''}`}>
+      <div className="compare-drawer-inner-container">
+        {
+          compareArray.map(c => (
+            <div key={c.id} className="compare-item">
+              <div className="check-container">
+                <CompareCheck
+                  refKey={c.position_number}
+                  customElement={<FA name="close" />}
+                  interactiveElementProps={{ title: 'Remove this comparison' }}
+                />
+              </div>
+              <span className="data-point title">
+                <strong>{c.title}</strong>
+              </span>
+              <span className="data-point">
+                <strong>Grade:</strong> {c.grade || NO_GRADE}
+              </span>
+              <span className="data-point">
+                <strong>Post:</strong> {getPostName(c.post, NO_POST)}
+              </span>
+            </div>
+          ))
+        }
+        {
+          emptyArray.map(() => (
+            <div
+              key={shortid.generate()}
+              className="compare-item compare-item-empty"
+            />
+          ))
+        }
+        <div className="button-container">
+          <ViewComparisonLink />
+          <ResetComparisons
+            className="reset-link"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+CompareDrawer.propTypes = {
+  comparisons: COMPARE_LIST,
+  isHidden: PropTypes.bool,
+};
+
+CompareDrawer.defaultProps = {
+  comparisons: [],
+  isHidden: false,
+};
+
+export default CompareDrawer;

--- a/src/Components/CompareDrawer/CompareDrawer.test.jsx
+++ b/src/Components/CompareDrawer/CompareDrawer.test.jsx
@@ -1,0 +1,36 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import CompareDrawer from './CompareDrawer';
+import resultsObject from '../../__mocks__/resultsObject';
+
+describe('CompareDrawer', () => {
+  const props = {
+    comparisons: resultsObject.results,
+    isHidden: false,
+  };
+  it('is defined', () => {
+    const wrapper = shallow(<CompareDrawer {...props} />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('applies correct css class when isHidden === true', () => {
+    const wrapper = shallow(<CompareDrawer {...props} isHidden />);
+    expect(wrapper.find('.drawer-hidden').exists()).toBe(true);
+  });
+
+  it('does not apply new css class when isHidden === false', () => {
+    const wrapper = shallow(<CompareDrawer {...props} isHidden={false} />);
+    expect(wrapper.find('.drawer-hidden').exists()).toBe(false);
+  });
+
+  it('displays the correct number of results data cards', () => {
+    const wrapper = shallow(<CompareDrawer {...props} isHidden={false} />);
+    expect(wrapper.find('.check-container').length).toBe(resultsObject.results.length);
+  });
+
+  it('displays the correct number of empty cards', () => {
+    const maxCards = 5;
+    const wrapper = shallow(<CompareDrawer {...props} isHidden={false} />);
+    expect(wrapper.find('.compare-item-empty').length).toBe(maxCards - resultsObject.results.length);
+  });
+});

--- a/src/Components/CompareDrawer/CompareDrawerContainer.jsx
+++ b/src/Components/CompareDrawer/CompareDrawerContainer.jsx
@@ -14,6 +14,7 @@ class Compare extends Component {
     this.scrollListener = this.scrollListener.bind(this);
     this.scrollDistance = 400;
     this.state = {
+      prevComparisons: [],
       comparisons: [],
       isHidden: false,
     };
@@ -49,7 +50,7 @@ class Compare extends Component {
 
   lsListener() {
     const comparisons = JSON.parse(localStorage.getItem('compare') || []);
-    this.setState({ comparisons }, () => {
+    this.setState({ prevComparisons: this.state.comparisons, comparisons }, () => {
       this.getComparisons(this.state.comparisons.toString());
     });
   }
@@ -65,12 +66,19 @@ class Compare extends Component {
   }
 
   render() {
-    const { isHidden, comparisons: comparisonsState } = this.state;
+    const { isHidden, comparisons: comparisonsState, prevComparisons } = this.state;
     const { comparisons, hasErrored } = this.props;
+
+    const comparisonsToUse = comparisonsState.length > prevComparisons.length
+      ? comparisonsState : prevComparisons;
+
+    /* sort based on any prior compare list, so the cards don't get jumbled
+    after one is removed, as it persists until the new request completes */
     const sortedComparisons = comparisons.sort((a, b) =>
-    (comparisonsState.indexOf(a.position_number) >
-        comparisonsState.indexOf(b.position_number) ? 1 : -1),
+    (comparisonsToUse.indexOf(a.position_number) >
+        comparisonsToUse.indexOf(b.position_number) ? 1 : -1),
     );
+
     const isHidden$ = isHidden || !sortedComparisons.length;
     return (
       <CompareDrawer

--- a/src/Components/CompareDrawer/CompareDrawerContainer.jsx
+++ b/src/Components/CompareDrawer/CompareDrawerContainer.jsx
@@ -12,7 +12,11 @@ class Compare extends Component {
     super(props);
     this.lsListener = this.lsListener.bind(this);
     this.scrollListener = this.scrollListener.bind(this);
-    this.scrollDistance = 400;
+
+    /* set to 0 for now, but could change to the distance in px from the bottom of the screen
+    that you want the drawer to hide at */
+    this.scrollDistance = 0;
+
     this.state = {
       prevComparisons: [],
       comparisons: [],
@@ -92,7 +96,7 @@ class Compare extends Component {
 
 Compare.propTypes = {
   fetchData: PropTypes.func.isRequired,
-  hasErrored: PropTypes.bool.isRequired,
+  hasErrored: PropTypes.bool,
   comparisons: COMPARE_LIST,
 };
 

--- a/src/Components/CompareDrawer/CompareDrawerContainer.test.jsx
+++ b/src/Components/CompareDrawer/CompareDrawerContainer.test.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import TestUtils from 'react-dom/test-utils';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { testDispatchFunctions } from '../../testUtilities/testUtilities';
+import CompareDrawerContainer, { mapDispatchToProps } from './CompareDrawerContainer';
+import resultsObject from '../../__mocks__/resultsObject';
+
+const middlewares = [thunk];
+const mockStore = configureStore(middlewares);
+
+describe('CompareDrawerContainer', () => {
+  it('is defined', () => {
+    const compare = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
+      <CompareDrawerContainer
+        fetchData={() => {}}
+        comparisons={resultsObject.results}
+      />
+    </MemoryRouter></Provider>);
+    expect(compare).toBeDefined();
+  });
+});
+
+describe('mapDispatchToProps', () => {
+  const config = {
+    fetchData: ['1,2'],
+  };
+  testDispatchFunctions(mapDispatchToProps, config);
+});

--- a/src/Components/CompareDrawer/index.js
+++ b/src/Components/CompareDrawer/index.js
@@ -1,0 +1,1 @@
+export { default } from './CompareDrawerContainer';

--- a/src/Components/ResetComparisons/ResetComparisons.jsx
+++ b/src/Components/ResetComparisons/ResetComparisons.jsx
@@ -1,10 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { EMPTY_FUNCTION } from '../../Constants/PropTypes';
+import { localStorageSetKey } from '../../utilities';
 
 class ResetComparisons extends Component {
 
   render() {
+    const { onToggle, ...rest } = this.props;
     const exists = () => {
       let result = false;
       const retrievedKey = localStorage
@@ -16,14 +18,14 @@ class ResetComparisons extends Component {
       return result;
     };
     const remove = () => {
-      localStorage.setItem('compare', '[]');
-      this.props.onToggle();
+      localStorageSetKey('compare', '[]');
+      onToggle();
     };
     const compare = exists() ?
-      <a onClick={remove} role="button" tabIndex={0}>Reset comparison choices</a>
+      <a onClick={remove} role="button" tabIndex={0}>Clear All</a>
       : null;
     return (
-      <div>
+      <div {...rest}>
         {compare}
       </div>
     );

--- a/src/Components/ResultsPage/ResultsPage.jsx
+++ b/src/Components/ResultsPage/ResultsPage.jsx
@@ -5,8 +5,6 @@ ACCORDION_SELECTION_OBJECT, FILTER_ITEMS_ARRAY, USER_PROFILE, BID_RESULTS,
 SAVED_SEARCH_MESSAGE, SAVED_SEARCH_OBJECT, MISSION_DETAILS_ARRAY,
 POST_DETAILS_ARRAY, EMPTY_FUNCTION, NEW_SAVED_SEARCH_SUCCESS_OBJECT } from '../../Constants/PropTypes';
 import { ACCORDION_SELECTION } from '../../Constants/DefaultProps';
-import ViewComparisonLink from '../ViewComparisonLink/ViewComparisonLink';
-import ResetComparisons from '../ResetComparisons/ResetComparisons';
 import ResultsContainer from '../ResultsContainer/ResultsContainer';
 import ResultsSearchHeader from '../ResultsSearchHeader/ResultsSearchHeader';
 import ResultsFilterContainer from '../ResultsFilterContainer/ResultsFilterContainer';
@@ -49,14 +47,6 @@ class Results extends Component {
             defaultLocation={defaultLocation}
           />
         }
-        <div className="usa-grid-full top-nav">
-          <div className="usa-width-one-third reset-compare-link">
-            <ResetComparisons onToggle={this.onChildToggle} />
-          </div>
-          <div className="usa-width-one-third comparisons-button">
-            <ViewComparisonLink onToggle={this.onChildToggle} />
-          </div>
-        </div>
         <div className="usa-grid-full results-section-container">
           <ResultsFilterContainer
             filters={filters}

--- a/src/Components/ViewComparisonLink/ViewComparisonLink.jsx
+++ b/src/Components/ViewComparisonLink/ViewComparisonLink.jsx
@@ -17,7 +17,7 @@ class ViewComparisonLink extends Component {
     // else, parse the key's value to use in the Link
     const compareArray = JSON.parse(localStorage.getItem('compare'));
     return (
-      <Link className={'usa-button'} to={`compare/${compareArray.toString()}`}>Compare positions</Link>
+      <Link className={'usa-button'} to={`compare/${compareArray.toString()}`}>Compare</Link>
     );
   }
 }

--- a/src/Containers/Results/Results.jsx
+++ b/src/Containers/Results/Results.jsx
@@ -16,6 +16,7 @@ import { postSearchFetchData } from '../../actions/autocomplete/postAutocomplete
 import { setSelectedAccordion } from '../../actions/selectedAccordion';
 import { toggleSearchBar } from '../../actions/showSearchBar';
 import ResultsPage from '../../Components/ResultsPage/ResultsPage';
+import CompareDrawer from '../../Components/CompareDrawer';
 import { POSITION_SEARCH_RESULTS, FILTERS_PARENT, ACCORDION_SELECTION_OBJECT,
 USER_PROFILE, SAVED_SEARCH_MESSAGE, NEW_SAVED_SEARCH_SUCCESS_OBJECT,
 SAVED_SEARCH_OBJECT, MISSION_DETAILS_ARRAY, POST_DETAILS_ARRAY,
@@ -210,42 +211,45 @@ class Results extends Component {
             fetchPostAutocomplete, postSearchResults, postSearchIsLoading,
             postSearchHasErrored, shouldShowSearchBar, bidList } = this.props;
     return (
-      <ResultsPage
-        results={results}
-        hasErrored={hasErrored}
-        isLoading={isLoading}
-        sortBy={POSITION_SEARCH_SORTS}
-        defaultSort={this.state.defaultSort.value}
-        pageSizes={POSITION_PAGE_SIZES}
-        defaultPageSize={this.state.defaultPageSize.value}
-        defaultPageNumber={this.state.defaultPageNumber.value}
-        onQueryParamUpdate={this.onQueryParamUpdate}
-        defaultKeyword={this.state.defaultKeyword.value}
-        resetFilters={this.resetFilters}
-        pillFilters={filters.mappedParams}
-        filters={filters.filters}
-        onQueryParamToggle={this.onQueryParamToggle}
-        selectedAccordion={selectedAccordion}
-        setAccordion={setAccordion}
-        scrollToTop={scrollToTop}
-        userProfile={userProfile}
-        newSavedSearchSuccess={newSavedSearchSuccess}
-        newSavedSearchIsSaving={newSavedSearchIsSaving}
-        newSavedSearchHasErrored={newSavedSearchHasErrored}
-        saveSearch={this.saveSearch}
-        currentSavedSearch={currentSavedSearch}
-        resetSavedSearchAlerts={resetSavedSearchAlerts}
-        fetchMissionAutocomplete={fetchMissionAutocomplete}
-        missionSearchResults={missionSearchResults}
-        missionSearchIsLoading={missionSearchIsLoading}
-        missionSearchHasErrored={missionSearchHasErrored}
-        fetchPostAutocomplete={fetchPostAutocomplete}
-        postSearchResults={postSearchResults}
-        postSearchIsLoading={postSearchIsLoading}
-        postSearchHasErrored={postSearchHasErrored}
-        shouldShowSearchBar={shouldShowSearchBar}
-        bidList={bidList.results}
-      />
+      <div>
+        <ResultsPage
+          results={results}
+          hasErrored={hasErrored}
+          isLoading={isLoading}
+          sortBy={POSITION_SEARCH_SORTS}
+          defaultSort={this.state.defaultSort.value}
+          pageSizes={POSITION_PAGE_SIZES}
+          defaultPageSize={this.state.defaultPageSize.value}
+          defaultPageNumber={this.state.defaultPageNumber.value}
+          onQueryParamUpdate={this.onQueryParamUpdate}
+          defaultKeyword={this.state.defaultKeyword.value}
+          resetFilters={this.resetFilters}
+          pillFilters={filters.mappedParams}
+          filters={filters.filters}
+          onQueryParamToggle={this.onQueryParamToggle}
+          selectedAccordion={selectedAccordion}
+          setAccordion={setAccordion}
+          scrollToTop={scrollToTop}
+          userProfile={userProfile}
+          newSavedSearchSuccess={newSavedSearchSuccess}
+          newSavedSearchIsSaving={newSavedSearchIsSaving}
+          newSavedSearchHasErrored={newSavedSearchHasErrored}
+          saveSearch={this.saveSearch}
+          currentSavedSearch={currentSavedSearch}
+          resetSavedSearchAlerts={resetSavedSearchAlerts}
+          fetchMissionAutocomplete={fetchMissionAutocomplete}
+          missionSearchResults={missionSearchResults}
+          missionSearchIsLoading={missionSearchIsLoading}
+          missionSearchHasErrored={missionSearchHasErrored}
+          fetchPostAutocomplete={fetchPostAutocomplete}
+          postSearchResults={postSearchResults}
+          postSearchIsLoading={postSearchIsLoading}
+          postSearchHasErrored={postSearchHasErrored}
+          shouldShowSearchBar={shouldShowSearchBar}
+          bidList={bidList.results}
+        />
+        <CompareDrawer />
+      </div>
     );
   }
 }

--- a/src/actions/comparisons.js
+++ b/src/actions/comparisons.js
@@ -1,4 +1,7 @@
+import { CancelToken } from 'axios';
 import api from '../api';
+
+let cancel;
 
 export function comparisonsHasErrored(bool) {
   return {
@@ -23,12 +26,15 @@ export function comparisonsFetchDataSuccess(comparisons) {
 
 export function comparisonsFetchData(query) {
   return (dispatch) => {
+    if (cancel) { cancel(); }
     dispatch(comparisonsIsLoading(true));
     if (!query) {
       dispatch(comparisonsFetchDataSuccess([]));
       dispatch(comparisonsIsLoading(false));
     } else {
-      api.get(`/position/?position_number__in=${query}`)
+      api.get(`/position/?position_number__in=${query}`, {
+        cancelToken: new CancelToken((c) => { cancel = c; }),
+      })
         .then((response) => {
           dispatch(comparisonsIsLoading(false));
           return response.data.results;

--- a/src/sass/_compareDrawer.scss
+++ b/src/sass/_compareDrawer.scss
@@ -1,0 +1,78 @@
+.drawer-hidden {
+  bottom: -30rem !important;
+}
+
+.compare-drawer {
+  $background: rgba(0, 0, 0, .8);
+  $item-background: rgba(255, 255, 255, .9);
+  $item-empty-background: rgba(0, 0, 0, .4);
+
+  background-color: $background;
+  bottom: 0;
+  left: 0;
+  min-height: 100px;
+  position: fixed;
+  transition: bottom 1s;
+  width: 100%;
+  z-index: 9999;
+
+  .compare-drawer-inner-container {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    margin: auto;
+    max-width: 1200px;
+    padding: 25px;
+  }
+
+  .compare-item {
+    background-color: $item-background;
+    display: flex;
+    flex: 1 1 0;
+    flex-direction: row;
+    flex-wrap: wrap;
+    float: left;
+    font-size: .8em;
+    height: 90px;
+    margin-right: 1.5%;
+    padding: 15px;
+    position: relative;
+    width: 0;
+  }
+
+  .compare-item-empty {
+    background-color: $item-empty-background;
+  }
+
+  .button-container {
+    display: flex;
+    flex: 1.5;
+    justify-content: space-around;
+  }
+
+  .reset-link {
+    align-items: center;
+    display: flex;
+  }
+
+  .check-container {
+    position: absolute;
+    right: 5px;
+    top: 5px;
+  }
+
+  .data-point {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .title {
+    width: 90%;
+  }
+
+  a {
+    color: $color-white;
+    cursor: pointer;
+  }
+}

--- a/src/sass/_results.scss
+++ b/src/sass/_results.scss
@@ -446,6 +446,7 @@ $results-container-width: 100% - $filter-container-width;
 }
 
 .results-section-container {
+  margin-top: 21px;
   max-width: 1140px;
 }
 

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -79,6 +79,7 @@
 @import 'betaHeader';
 @import 'savedSearches';
 @import 'emptyListAlert';
+@import 'compareDrawer';
 @import 'inputs';
 @import 'toast';
 @import 'overrides';

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -28,6 +28,19 @@ export function localStorageFetchValue(key, value) {
   return saved;
 }
 
+const dispatchLs = (key) => {
+  // create, initialize, and dispatch event
+  const event = document.createEvent('Event');
+  event.initEvent(`${key}-ls`, true, true);
+  document.dispatchEvent(event);
+};
+
+export function localStorageSetKey(key, value) {
+  localStorage.setItem(key, value);
+  dispatchLs(key);
+}
+
+// toggling a specific value in an array
 export function localStorageToggleValue(key, value) {
   const existingArray = JSON.parse(localStorage.getItem(key)) || [];
   const indexOfId = existingArray.indexOf(value);
@@ -35,10 +48,12 @@ export function localStorageToggleValue(key, value) {
     existingArray.splice(indexOfId, 1);
     localStorage.setItem(key,
         JSON.stringify(existingArray));
+    dispatchLs(key);
   } else {
     existingArray.push(value);
     localStorage.setItem(key,
         JSON.stringify(existingArray));
+    dispatchLs(key);
   }
 }
 
@@ -515,4 +530,11 @@ export const isUrl = (url) => {
   const expression = /(http|ftp|https):\/\/[\w-]+(\.[\w-]+)+([\w.,@?^=%&amp;:\/~+#-]*[\w@?^=%&amp;\/~+#-])?/;
   const regex = new RegExp(expression);
   return url.match(regex);
+};
+
+export const getScrollDistanceFromBottom = () => {
+  const scrollPosition = window.pageYOffset;
+  const windowSize = window.innerHeight;
+  const bodyHeight = document.body.offsetHeight;
+  return (Math.max(bodyHeight - (scrollPosition + windowSize), 0));
 };


### PR DESCRIPTION
- Adds Comparison Drawer to the results page
- Uses event listeners to sync local storage states between drawer and compare "checks" in results cards
- Currently disabled functionality to hide the Comparison drawer if the user reaches a certain scroll distance from the bottom (disabled and set to 0 per design feedback, but wanted to keep functionality included)