### PR TITLE
Auto-complete dropdown on Bidder Portfolio

### DIFF
--- a/src/Components/AutoSuggest/AutoSuggest.jsx
+++ b/src/Components/AutoSuggest/AutoSuggest.jsx
@@ -61,14 +61,15 @@ export default class AutoSuggest extends Component {
 
   // Use your imagination to render suggestions.
   renderSuggestion(suggestion) {
+    const { templateProps } = this.props;
     const Template = this.props.suggestionTemplate;
-    return <Template suggestion={suggestion} />;
+    return <Template suggestion={suggestion} {...templateProps} />;
   }
 
   render() {
     const { value } = this.state;
     const { placeholder, suggestions, onSuggestionsClearRequested, id,
-      customInputProps, inputId, label, labelSrOnly, className } = this.props;
+      customInputProps, inputId, label, labelSrOnly, className, autoSuggestProps } = this.props;
 
     // Autosuggest will pass through all these props to the input.
     const inputProps = {
@@ -92,6 +93,7 @@ export default class AutoSuggest extends Component {
           renderSuggestion={this.renderSuggestion}
           inputProps={inputProps}
           id={id}
+          {...autoSuggestProps}
         />
       </div>
     );
@@ -123,9 +125,9 @@ AutoSuggest.propTypes = {
   // ...but we can make that label srOnly if we want. It will default to true.
   labelSrOnly: PropTypes.bool,
 
-  getSuggestions: PropTypes.func.isRequired,
+  getSuggestions: PropTypes.func,
   debounceMillis: PropTypes.number, // Number in milliseconds to debounce typing.
-  onSuggestionSelected: PropTypes.func.isRequired,
+  onSuggestionSelected: PropTypes.func,
 
   // This is required by the AutoSuggest component, but is not necessary for our use.
   onSuggestionsClearRequested: PropTypes.func,
@@ -142,6 +144,12 @@ AutoSuggest.propTypes = {
   suggestionTemplate: PropTypes.func,
 
   className: PropTypes.string,
+
+  // other autosuggest props
+  autoSuggestProps: PropTypes.shape({}),
+
+  // props to pass to template
+  templateProps: PropTypes.shape({}),
 };
 
 AutoSuggest.defaultProps = {
@@ -150,10 +158,14 @@ AutoSuggest.defaultProps = {
   suggestions: [],
   placeholder: '',
   labelSrOnly: true,
+  getSuggestions: EMPTY_FUNCTION,
   debounceMillis: 350,
+  onSuggestionSelected: EMPTY_FUNCTION,
   onSuggestionsClearRequested: EMPTY_FUNCTION,
   displayProperty: 'short_name',
   queryProperty: '',
   suggestionTemplate: SuggestionChoice,
   className: undefined,
+  autoSuggestProps: {},
+  templateProps: {},
 };

--- a/src/Components/AutoSuggest/SuggestionChoiceCDOName/SuggestionChoice.jsx
+++ b/src/Components/AutoSuggest/SuggestionChoiceCDOName/SuggestionChoice.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FA from 'react-fontawesome';
+
+const SuggestionChoice = ({ suggestion, value }) => {
+  const name = `${suggestion.first_name} ${suggestion.last_name}`;
+  const isSelection = suggestion.id === value.id;
+  return (
+    <div className="render-suggestion" style={{ position: 'relative' }} >
+      {isSelection && <FA name="check" style={{ position: 'absolute', left: '-20px', top: '2px' }} />}
+      {`${name}${suggestion.isCurrentUser ? ' (me)' : ''}`}
+    </div>
+  );
+};
+
+SuggestionChoice.propTypes = {
+  suggestion: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    first_name: PropTypes.string.isRequired,
+    last_name: PropTypes.string.isRequired,
+    isCurrentUser: PropTypes.bool,
+  }).isRequired,
+  value: PropTypes.shape({
+    id: PropTypes.number,
+  }),
+};
+
+SuggestionChoice.defaultProps = {
+  value: {},
+};
+
+export default SuggestionChoice;

--- a/src/Components/AutoSuggest/SuggestionChoiceCDOName/SuggestionChoice.test.jsx
+++ b/src/Components/AutoSuggest/SuggestionChoiceCDOName/SuggestionChoice.test.jsx
@@ -1,0 +1,39 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import toJSON from 'enzyme-to-json';
+import SuggestionChoice from './SuggestionChoice';
+
+describe('SuggestionChoiceCDONameComponent', () => {
+  const suggestion = {
+    id: 2,
+    first_name: 'Bob',
+    last_name: 'Smith',
+  };
+  it('is defined', () => {
+    const wrapper = shallow(
+      <SuggestionChoice
+        suggestion={suggestion}
+      />,
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(
+      <SuggestionChoice
+        suggestion={suggestion}
+      />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
+  it('matches snapshot when isCurrentUser === true', () => {
+    const wrapper = shallow(
+      <SuggestionChoice
+        suggestion={{ ...suggestion, isCurrentUser: true }}
+        value={suggestion}
+      />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/AutoSuggest/SuggestionChoiceCDOName/__snapshots__/SuggestionChoice.test.jsx.snap
+++ b/src/Components/AutoSuggest/SuggestionChoiceCDOName/__snapshots__/SuggestionChoice.test.jsx.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SuggestionChoiceCDONameComponent matches snapshot 1`] = `
+<div
+  className="render-suggestion"
+  style={
+    Object {
+      "position": "relative",
+    }
+  }
+>
+  Bob Smith
+</div>
+`;
+
+exports[`SuggestionChoiceCDONameComponent matches snapshot when isCurrentUser === true 1`] = `
+<div
+  className="render-suggestion"
+  style={
+    Object {
+      "position": "relative",
+    }
+  }
+>
+  <FontAwesome
+    name="check"
+    style={
+      Object {
+        "left": "-20px",
+        "position": "absolute",
+        "top": "2px",
+      }
+    }
+  />
+  Bob Smith (me)
+</div>
+`;

--- a/src/Components/AutoSuggest/SuggestionChoiceCDOName/index.js
+++ b/src/Components/AutoSuggest/SuggestionChoiceCDOName/index.js
@@ -1,0 +1,1 @@
+export { default } from './SuggestionChoice';

--- a/src/Components/BidderPortfolio/BidderPortfolioSearch/BidderPortfolioSearch.jsx
+++ b/src/Components/BidderPortfolio/BidderPortfolioSearch/BidderPortfolioSearch.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ResultsSearchHeader from '../../ResultsSearchHeader';
+import CDOAutoSuggest from '../CDOAutoSuggest';
 
 const BidderPortfolioSearch = ({ onUpdate }) => (
   <div className="bidder-portfolio-search-container">
+    <div className="usa-grid-full">
+      <CDOAutoSuggest />
+    </div>
     <div className="results-search-bar-container">
       <ResultsSearchHeader
         labelSrOnly

--- a/src/Components/BidderPortfolio/BidderPortfolioSearch/__snapshots__/BidderPortfolioSearch.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidderPortfolioSearch/__snapshots__/BidderPortfolioSearch.test.jsx.snap
@@ -5,6 +5,11 @@ exports[`BidderPortfolioSearchComponent matches snapshot 1`] = `
   className="bidder-portfolio-search-container"
 >
   <div
+    className="usa-grid-full"
+  >
+    <CDOAutoSuggest />
+  </div>
+  <div
     className="results-search-bar-container"
   >
     <ResultsSearchHeader

--- a/src/Components/BidderPortfolio/CDOAutoSuggest/CDOAutoSuggest.jsx
+++ b/src/Components/BidderPortfolio/CDOAutoSuggest/CDOAutoSuggest.jsx
@@ -1,0 +1,121 @@
+import React, { Component } from 'react';
+import Dropdown, { DropdownContent } from 'react-simple-dropdown';
+import FA from 'react-fontawesome';
+import AutoSuggest from '../../AutoSuggest';
+import SuggestionChoiceCDOName from '../../AutoSuggest/SuggestionChoiceCDOName';
+import { getCurrentUser, filterUsers } from '../temporyHelpers';
+import BoxShadow from '../../BoxShadow';
+import InteractiveElement from '../../InteractiveElement';
+
+// we'll reference this to return focus after making a selection
+const dropdownID = 'cdo-portfolio-dropdown-trigger';
+
+class CDOAutoSuggest extends Component {
+  constructor(props) {
+    super(props);
+    this.onSuggestionSelected = this.onSuggestionSelected.bind(this);
+    this.getFilteredUsers = this.getFilteredUsers.bind(this);
+    this.toggleDropdown = this.toggleDropdown.bind(this);
+    this.dropdown = {};
+    this.state = {
+      suggestions: filterUsers(''),
+      selection: getCurrentUser(),
+      isActive: false,
+    };
+  }
+
+  onSuggestionSelected(selection) {
+    this.setState({ selection }, () => {
+      this.hideDropdown();
+      document.getElementById(dropdownID).focus();
+    });
+  }
+
+  getFilteredUsers(term) {
+    this.setState({ suggestions: filterUsers(term) });
+  }
+
+  hideDropdown() {
+    // Explicitly hide the dropdown using the built-in hide() function from react-simple-dropdown
+    if (this.dropdown.hide) { this.dropdown.hide(); }
+    this.setState({ isActive: false });
+  }
+
+  showDropdown() {
+    // Explicitly show the dropdown using the built-in show() function from react-simple-dropdown
+    if (this.dropdown.show) { this.dropdown.show(); }
+    this.setState({ isActive: true });
+  }
+
+  toggleDropdown() {
+    const { isActive } = this.state;
+    if (isActive) {
+      this.hideDropdown();
+    } else {
+      this.showDropdown();
+    }
+  }
+
+  render() {
+    const { isActive, selection, suggestions } = this.state;
+    let triggerLabel = `${selection.first_name} ${selection.last_name}`;
+    let icon = 'chevron-down';
+    let altPrefix = 'Open';
+    if (isActive) {
+      triggerLabel = 'See client list as';
+      icon = 'chevron-up';
+      altPrefix = 'Close';
+    }
+    const alt = `${altPrefix} client list search`;
+    return (
+      <Dropdown
+        className="portfolio-account-dropdown"
+        ref={(dropdown) => { this.dropdown = dropdown; }}
+        removeElement
+        active={isActive}
+      >
+        <h2>Client Profiles</h2>
+        <div className="usa-grid-full dropdown-trigger-container">
+          <span>Client list:</span>
+          <InteractiveElement
+            onClick={this.toggleDropdown}
+            className="account-dropdown--name"
+            id={dropdownID}
+            alt={alt}
+          >
+            {triggerLabel}
+            <FA name={icon} />
+          </InteractiveElement>
+        </div>
+        <BoxShadow>
+          <div className="dropdown-content-outer-container">
+            <DropdownContent>
+              <div className="autosuggest-container">
+                <AutoSuggest
+                  label="Client list"
+                  inputId="cdo-portfolio-autosuggest"
+                  debounceMillis={0}
+                  suggestions={suggestions}
+                  getSuggestions={this.getFilteredUsers}
+                  displayProperty={o => `${o.first_name} ${o.last_name}`}
+                  suggestionTemplate={SuggestionChoiceCDOName}
+                  onSuggestionSelected={this.onSuggestionSelected}
+                  placeholder="Start typing CDO name"
+                  autoSuggestProps={{
+                    shouldRenderSuggestions: () => true,
+                    alwaysRenderSuggestions: true,
+                  }}
+                  templateProps={{
+                    value: selection,
+                  }}
+                />
+              </div>
+            </DropdownContent>
+          </div>
+        </BoxShadow>
+      </Dropdown>
+    );
+  }
+}
+
+export default CDOAutoSuggest;

--- a/src/Components/BidderPortfolio/CDOAutoSuggest/CDOAutoSuggest.test.jsx
+++ b/src/Components/BidderPortfolio/CDOAutoSuggest/CDOAutoSuggest.test.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJSON from 'enzyme-to-json';
+import CDOAutoSuggest from './CDOAutoSuggest';
+
+describe('CDOAutoSuggest', () => {
+  it('is defined', () => {
+    const wrapper = shallow(<CDOAutoSuggest />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(<CDOAutoSuggest />);
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
+  it('matches snapshot after toggling', () => {
+    const wrapper = shallow(<CDOAutoSuggest />);
+    wrapper.find('InteractiveElement').simulate('click');
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/BidderPortfolio/CDOAutoSuggest/__snapshots__/CDOAutoSuggest.test.jsx.snap
+++ b/src/Components/BidderPortfolio/CDOAutoSuggest/__snapshots__/CDOAutoSuggest.test.jsx.snap
@@ -1,0 +1,289 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CDOAutoSuggest matches snapshot 1`] = `
+<Dropdown
+  active={false}
+  className="portfolio-account-dropdown"
+  removeElement={true}
+>
+  <h2>
+    Client Profiles
+  </h2>
+  <div
+    className="usa-grid-full dropdown-trigger-container"
+  >
+    <span>
+      Client list:
+    </span>
+    <InteractiveElement
+      alt="Open client list search"
+      className="account-dropdown--name"
+      id="cdo-portfolio-dropdown-trigger"
+      onClick={[Function]}
+      type="div"
+    >
+      Leah Shadtrach
+      <FontAwesome
+        name="chevron-down"
+      />
+    </InteractiveElement>
+  </div>
+  <BoxShadow
+    blurRadius={10}
+    color="rgba(0,0,0,.15)"
+    inset={false}
+    is="div"
+    offsetX={3}
+    offsetY={2}
+    spreadRadius={1}
+    style={Object {}}
+  >
+    <div
+      className="dropdown-content-outer-container"
+    >
+      <DropdownContent
+        className=""
+      >
+        <div
+          className="autosuggest-container"
+        >
+          <AutoSuggest
+            autoSuggestProps={
+              Object {
+                "alwaysRenderSuggestions": true,
+                "shouldRenderSuggestions": [Function],
+              }
+            }
+            customInputProps={Object {}}
+            debounceMillis={0}
+            displayProperty={[Function]}
+            getSuggestions={[Function]}
+            inputId="cdo-portfolio-autosuggest"
+            label="Client list"
+            labelSrOnly={true}
+            onSuggestionSelected={[Function]}
+            onSuggestionsClearRequested={[Function]}
+            placeholder="Start typing CDO name"
+            queryProperty=""
+            suggestionTemplate={[Function]}
+            suggestions={
+              Array [
+                Object {
+                  "first_name": "Leah",
+                  "id": 11,
+                  "isCurrentUser": true,
+                  "last_name": "Shadtrach",
+                },
+                Object {
+                  "first_name": "Mary",
+                  "id": 4,
+                  "last_name": "Brown",
+                },
+                Object {
+                  "first_name": "John",
+                  "id": 3,
+                  "last_name": "Daniels",
+                },
+                Object {
+                  "first_name": "Daniel",
+                  "id": 7,
+                  "last_name": "Garcia",
+                },
+                Object {
+                  "first_name": "Marcus",
+                  "id": 8,
+                  "last_name": "Johnson",
+                },
+                Object {
+                  "first_name": "Mike",
+                  "id": 2,
+                  "last_name": "Jones",
+                },
+                Object {
+                  "first_name": "Madeline",
+                  "id": 10,
+                  "last_name": "Lee",
+                },
+                Object {
+                  "first_name": "Jennifer",
+                  "id": 9,
+                  "last_name": "McAndrew",
+                },
+                Object {
+                  "first_name": "Bob",
+                  "id": 1,
+                  "last_name": "Smith",
+                },
+                Object {
+                  "first_name": "Maria",
+                  "id": 6,
+                  "last_name": "Smith",
+                },
+                Object {
+                  "first_name": "Elizabeth",
+                  "id": 5,
+                  "last_name": "Walters",
+                },
+              ]
+            }
+            templateProps={
+              Object {
+                "value": Object {
+                  "first_name": "Leah",
+                  "id": 11,
+                  "isCurrentUser": true,
+                  "last_name": "Shadtrach",
+                },
+              }
+            }
+          />
+        </div>
+      </DropdownContent>
+    </div>
+  </BoxShadow>
+</Dropdown>
+`;
+
+exports[`CDOAutoSuggest matches snapshot after toggling 1`] = `
+<Dropdown
+  active={true}
+  className="portfolio-account-dropdown"
+  removeElement={true}
+>
+  <h2>
+    Client Profiles
+  </h2>
+  <div
+    className="usa-grid-full dropdown-trigger-container"
+  >
+    <span>
+      Client list:
+    </span>
+    <InteractiveElement
+      alt="Close client list search"
+      className="account-dropdown--name"
+      id="cdo-portfolio-dropdown-trigger"
+      onClick={[Function]}
+      type="div"
+    >
+      See client list as
+      <FontAwesome
+        name="chevron-up"
+      />
+    </InteractiveElement>
+  </div>
+  <BoxShadow
+    blurRadius={10}
+    color="rgba(0,0,0,.15)"
+    inset={false}
+    is="div"
+    offsetX={3}
+    offsetY={2}
+    spreadRadius={1}
+    style={Object {}}
+  >
+    <div
+      className="dropdown-content-outer-container"
+    >
+      <DropdownContent
+        className=""
+      >
+        <div
+          className="autosuggest-container"
+        >
+          <AutoSuggest
+            autoSuggestProps={
+              Object {
+                "alwaysRenderSuggestions": true,
+                "shouldRenderSuggestions": [Function],
+              }
+            }
+            customInputProps={Object {}}
+            debounceMillis={0}
+            displayProperty={[Function]}
+            getSuggestions={[Function]}
+            inputId="cdo-portfolio-autosuggest"
+            label="Client list"
+            labelSrOnly={true}
+            onSuggestionSelected={[Function]}
+            onSuggestionsClearRequested={[Function]}
+            placeholder="Start typing CDO name"
+            queryProperty=""
+            suggestionTemplate={[Function]}
+            suggestions={
+              Array [
+                Object {
+                  "first_name": "Leah",
+                  "id": 11,
+                  "isCurrentUser": true,
+                  "last_name": "Shadtrach",
+                },
+                Object {
+                  "first_name": "Mary",
+                  "id": 4,
+                  "last_name": "Brown",
+                },
+                Object {
+                  "first_name": "John",
+                  "id": 3,
+                  "last_name": "Daniels",
+                },
+                Object {
+                  "first_name": "Daniel",
+                  "id": 7,
+                  "last_name": "Garcia",
+                },
+                Object {
+                  "first_name": "Marcus",
+                  "id": 8,
+                  "last_name": "Johnson",
+                },
+                Object {
+                  "first_name": "Mike",
+                  "id": 2,
+                  "last_name": "Jones",
+                },
+                Object {
+                  "first_name": "Madeline",
+                  "id": 10,
+                  "last_name": "Lee",
+                },
+                Object {
+                  "first_name": "Jennifer",
+                  "id": 9,
+                  "last_name": "McAndrew",
+                },
+                Object {
+                  "first_name": "Bob",
+                  "id": 1,
+                  "last_name": "Smith",
+                },
+                Object {
+                  "first_name": "Maria",
+                  "id": 6,
+                  "last_name": "Smith",
+                },
+                Object {
+                  "first_name": "Elizabeth",
+                  "id": 5,
+                  "last_name": "Walters",
+                },
+              ]
+            }
+            templateProps={
+              Object {
+                "value": Object {
+                  "first_name": "Leah",
+                  "id": 11,
+                  "isCurrentUser": true,
+                  "last_name": "Shadtrach",
+                },
+              }
+            }
+          />
+        </div>
+      </DropdownContent>
+    </div>
+  </BoxShadow>
+</Dropdown>
+`;

--- a/src/Components/BidderPortfolio/CDOAutoSuggest/index.js
+++ b/src/Components/BidderPortfolio/CDOAutoSuggest/index.js
@@ -1,0 +1,1 @@
+export { default } from './CDOAutoSuggest';

--- a/src/Components/BidderPortfolio/temporyHelpers.js
+++ b/src/Components/BidderPortfolio/temporyHelpers.js
@@ -1,0 +1,28 @@
+// Temporary helpers used for static data
+
+import { find, orderBy } from 'lodash';
+import { filterByProps } from '../../utilities';
+
+export const CDO_USERS = [
+  { first_name: 'Bob', last_name: 'Smith', id: 1 },
+  { first_name: 'Mike', last_name: 'Jones', id: 2 },
+  { first_name: 'John', last_name: 'Daniels', id: 3 },
+  { first_name: 'Mary', last_name: 'Brown', id: 4 },
+  { first_name: 'Elizabeth', last_name: 'Walters', id: 5 },
+  { first_name: 'Maria', last_name: 'Smith', id: 6 },
+  { first_name: 'Daniel', last_name: 'Garcia', id: 7 },
+  { first_name: 'Marcus', last_name: 'Johnson', id: 8 },
+  { first_name: 'Jennifer', last_name: 'McAndrew', id: 9 },
+  { first_name: 'Madeline', last_name: 'Lee', id: 10 },
+  { first_name: 'Leah', last_name: 'Shadtrach', id: 11, isCurrentUser: true },
+];
+
+export const getCurrentUser = () => find(CDO_USERS, 'isCurrentUser');
+
+export function filterUsers(term) {
+  const getOrdered = a => orderBy(a, ['isCurrentUser', 'last_name']);
+
+  return term.length ?
+  getOrdered(filterByProps(term, ['first_name', 'last_name'], CDO_USERS)) :
+  getOrdered(CDO_USERS);
+}

--- a/src/Components/SearchFilters/PostFilter/__snapshots__/PostFilter.test.jsx.snap
+++ b/src/Components/SearchFilters/PostFilter/__snapshots__/PostFilter.test.jsx.snap
@@ -5,6 +5,7 @@ exports[`PostFilterComponent matches snapshot 1`] = `
   className="usa-grid-full"
 >
   <AutoSuggest
+    autoSuggestProps={Object {}}
     className="post-auto-suggest-container"
     customInputProps={
       Object {
@@ -24,6 +25,7 @@ exports[`PostFilterComponent matches snapshot 1`] = `
     queryProperty="id"
     suggestionTemplate={[Function]}
     suggestions={Array []}
+    templateProps={Object {}}
   />
   <div
     className="usa-grid-full tm-nested-accordions"

--- a/src/sass/_accessibility.scss
+++ b/src/sass/_accessibility.scss
@@ -31,10 +31,12 @@ a {
   }
 }
 
-.bidder-portfolio-search-container {
-  .results-search-bar {
-    *:focus {
-      outline-color: $tm-focus-outline-color;
+.portfolio-account-dropdown {
+  .label-input-wrapper > input,
+  .usa-button,
+  .account-dropdown--name {
+    &:focus {
+      outline-color: $tm-focus-outline-color-alt;
     }
   }
 }

--- a/src/sass/_bidderPortfolio.scss
+++ b/src/sass/_bidderPortfolio.scss
@@ -144,7 +144,43 @@
   }
 }
 
+$cdo-search-container-width: 270px;
+$cdo-search-container-padding: 10px;
+
 .bidder-portfolio-page {
+
+  .results-single-search {
+    padding-left: 0 !important;
+  }
+
+  h2 {
+    color: $color-white;
+    font-family: inherit;
+    font-size: 2.4rem;
+    font-weight: normal;
+    margin: 0;
+  }
+
+  .dropdown-trigger-container {
+    align-items: center;
+    color: $color-white;
+    display: flex;
+    margin-top: 10px;
+
+    > span {
+      margin-right: 10px;
+    }
+  }
+
+  .account-dropdown--name {
+    border: 1px solid $color-white;
+    color: $color-white;
+    display: flex;
+    justify-content: space-between;
+    margin-left: 0;
+    min-width: $cdo-search-container-width + ($cdo-search-container-padding * 2);
+    padding: 8px 11px;
+  }
 
   .tm-avatar {
     font-size: 2rem;
@@ -154,8 +190,8 @@
   }
 
   .bidder-portfolio-search-container {
-    background-color: $color-gray-lighter;
-    padding-bottom: 3px;
+    background-color: $bg-blue-dark-1;
+    padding: 12px 31px;
   }
 
   .portfolio-sort-container {
@@ -182,7 +218,7 @@
 
   .results-search-bar-container {
     max-width: unset;
-    padding: 0 5px 0 15px;
+    padding: 0;
   }
 
   .search-submit-button {
@@ -465,3 +501,60 @@
     margin-bottom: .5em;
   }
 }
+
+// scss-lint:disable SelectorFormat
+.portfolio-account-dropdown {
+  $highlighted-color: #D9E3EB;
+  $unhighlighted-color: #F1F1F1;
+
+  input {
+    position: relative;
+    top: -2px;
+  }
+
+  .dropdown__content {
+    position: relative;
+  }
+
+  .react-autosuggest__suggestions-container {
+    border: 1px solid $color-black;
+    border-top: 0;
+    max-height: 200px;
+    overflow-y: scroll;
+    width: $cdo-search-container-width;
+  }
+
+  li {
+    background-color: $unhighlighted-color;
+    border: 0;
+  }
+
+  .react-autosuggest__suggestion--highlighted {
+    background-color: $highlighted-color;
+  }
+
+  .react-autosuggest__container {
+    background-color: $unhighlighted-color;
+    border: 1px solid $color-black;
+    border-top: 0;
+    left: 74px;
+    padding: $cdo-search-container-padding $cdo-search-container-padding 0;
+    top: -11px;
+  }
+
+  .dropdown-content-outer-container {
+    position: absolute;
+  }
+
+  .autosuggest-container {
+    padding: 5px;
+  }
+
+  .react-autosuggest__suggestions-container--open {
+    border: 0;
+    position: relative;
+    right: 0;
+    top: 0;
+  }
+}
+// scss-lint:enable SelectorFormat

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -275,18 +275,23 @@ export const filterByProps = (keyword, props = [], array = []) => {
   if (keyword.length) {
     // filter the array and return its value
     return array.filter((data) => {
-      let doesMatch;
+      let doesMatch = true;
       // iterate through props and see if keyword is found in their values
-      props.forEach((prop) => {
-        // if so, doesMatch = true
-        if (data[prop].toString().toLowerCase().indexOf(keyword.toString().toLowerCase()) !== -1) {
-          doesMatch = true;
-        }
+      keyword.split(' ').filter(f => f.length).forEach((k) => {
+        let doesMatch$ = false;
+        props.forEach((prop) => {
+          if (doesMatch) {
+            // if so, doesMatch = true
+            if (data[prop].toString().toLowerCase().indexOf(k.toString().toLowerCase()) !== -1) {
+              doesMatch$ = true;
+            }
+          }
+        });
+        doesMatch = doesMatch$;
       });
       // if keyword was found in at least one of the props, doesMatch should be true
       return doesMatch;
-    },
-    );
+    });
   }
   // if keyword length === 0, return the unfiltered array
   return array;


### PR DESCRIPTION
Completes TM-719 by adding an auto-complete dropdown of CDOs to the Bidder Portfolio. This currently uses notional data, so there is no API connection.

Part of this task required me to improve the text search used by the Glossary, so now you can search the Glossary for words that aren't adjacent (ex: search term of "quick fox" will now return the glossary term with definition "the quick brown fox jumped...").