### PR TITLE
fix: Search results export

### DIFF
--- a/src/Components/SearchResultsExportLink/SearchResultsExportLink.jsx
+++ b/src/Components/SearchResultsExportLink/SearchResultsExportLink.jsx
@@ -42,11 +42,18 @@ class SearchResultsExportLink extends Component {
     };
   }
 
+  componentWillReceiveProps() {
+    const query = window.location.search.replace('?', '') || '';
+    if (this.state.query.value !== query) {
+      this.setState({ query: { value: query } });
+    }
+  }
+
   onClick() {
     // reset the state to support multiple clicks
     this.setState({ data: '' });
     const query = {
-      ordering: POSITION_SEARCH_SORTS,
+      ordering: POSITION_SEARCH_SORTS.defaultSort,
       ...queryString.parse(this.state.query.value),
       limit: this.props.count,
     };


### PR DESCRIPTION
I noticed a couple of issues with the Search Results export button that are fixed by this PR:
- The process of pulling the default sort option was referencing an object instead of the required property within that object
- The search query for the Export to use was only initialized on mount, and did not refresh after new filters were chosen