### PR TITLE
Pull css-box-shadow repo into app to force es6 to compile

### DIFF
--- a/src/Components/BoxShadow/BoxShadow.jsx
+++ b/src/Components/BoxShadow/BoxShadow.jsx
@@ -1,7 +1,7 @@
 // forked from https://github.com/lachlanjc/react-box-shadow
 import React from 'react';
 import PropTypes from 'prop-types';
-import cssShadow from 'css-box-shadow';
+import cssShadow from './BoxShadowUtility';
 
 const BoxShadow = ({ is, inset, offsetX, offsetY, blurRadius, spreadRadius, color, style,
 ...props }) => {

--- a/src/Components/BoxShadow/BoxShadowUtility.js
+++ b/src/Components/BoxShadow/BoxShadowUtility.js
@@ -1,0 +1,70 @@
+// from https://www.npmjs.com/package/css-box-shadow
+
+/* eslint-disable */
+
+const VALUES_REG = /,(?![^\(]*\))/;
+const PARTS_REG = /\s(?![^(]*\))/;
+const LENGTH_REG = /^[0-9]+[a-zA-Z%]+?$/;
+
+const parseValue = (str) => {
+  const parts = str.split(PARTS_REG);
+  const inset = parts.includes('inset');
+  const last = parts.slice(-1)[0];
+  const color = !isLength(last) ? last : undefined;
+
+  const nums = parts
+    .filter(n => n !== 'inset')
+    .filter(n => n !== color)
+    .map(toNum);
+  const [offsetX, offsetY, blurRadius, spreadRadius] = nums;
+
+  return {
+    inset,
+    offsetX,
+    offsetY,
+    blurRadius,
+    spreadRadius,
+    color,
+  };
+};
+
+const stringifyValue = (obj) => {
+  const {
+    inset,
+    offsetX = 0,
+    offsetY = 0,
+    blurRadius = 0,
+    spreadRadius,
+    color,
+  } = obj || {};
+
+  return [
+    (inset ? 'inset' : null),
+    offsetX,
+    offsetY,
+    blurRadius,
+    spreadRadius,
+    color,
+  ].filter(v => v !== null && v !== undefined)
+    .map(toPx)
+    .map(s => (`${s}`).trim())
+    .join(' ');
+};
+
+const isLength = v => v === '0' || LENGTH_REG.test(v);
+const toNum = (v) => {
+  if (!/px$/.test(v) && v !== '0') return v;
+  const n = parseFloat(v);
+  return !isNaN(n) ? n : v;
+};
+const toPx = n => typeof n === 'number' && n !== 0 ? (`${n}px`) : n;
+
+const parse = str => str.split(VALUES_REG).map(s => s.trim()).map(parseValue);
+const stringify = arr => arr.map(stringifyValue).join(', ');
+
+module.exports = {
+  parse,
+  stringify,
+};
+
+/* eslint-enable */


### PR DESCRIPTION
Fixes an issue with `yarn build` where the app wouldn't compile. It was caused by the css-box-shadow dependency not including an es5 compiled version. I've brought the functionality directly into our app to force it to compile.