### PR TITLE
Display the service needs filter as a pill on the results page

### DIFF
--- a/src/Constants/EndpointParams.js
+++ b/src/Constants/EndpointParams.js
@@ -15,6 +15,7 @@ export const ENDPOINT_PARAMS = {
   post: 'post__in',
   available: 'is_available_in_current_bidcycle',
   bidCycle: 'is_available_in_bidcycle',
+  highlighted: 'is_highlighted',
 };
 
 // any properties that we want to abstract to a common name

--- a/src/reducers/filters/filters.js
+++ b/src/reducers/filters/filters.js
@@ -187,6 +187,26 @@ const items =
           { code: 'true', short_description: 'Yes' },
         ],
       },
+
+      /* Currently we don't display this as a filter, but will appear
+      as a pill if the query param exists (e.g., the user clicked on Service Needs
+      positions from the home page). */
+      {
+        item: {
+          title: 'Service Needs',
+          sort: 1000,
+          bool: true,
+          description: 'service_needs',
+          selectionRef: ENDPOINT_PARAMS.highlighted,
+          text: 'Include only Service Needs positions',
+          choices: [
+          ],
+        },
+        data: [
+          { code: 'true', short_description: 'Service Needs' },
+        ],
+      },
+
       {
         item: {
           title: 'Post',


### PR DESCRIPTION
Completes TM-551 by mapping the `is_highlighted=true` query parameter (initiated by the homepage's "Service Needs Positions" section) to a search pill. The filter is still not accessible from the main search filters, but now the user is at least able to remove the filter, which they could not do before.