### PR TITLE
Set min-width on compare drawer cards in IE11

### DIFF
--- a/src/sass/_compareDrawer.scss
+++ b/src/sass/_compareDrawer.scss
@@ -38,6 +38,11 @@
     padding: 15px;
     position: relative;
     width: 0;
+
+    // fix card width in IE11
+    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+      min-width: 15%;
+    }
   }
 
   .compare-item-empty {


### PR DESCRIPTION
Resolves TM-765 by forcing a `min-width` on the Compare Drawer cards in IE11 only.