### PR TITLE
Condensed card layouts for "Projected Vacancy" and "Now available"

### DIFF
--- a/src/Components/FavoritePositions/FavoritePositions.jsx
+++ b/src/Components/FavoritePositions/FavoritePositions.jsx
@@ -41,6 +41,7 @@ bidList, onSortChange }) => (
       maxLength={300}
       refreshFavorites
       showBidListButton
+      useShortFavButton
     />
   </div>
 );

--- a/src/Components/FavoritePositions/__snapshots__/FavoritePositions.test.jsx.snap
+++ b/src/Components/FavoritePositions/__snapshots__/FavoritePositions.test.jsx.snap
@@ -562,6 +562,7 @@ exports[`FavoritePositionsComponent matches snapshot 1`] = `
     showBidListButton={true}
     title="favorites"
     type="default"
+    useShortFavButton={true}
   />
 </div>
 `;

--- a/src/Components/HomePagePositionsList/HomePagePositionsList.jsx
+++ b/src/Components/HomePagePositionsList/HomePagePositionsList.jsx
@@ -12,6 +12,7 @@ const propTypes = {
   refreshFavorites: PropTypes.bool,
   title: PropTypes.string.isRequired, // should be unique per page, since its used a react key
   showBidListButton: PropTypes.bool,
+  useShortFavButton: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -21,10 +22,11 @@ const defaultProps = {
   type: 'default',
   refreshFavorites: false,
   showBidListButton: false,
+  useShortFavButton: false,
 };
 
 const HomePagePositionsList = ({ positions, favorites, isLoading,
-    bidList, type, refreshFavorites, title, showBidListButton }) => (
+    bidList, type, refreshFavorites, title, showBidListButton, useShortFavButton }) => (
       <div className={`condensed-card-highlighted ${isLoading ? 'results-loading' : ''}`}>
         <div className="usa-grid-full condensed-card-grid">
           {positions.map(p => (
@@ -36,6 +38,7 @@ const HomePagePositionsList = ({ positions, favorites, isLoading,
                 type={type}
                 refreshFavorites={refreshFavorites}
                 showBidListButton={showBidListButton}
+                useShortFavButton={useShortFavButton}
               />
             </div>
           ))}

--- a/src/Components/HomePagePositionsList/__snapshots__/HomePagePositionsList.test.jsx.snap
+++ b/src/Components/HomePagePositionsList/__snapshots__/HomePagePositionsList.test.jsx.snap
@@ -157,6 +157,8 @@ exports[`HomePagePositionsList displays two rows 1`] = `
           ]
         }
         favorites={Array []}
+        isProjectedVacancy={false}
+        isRecentlyAvailable={false}
         position={
           Object {
             "bid_statistics": Array [
@@ -239,6 +241,7 @@ exports[`HomePagePositionsList displays two rows 1`] = `
         refreshFavorites={false}
         showBidListButton={false}
         type="default"
+        useShortFavButton={false}
       />
     </div>
     <div
@@ -391,6 +394,8 @@ exports[`HomePagePositionsList displays two rows 1`] = `
           ]
         }
         favorites={Array []}
+        isProjectedVacancy={false}
+        isRecentlyAvailable={false}
         position={
           Object {
             "bid_statistics": Array [
@@ -473,6 +478,7 @@ exports[`HomePagePositionsList displays two rows 1`] = `
         refreshFavorites={false}
         showBidListButton={false}
         type="default"
+        useShortFavButton={false}
       />
     </div>
     <div
@@ -625,6 +631,8 @@ exports[`HomePagePositionsList displays two rows 1`] = `
           ]
         }
         favorites={Array []}
+        isProjectedVacancy={false}
+        isRecentlyAvailable={false}
         position={
           Object {
             "bid_statistics": Array [
@@ -707,6 +715,7 @@ exports[`HomePagePositionsList displays two rows 1`] = `
         refreshFavorites={false}
         showBidListButton={false}
         type="default"
+        useShortFavButton={false}
       />
     </div>
     <div
@@ -859,6 +868,8 @@ exports[`HomePagePositionsList displays two rows 1`] = `
           ]
         }
         favorites={Array []}
+        isProjectedVacancy={false}
+        isRecentlyAvailable={false}
         position={
           Object {
             "bid_statistics": Array [
@@ -941,6 +952,7 @@ exports[`HomePagePositionsList displays two rows 1`] = `
         refreshFavorites={false}
         showBidListButton={false}
         type="default"
+        useShortFavButton={false}
       />
     </div>
     <div
@@ -1093,6 +1105,8 @@ exports[`HomePagePositionsList displays two rows 1`] = `
           ]
         }
         favorites={Array []}
+        isProjectedVacancy={false}
+        isRecentlyAvailable={false}
         position={
           Object {
             "bid_statistics": Array [
@@ -1175,6 +1189,7 @@ exports[`HomePagePositionsList displays two rows 1`] = `
         refreshFavorites={false}
         showBidListButton={false}
         type="default"
+        useShortFavButton={false}
       />
     </div>
     <div
@@ -1327,6 +1342,8 @@ exports[`HomePagePositionsList displays two rows 1`] = `
           ]
         }
         favorites={Array []}
+        isProjectedVacancy={false}
+        isRecentlyAvailable={false}
         position={
           Object {
             "bid_statistics": Array [
@@ -1409,6 +1426,7 @@ exports[`HomePagePositionsList displays two rows 1`] = `
         refreshFavorites={false}
         showBidListButton={false}
         type="default"
+        useShortFavButton={false}
       />
     </div>
     <div
@@ -1561,6 +1579,8 @@ exports[`HomePagePositionsList displays two rows 1`] = `
           ]
         }
         favorites={Array []}
+        isProjectedVacancy={false}
+        isRecentlyAvailable={false}
         position={
           Object {
             "bid_statistics": Array [
@@ -1643,6 +1663,7 @@ exports[`HomePagePositionsList displays two rows 1`] = `
         refreshFavorites={false}
         showBidListButton={false}
         type="default"
+        useShortFavButton={false}
       />
     </div>
   </div>

--- a/src/Components/HomePagePositionsSection/__snapshots__/HomePagePositionsSection.test.jsx.snap
+++ b/src/Components/HomePagePositionsSection/__snapshots__/HomePagePositionsSection.test.jsx.snap
@@ -346,6 +346,7 @@ exports[`HomePagePositionsSection matches snapshot 1`] = `
     showBidListButton={false}
     title="Title"
     type="default"
+    useShortFavButton={false}
   />
 </div>
 `;

--- a/src/Components/ResultsCondensedCard/ResultsCondensedCard.jsx
+++ b/src/Components/ResultsCondensedCard/ResultsCondensedCard.jsx
@@ -14,19 +14,26 @@ const ResultsCondensedCard = (
     type,
     refreshFavorites,
     showBidListButton,
+    isProjectedVacancy,
+    isRecentlyAvailable,
+    useShortFavButton,
   }) => (
     <BoxShadow className="usa-grid-full condensed-card-inner">
       <ResultsCondensedCardTop
         favorites={favorites}
         position={position}
         type={type}
+        isProjectedVacancy={isProjectedVacancy}
+        isRecentlyAvailable={isRecentlyAvailable}
       />
       <ResultsCondensedCardBottom
         position={position}
         favorites={favorites}
         bidList={bidList}
         refreshFavorites={refreshFavorites}
-        showBidListButton={showBidListButton}
+        showBidListButton={showBidListButton && !isProjectedVacancy}
+        showBidCount={!isProjectedVacancy}
+        useShortFavButton={useShortFavButton}
       />
       <ResultsCondensedCardFooter
         position={position}
@@ -41,12 +48,18 @@ ResultsCondensedCard.propTypes = {
   type: HOME_PAGE_CARD_TYPE.isRequired,
   refreshFavorites: PropTypes.bool,
   showBidListButton: PropTypes.bool,
+  isProjectedVacancy: PropTypes.bool,
+  isRecentlyAvailable: PropTypes.bool,
+  useShortFavButton: PropTypes.bool,
 };
 
 ResultsCondensedCard.defaultProps = {
   favorites: [],
   refreshFavorites: false,
   showBidListButton: false,
+  isProjectedVacancy: false,
+  isRecentlyAvailable: false,
+  useShortFavButton: false,
 };
 
 export default ResultsCondensedCard;

--- a/src/Components/ResultsCondensedCard/__snapshots__/ResultsCondensedCard.test.jsx.snap
+++ b/src/Components/ResultsCondensedCard/__snapshots__/ResultsCondensedCard.test.jsx.snap
@@ -14,6 +14,8 @@ exports[`ResultsCondensedCardComponent matches snapshot 1`] = `
 >
   <ResultsCondensedCardTop
     favorites={Array []}
+    isProjectedVacancy={false}
+    isRecentlyAvailable={false}
     position={
       Object {
         "bid_statistics": Array [
@@ -322,8 +324,10 @@ exports[`ResultsCondensedCardComponent matches snapshot 1`] = `
       }
     }
     refreshFavorites={false}
+    showBidCount={true}
     showBidListButton={false}
     type="default"
+    useShortFavButton={false}
   />
   <ResultsCondensedCardFooter
     position={

--- a/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.jsx
+++ b/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.jsx
@@ -13,20 +13,22 @@ const ResultsCondensedCardBottom = (
     favorites,
     refreshFavorites,
     showBidListButton,
+    showBidCount,
+    useShortFavButton,
   }) => (
     <div className="condensed-card-bottom-container">
       <div className="usa-grid-full condensed-card-bottom">
-        <ResultsCondensedCardStats bidStatisticsArray={position.bid_statistics} />
+        {showBidCount && <ResultsCondensedCardStats bidStatisticsArray={position.bid_statistics} />}
         <CondensedCardData position={position} />
         <div className="usa-grid-full condensed-card-buttons-section">
           <Favorite
             useLongText
-            hideText={showBidListButton}
+            hideText={useShortFavButton}
             hasBorder
             refKey={position.id}
             compareArray={favorites}
-            useButtonClass={!showBidListButton}
-            useButtonClassSecondary={showBidListButton}
+            useButtonClass={!useShortFavButton}
+            useButtonClassSecondary={useShortFavButton}
             refresh={refreshFavorites}
           />
           {
@@ -48,12 +50,16 @@ ResultsCondensedCardBottom.propTypes = {
   favorites: FAVORITE_POSITIONS_ARRAY.isRequired,
   refreshFavorites: PropTypes.bool,
   showBidListButton: PropTypes.bool,
+  showBidCount: PropTypes.bool,
+  useShortFavButton: PropTypes.bool,
 };
 
 ResultsCondensedCardBottom.defaultProps = {
   type: 'default',
   refreshFavorites: false,
   showBidListButton: false,
+  showBidCount: true,
+  useShortFavButton: false,
 };
 
 export default ResultsCondensedCardBottom;

--- a/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.test.jsx
+++ b/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.test.jsx
@@ -31,6 +31,18 @@ describe('ResultsCondensedCardBottomComponent', () => {
     expect(wrapper.instance().props.type).toBe(type);
   });
 
+  it('does not render the bid stats when showBidCount === false', () => {
+    const wrapper = shallow(
+      <ResultsCondensedCardBottom
+        position={resultsObject.results[0]}
+        bidList={bidListObject.results}
+        favorites={favorites}
+        showBidCount={false}
+      />,
+    );
+    expect(wrapper.find('ResultsCondensedCardStats').exists()).toBe(false);
+  });
+
   it('matches snapshot', () => {
     const wrapper = shallow(
       <ResultsCondensedCardBottom

--- a/src/Components/ResultsCondensedCardBottom/__snapshots__/ResultsCondensedCardBottom.test.jsx.snap
+++ b/src/Components/ResultsCondensedCardBottom/__snapshots__/ResultsCondensedCardBottom.test.jsx.snap
@@ -250,11 +250,11 @@ exports[`ResultsCondensedCardBottomComponent matches snapshot with bidlist butto
           ]
         }
         hasBorder={true}
-        hideText={true}
+        hideText={false}
         refKey={6}
         refresh={false}
-        useButtonClass={false}
-        useButtonClassSecondary={true}
+        useButtonClass={true}
+        useButtonClassSecondary={false}
         useLongText={true}
       />
       <Connect(PermissionsWrapper)

--- a/src/Components/ResultsCondensedCardTop/ResultsCondensedCardTop.jsx
+++ b/src/Components/ResultsCondensedCardTop/ResultsCondensedCardTop.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import FontAwesome from 'react-fontawesome';
 import Handshake from '../Ribbon/Handshake';
@@ -7,19 +8,36 @@ import { POSITION_DETAILS, HOME_PAGE_CARD_TYPE } from '../../Constants/PropTypes
 import { NO_POST } from '../../Constants/SystemMessages';
 import { getPostName, getBidStatisticsObject } from '../../utilities';
 
-const ResultsCondensedCardTop = ({ position, type }) => {
+const ResultsCondensedCardTop = ({ position, type, isProjectedVacancy, isRecentlyAvailable }) => {
   let icon = '';
   let cardTopClass = '';
   let useType = false;
+  let vacancyClass;
+  let vacancyText;
   if (type === 'serviceNeed') {
     icon = 'bolt';
     cardTopClass = 'card-top-alternate';
     useType = true;
   }
+  if (isProjectedVacancy) {
+    vacancyClass = 'vacancy--projected';
+    vacancyText = 'Projected Vacancy';
+    cardTopClass = 'card-top-vacancy';
+  } else if (isRecentlyAvailable) {
+    vacancyClass = 'vacancy--recent';
+    vacancyText = 'Now available';
+  }
   const stats = getBidStatisticsObject(position.bid_statistics);
   const hasHandshake = get(stats, 'has_handshake_offered', false);
+
   return (
     <div className={`usa-grid-full condensed-card-top ${cardTopClass}`}>
+      {
+        vacancyText &&
+        <div className={`usa-grid-full condensed-card-top-header-container vacancy-text-container ${vacancyClass}`}>
+          {vacancyText}
+        </div>
+      }
       <div className="usa-grid-full condensed-card-top-header-container">
         <div
           className={
@@ -48,10 +66,14 @@ const ResultsCondensedCardTop = ({ position, type }) => {
 ResultsCondensedCardTop.propTypes = {
   position: POSITION_DETAILS.isRequired,
   type: HOME_PAGE_CARD_TYPE.isRequired,
+  isProjectedVacancy: PropTypes.bool,
+  isRecentlyAvailable: PropTypes.bool,
 };
 
 ResultsCondensedCardTop.defaultProps = {
   type: 'default',
+  isProjectedVacancy: false,
+  isRecentlyAvailable: false,
 };
 
 export default ResultsCondensedCardTop;

--- a/src/sass/_bidTracker.scss
+++ b/src/sass/_bidTracker.scss
@@ -607,11 +607,6 @@ $draft-icon-offset: 120px;
     flex-direction: column;
   }
 
-  .bid-tracker-standby-inner-container {
-    display: flex;
-    flex-direction: column;
-  }
-
   .bid-tracker-standby-title {
     background-color: $tm-navy-dark;
     color: $color-white;

--- a/src/sass/_condensedCard.scss
+++ b/src/sass/_condensedCard.scss
@@ -1,5 +1,5 @@
 $condensed-card-margin-bottom: 15px;
-$condensed-card-padding: 9px 20px 9px;
+$condensed-card-padding: 9px 20px 7px;
 $condensed-card-data-padding: 15px 20px 9px;
 
 .condensed-card {
@@ -92,6 +92,10 @@ $condensed-card-data-padding: 15px 20px 9px;
     background-color: $tm-navy;
   }
 
+  .card-top-vacancy {
+    background-color: $bg-blue-dark-0;
+  }
+
   .condensed-top-background-image {
     filter: alpha(opacity = 10);
     font-size: 150px;
@@ -103,6 +107,14 @@ $condensed-card-data-padding: 15px 20px 9px;
 
   .condensed-card-top-header-container {
     margin-bottom: 5px;
+  }
+
+  .vacancy-text-container {
+    font-size: 1.2rem;
+  }
+
+  .vacancy--projected {
+    color: $tertiary-gold-lighter;
   }
 
   .condensed-card-top-header-left {

--- a/src/sass/_ribbon.scss
+++ b/src/sass/_ribbon.scss
@@ -54,6 +54,7 @@ $ribbon-shadow-color: rgba(112, 112, 112, .5);
 }
 
 .ribbon-condensed-card {
+  bottom: 0;
   position: absolute;
   right: 0;
   z-index: $ribbon-z;


### PR DESCRIPTION
**Don't merge until #118 is merged**

Completes TM-660 by adding new Condensed Card layouts for "Projected Vacancy" and "Now available".

Normal:
<img width="476" alt="Screen Shot 2019-03-21 at 3 57 40 PM" src="https://user-images.githubusercontent.com/11576347/54781245-21a2d880-4bf2-11e9-9c8f-c16ac1ca14e3.png">

Projected Vacancy:
<img width="476" alt="Screen Shot 2019-03-21 at 3 57 46 PM" src="https://user-images.githubusercontent.com/11576347/54781246-21a2d880-4bf2-11e9-8a13-ea804a7d2684.png">

Now available:
<img width="472" alt="Screen Shot 2019-03-21 at 3 57 53 PM" src="https://user-images.githubusercontent.com/11576347/54781247-223b6f00-4bf2-11e9-9ca9-ce62843a8e5c.png">
