### PR TITLE
Add custom filter for including null language positions

### DIFF
--- a/src/Constants/EndpointParams.js
+++ b/src/Constants/EndpointParams.js
@@ -2,7 +2,7 @@
 
 export const ENDPOINT_PARAMS = {
   skill: 'skill__code__in',
-  language: 'languages__language__code__in',
+  language: 'language_codes',
   grade: 'grade__code__in',
   tod: 'post__tour_of_duty__code__in',
   org: 'bureau__code__in',
@@ -21,6 +21,7 @@ export const ENDPOINT_PARAMS = {
 // any properties that we want to abstract to a common name
 export const COMMON_PROPERTIES = {
   posted: 'posted_date',
+  NULL_LANGUAGE: 'NONE',
 };
 
 // Take our custom query param from the Bidder Portfolio navigation and convert them to queries

--- a/src/actions/filters/filters.js
+++ b/src/actions/filters/filters.js
@@ -1,3 +1,4 @@
+import { union } from 'lodash';
 import api from '../../api';
 import { ASYNC_PARAMS, ENDPOINT_PARAMS } from '../../Constants/EndpointParams';
 import { removeDuplicates } from '../../utilities';
@@ -218,7 +219,8 @@ export function filtersFetchData(items = { filters: [] }, queryParams = {}, save
         api.get(`/${item.item.endpoint}`)
           .then((response) => {
             const itemFilter = Object.assign({}, item);
-            itemFilter.data = response.data.results;
+            // We have a mix of server-supplied and hard-coded data, so we combine them with union.
+            itemFilter.data = union(response.data.results, item.initialData);
             return itemFilter;
           })
       ),

--- a/src/actions/filters/helpers.js
+++ b/src/actions/filters/helpers.js
@@ -1,4 +1,5 @@
 import { getPostName } from '../../utilities';
+import { COMMON_PROPERTIES } from '../../Constants/EndpointParams';
 
 // Attempt to map the non-numeric grade codes to a full description.
 // If no match is found, return the unmodified code.
@@ -29,7 +30,11 @@ export function getFilterCustomDescription(filterItem, filterItemObject) {
     case 'bidCycle':
       return filterItemObject.name;
     case 'language':
-      return `${filterItemObject.formal_description} (${filterItemObject.code})`;
+      // language code NONE gets displayed differently
+      return filterItemObject.code === COMMON_PROPERTIES.NULL_LANGUAGE ?
+        filterItemObject.customDescription
+        :
+        `${filterItemObject.formal_description} (${filterItemObject.code})`;
     case 'grade':
       return getCustomGradeDescription(filterItemObject.code);
     case 'postDiff':

--- a/src/reducers/filters/filters.js
+++ b/src/reducers/filters/filters.js
@@ -1,4 +1,4 @@
-import { ENDPOINT_PARAMS } from '../../Constants/EndpointParams';
+import { COMMON_PROPERTIES, ENDPOINT_PARAMS } from '../../Constants/EndpointParams';
 
 // Set what filters we want to fetch
 const items =
@@ -49,6 +49,15 @@ const items =
           text: 'Choose languages',
         },
         data: [
+        ],
+        // Allow users to include languages with no code. This option is not supplied from
+        // the endpoint, so we define it here.
+        initialData: [
+          {
+            code: COMMON_PROPERTIES.NULL_LANGUAGE,
+            short_description: 'No language requirement',
+            custom_description: 'No language requirement',
+          },
         ],
       },
       {


### PR DESCRIPTION
Adds front-end search capability for work done in https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/37 by allowing users to search by multiple languages, including positions with `null` language.