### PR TITLE
Remove Status component throughout app

### DIFF
--- a/src/Components/ProfileDashboard/ExternalUserStatus/ExternalUserStatus.jsx
+++ b/src/Components/ProfileDashboard/ExternalUserStatus/ExternalUserStatus.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Avatar from '../../Avatar';
-import Status from '../UserProfile/Status';
 import USER_TYPES from '../../../Constants/UserTypes';
 import MailToButton from '../../MailToButton';
 
@@ -10,9 +9,6 @@ const ExternalUserStatus = ({ initials, firstName, lastName, type, showMail, ema
     <div className="usa-grid-full cdo-container-inner section-padded-inner-container">
       <div className="profile-picture-container">
         <Avatar initials={initials} firstName={firstName} lastName={lastName} small />
-        <div className="picture-status-container">
-          <Status hideText />
-        </div>
       </div>
       <div className="cdo-text-container">
         <div className="usa-grid-full">

--- a/src/Components/ProfileDashboard/ExternalUserStatus/__snapshots__/ExternalUserStatus.test.jsx.snap
+++ b/src/Components/ProfileDashboard/ExternalUserStatus/__snapshots__/ExternalUserStatus.test.jsx.snap
@@ -18,13 +18,6 @@ exports[`ExternalUserStatusComponent matches snapshot 1`] = `
         onClick={[Function]}
         small={true}
       />
-      <div
-        className="picture-status-container"
-      >
-        <Status
-          hideText={true}
-        />
-      </div>
     </div>
     <div
       className="cdo-text-container"
@@ -70,13 +63,6 @@ exports[`ExternalUserStatusComponent matches snapshot when showMail is true 1`] 
         onClick={[Function]}
         small={true}
       />
-      <div
-        className="picture-status-container"
-      >
-        <Status
-          hideText={true}
-        />
-      </div>
     </div>
     <div
       className="cdo-text-container"

--- a/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/UserProfileGeneralInformation.jsx
+++ b/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/UserProfileGeneralInformation.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { USER_PROFILE } from '../../../../Constants/PropTypes';
 import SectionTitle from '../../SectionTitle';
 import InformationDataPoint from '../../InformationDataPoint';
-import Status from '../Status';
 import EditProfile from '../EditProfile';
 import Avatar from '../../../Avatar';
 import StaticDevContent from '../../../StaticDevContent';
@@ -13,7 +12,6 @@ const UserProfileGeneralInformation = ({ userProfile, showEditLink, useGroup }) 
   <div className="current-user-top current-user-section-border current-user-section-container">
     <div className="section-padded-inner-container">
       <div className="avatar-group">
-        <Status />
         <Avatar
           className="dashboard-user-profile-picture"
           initials={userProfile.initials}

--- a/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/__snapshots__/UserProfileGeneralInformation.test.jsx.snap
+++ b/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/__snapshots__/UserProfileGeneralInformation.test.jsx.snap
@@ -10,9 +10,6 @@ exports[`UserProfileGeneralInformationComponent matches snapshot 1`] = `
     <div
       className="avatar-group"
     >
-      <Status
-        hideText={false}
-      />
       <Avatar
         className="dashboard-user-profile-picture"
         display_name="John"
@@ -74,9 +71,6 @@ exports[`UserProfileGeneralInformationComponent matches snapshot when showEditLi
     <div
       className="avatar-group"
     >
-      <Status
-        hideText={false}
-      />
       <Avatar
         className="dashboard-user-profile-picture"
         display_name="John"
@@ -138,9 +132,6 @@ exports[`UserProfileGeneralInformationComponent matches snapshot when useGroup i
     <div
       className="avatar-group"
     >
-      <Status
-        hideText={false}
-      />
       <Avatar
         className="dashboard-user-profile-picture"
         display_name="John"


### PR DESCRIPTION
Complete TM-459 by removing the Status component throughout the app. I decided not to delete the actual component since we could possible re-use it for some other purpose.