### PR TITLE
Track favoriting loading state of individual IDs

### DIFF
--- a/src/Components/Favorite/Favorite.jsx
+++ b/src/Components/Favorite/Favorite.jsx
@@ -173,7 +173,7 @@ Favorite.propTypes = {
   className: PropTypes.string,
   as: PropTypes.string.isRequired,
   onToggle: PropTypes.func.isRequired,
-  refKey: PropTypes.node.isRequired,
+  refKey: PropTypes.oneOfType([PropTypes.number, PropTypes.string.isRequired]).isRequired,
   hideText: PropTypes.bool,
   compareArray: FAVORITE_POSITIONS_ARRAY.isRequired,
   isLoading: PropTypes.bool,

--- a/src/Components/Favorite/Favorite.jsx
+++ b/src/Components/Favorite/Favorite.jsx
@@ -51,25 +51,8 @@ class Favorite extends Component {
     };
   }
 
-  shouldComponentUpdate(nextProps, nextState) {
-    let isUpdate = true;
-
-    const { compareArray, refKey } = nextProps;
-    const oldState = this.getSavedState();
-    const newState = existsInArray(refKey, compareArray);
-
-    if (this.state.loading && !nextProps.isLoading) {
-      // Only update the loading state if current state.loading
-      // and prop change detected is turning it off
-      this.setState({
-        loading: nextProps.isLoading,
-      });
-    }
-
-    isUpdate = (oldState !== newState) ||
-               (this.state.loading !== nextState.isLoading);
-
-    return isUpdate;
+  componentWillReceiveProps(nextProps) {
+    this.setState({ loading: nextProps.isLoading });
   }
 
   getSavedState() {

--- a/src/Containers/BidListButton/BidListButton.jsx
+++ b/src/Containers/BidListButton/BidListButton.jsx
@@ -7,7 +7,7 @@ import { SetType } from '../../Constants/PropTypes';
 
 const BidListButtonContainer = ({ toggleBid, isLoading, id, ...rest }) => (
   <BidListButton toggleBidPosition={toggleBid} id={id} isLoading={isLoading.has(id)} {...rest} />
-  );
+);
 
 BidListButtonContainer.propTypes = {
   toggleBid: PropTypes.func.isRequired,

--- a/src/Containers/Favorite/Favorite.jsx
+++ b/src/Containers/Favorite/Favorite.jsx
@@ -24,7 +24,7 @@ FavoriteContainer.propTypes = {
   onToggle: PropTypes.func.isRequired,
   isLoading: SetType,
   hasErrored: PropTypes.bool.isRequired,
-  refKey: PropTypes.number.isRequired,
+  refKey: PropTypes.oneOfType([PropTypes.number, PropTypes.string.isRequired]).isRequired,
 };
 
 FavoriteContainer.defaultProps = {

--- a/src/Containers/Favorite/Favorite.jsx
+++ b/src/Containers/Favorite/Favorite.jsx
@@ -3,23 +3,36 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { userProfileToggleFavoritePosition } from '../../actions/userProfile';
 import Favorite from '../../Components/Favorite';
+import { SetType } from '../../Constants/PropTypes';
 
 const FavoriteContainer = ({
   onToggle,
   isLoading,
   hasErrored,
+  refKey,
   ...rest }) => (
-    <Favorite onToggle={onToggle} isLoading={isLoading} hasErrored={hasErrored} {...rest} />
-);
+    <Favorite
+      onToggle={onToggle}
+      isLoading={isLoading.has(refKey)}
+      hasErrored={hasErrored}
+      refKey={refKey}
+      {...rest}
+    />
+  );
 
 FavoriteContainer.propTypes = {
   onToggle: PropTypes.func.isRequired,
-  isLoading: PropTypes.bool.isRequired,
+  isLoading: SetType,
   hasErrored: PropTypes.bool.isRequired,
+  refKey: PropTypes.number.isRequired,
+};
+
+FavoriteContainer.defaultProps = {
+  isLoading: new Set(),
 };
 
 export const mapStateToProps = state => ({
-  isLoading: state.userProfileFavoritePositionIsLoading || false,
+  isLoading: state.userProfileFavoritePositionIsLoading,
   hasErrored: state.userProfileFavoritePositionHasErrored || false,
 });
 

--- a/src/Containers/Favorite/Favorite.test.jsx
+++ b/src/Containers/Favorite/Favorite.test.jsx
@@ -6,7 +6,7 @@ import Favorite, { mapDispatchToProps } from './Favorite';
 describe('Favorite', () => {
   const props = {
     onToggle: () => {},
-    isLoading: false,
+    isLoading: new Set(),
     hasErrored: false,
     refKey: 'key',
     compareArray: [],

--- a/src/actions/favoritePositions.js
+++ b/src/actions/favoritePositions.js
@@ -31,9 +31,9 @@ export function favoritePositionsFetchData(sortType) {
     api.get(url)
       .then(response => response.data)
       .then((results) => {
+        dispatch(favoritePositionsFetchDataSuccess(results));
         dispatch(favoritePositionsHasErrored(false));
         dispatch(favoritePositionsIsLoading(false));
-        dispatch(favoritePositionsFetchDataSuccess(results));
       })
       .catch(() => {
         dispatch(favoritePositionsHasErrored(true));

--- a/src/reducers/userProfile/userProfile.js
+++ b/src/reducers/userProfile/userProfile.js
@@ -32,10 +32,16 @@ export function userProfileFavoritePositionHasErrored(state = false, action) {
       return state;
   }
 }
-export function userProfileFavoritePositionIsLoading(state = false, action) {
+export function userProfileFavoritePositionIsLoading(state = new Set(), action) {
+  const newSet = new Set(state);
   switch (action.type) {
     case 'USER_PROFILE_FAVORITE_POSITION_IS_LOADING':
-      return action.userProfileFavoritePositionIsLoading;
+      if (action.userProfileFavoritePositionIsLoading.bool) {
+        newSet.add(action.userProfileFavoritePositionIsLoading.id);
+        return newSet;
+      }
+      newSet.delete(action.userProfileFavoritePositionIsLoading.id);
+      return newSet;
     default:
       return state;
   }

--- a/src/reducers/userProfile/userProfile.test.js
+++ b/src/reducers/userProfile/userProfile.test.js
@@ -14,10 +14,14 @@ describe('reducers', () => {
   });
 
   it('can set reducer USER_PROFILE_FAVORITE_POSITION_HAS_ERRORED', () => {
-    expect(reducers.userProfileFavoritePositionHasErrored(false, { type: 'USER_PROFILE_FAVORITE_POSITION_HAS_ERRORED', userProfileFavoritePositionHasErrored: true })).toBe(true);
+    expect(reducers.userProfileFavoritePositionHasErrored(new Set(), { type: 'USER_PROFILE_FAVORITE_POSITION_HAS_ERRORED', userProfileFavoritePositionHasErrored: true })).toBe(true);
   });
 
-  it('can set reducer USER_PROFILE_FAVORITE_POSITION_IS_LOADING', () => {
-    expect(reducers.userProfileFavoritePositionIsLoading(false, { type: 'USER_PROFILE_FAVORITE_POSITION_IS_LOADING', userProfileFavoritePositionIsLoading: true })).toBe(true);
+  it('can set reducer USER_PROFILE_FAVORITE_POSITION_IS_LOADING to add an id', () => {
+    expect(reducers.userProfileFavoritePositionIsLoading(new Set(), { type: 'USER_PROFILE_FAVORITE_POSITION_IS_LOADING', userProfileFavoritePositionIsLoading: { bool: true, id: 1 } })).toEqual(new Set([1]));
+  });
+
+  it('can set reducer USER_PROFILE_FAVORITE_POSITION_IS_LOADING to remove an id', () => {
+    expect(reducers.userProfileFavoritePositionIsLoading(new Set([1]), { type: 'USER_PROFILE_FAVORITE_POSITION_IS_LOADING', userProfileFavoritePositionIsLoading: { bool: false, id: 1 } })).toEqual(new Set());
   });
 });


### PR DESCRIPTION
Complete TM-587 by tracking the favoriting loading state of multiple position IDs at once, similar to how we've recently implemented the same thing for bids.