### PR TITLE
Better "Go Back" button usability

### DIFF
--- a/src/Components/BackButton/BackButton.jsx
+++ b/src/Components/BackButton/BackButton.jsx
@@ -1,22 +1,23 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import FontAwesome from 'react-fontawesome';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { getLastRouteLink } from '../../actions/routerLocations';
 import { ROUTER_LOCATIONS } from '../../Constants/PropTypes';
 
-const BackButton = ({ routerLocations }) => {
-  const goBackLink = getLastRouteLink(routerLocations);
+export const BackButton = ({ routerLocations, location, ignoreCurrentPath }) => {
+  const { text, distance } = getLastRouteLink(routerLocations, location, ignoreCurrentPath);
   return (
-    goBackLink.text ?
+    text ?
       <button
         className="button-back-link usa-button-secondary"
         tabIndex="0"
         role="link"
-        onClick={() => window.history.back()}
+        onClick={() => window.history.go(-(distance))}
       >
         <FontAwesome name="arrow-left" />
-        {goBackLink.text}
+        {text}
       </button>
       :
       null
@@ -25,10 +26,14 @@ const BackButton = ({ routerLocations }) => {
 
 BackButton.propTypes = {
   routerLocations: ROUTER_LOCATIONS,
+  location: PropTypes.shape({}),
+  ignoreCurrentPath: PropTypes.bool,
 };
 
 BackButton.defaultProps = {
   routerLocations: [],
+  location: {},
+  ignoreCurrentPath: false,
 };
 
 const mapStateToProps = state => ({

--- a/src/Components/BackButton/BackButton.test.jsx
+++ b/src/Components/BackButton/BackButton.test.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
+import toJSON from 'enzyme-to-json';
 import TestUtils from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { MemoryRouter } from 'react-router-dom';
-import toJSON from 'enzyme-to-json';
-import BackButton from './BackButton';
+import BackButtonContainer, { BackButton } from './BackButton';
 
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
@@ -15,33 +15,40 @@ const mockStore = configureStore(middlewares);
 describe('BackButton', () => {
   const props = {
     routerLocations: [
-      { pathname: '/' },
-      { pathname: '/results' },
+      { pathname: '/results', search: '?q=', hash: '', state: undefined, key: 'dudni5' },
+      { pathname: '/compare/58312870,58312869', search: '', hash: '', state: undefined, key: 't0s36f' },
     ],
+    location: { pathname: '/compare/58312870,58312869', search: '', hash: '', key: 't0s36f' },
+    ignoreCurrentPath: true,
   };
 
   it('is defined', () => {
+    const wrapper = shallow(<BackButton {...props} />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('is defined when connected', () => {
     const wrapper = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <BackButton {...props} />
+      <BackButtonContainer {...props} />
     </MemoryRouter></Provider>);
     expect(wrapper).toBeDefined();
   });
 
   it('renders the button', () => {
-    const wrapper = shallow(<BackButton.WrappedComponent {...props} />);
+    const wrapper = shallow(<BackButton {...props} />);
     expect(wrapper.find('.button-back-link').exists()).toBe(true);
   });
 
-  it('calls window.history.back on click', () => {
-    const wrapper = shallow(<BackButton.WrappedComponent {...props} />);
+  it('calls window.history.go on click', () => {
+    const wrapper = shallow(<BackButton {...props} />);
     const spy = sinon.spy();
-    window.history.back = spy;
+    window.history.go = spy;
     expect(wrapper.find('button').simulate('click'));
     sinon.assert.calledOnce(spy);
   });
 
   it('matches snapshot', () => {
-    const wrapper = shallow(<BackButton.WrappedComponent {...props} />);
+    const wrapper = shallow(<BackButton {...props} />);
     expect(toJSON(wrapper)).toMatchSnapshot();
   });
 });

--- a/src/Components/BackButton/__snapshots__/BackButton.test.jsx.snap
+++ b/src/Components/BackButton/__snapshots__/BackButton.test.jsx.snap
@@ -10,6 +10,6 @@ exports[`BackButton matches snapshot 1`] = `
   <FontAwesome
     name="arrow-left"
   />
-  Back to Home Page
+  Back to Search Results
 </button>
 `;

--- a/src/Components/CompareList/CompareList.jsx
+++ b/src/Components/CompareList/CompareList.jsx
@@ -80,7 +80,7 @@ class CompareList extends Component {
     return (
       <div className="usa-grid-full content-container comparison-outer-container">
         <div>
-          <BackButton />
+          <BackButton blacklistMatcher="/compare" ignoreCurrentPath />
         </div>
         <div className="comparison-container">
           <h1>Compare Positions</h1>

--- a/src/Components/CompareList/__snapshots__/CompareList.test.jsx.snap
+++ b/src/Components/CompareList/__snapshots__/CompareList.test.jsx.snap
@@ -5,7 +5,10 @@ exports[`CompareListComponent matches snapshot 1`] = `
   className="usa-grid-full content-container comparison-outer-container"
 >
   <div>
-    <Connect(withRouter(BackButton)) />
+    <Connect(withRouter())
+      blacklistMatcher="/compare"
+      ignoreCurrentPath={true}
+    />
   </div>
   <div
     className="comparison-container"
@@ -458,7 +461,10 @@ exports[`CompareListComponent matches snapshot when isLoading is true 1`] = `
   className="usa-grid-full content-container comparison-outer-container"
 >
   <div>
-    <Connect(withRouter(BackButton)) />
+    <Connect(withRouter())
+      blacklistMatcher="/compare"
+      ignoreCurrentPath={true}
+    />
   </div>
   <div
     className="comparison-container"
@@ -479,7 +485,10 @@ exports[`CompareListComponent matches snapshot when there is an obc id 1`] = `
   className="usa-grid-full content-container comparison-outer-container"
 >
   <div>
-    <Connect(withRouter(BackButton)) />
+    <Connect(withRouter())
+      blacklistMatcher="/compare"
+      ignoreCurrentPath={true}
+    />
   </div>
   <div
     className="comparison-container"

--- a/src/__mocks__/routerLocations.js
+++ b/src/__mocks__/routerLocations.js
@@ -1,6 +1,6 @@
 const routerLocations = [
-  { pathname: '/results', search: '?page=1&q=german', hash: '', key: 'xvwp1n' },
   { pathname: '/details/55360000', search: '', hash: '', key: '5n07nr' },
+  { pathname: '/results', search: '?page=1&q=german', hash: '', key: 'xvwp1n' },
 ];
 
 export default routerLocations;

--- a/src/actions/routerLocations.js
+++ b/src/actions/routerLocations.js
@@ -1,3 +1,5 @@
+import { findIndex, get, isEqual, last } from 'lodash';
+
 // map paths to readable link text
 export function mapRoutesToNames(route) {
   const preText = 'Back to';
@@ -10,6 +12,8 @@ export function mapRoutesToNames(route) {
       return `${preText} Position Details`;
     case '/profile':
       return `${preText} Profile`;
+    case '/profile/dashboard':
+      return `${preText} Dashboard`;
     case '/compare':
       return `${preText} Comparison`;
     case '/profile/bidtracker/':
@@ -19,43 +23,65 @@ export function mapRoutesToNames(route) {
   }
 }
 
-// get the full object for the most recently visited route
-export function getLastRoute(routerLocations) {
+// Get the full object for the most recently visited route, as well as the distance from
+// the last unique page visited.
+// routerLocations is the array of history objects, created by the routerLocations reducer
+// location is the current location object, created by withRouter
+// ignoreCurrentPath determines whether subsequent history pushes to the same path should be ignored
+export function getLastRoute(routerLocations, location = {}, ignoreCurrentPath = false) {
+  // no history, return false
   if (!routerLocations || routerLocations.length <= 1) {
     return false;
   }
+
   // Else, return the pathname...
-  // by first getting the current route (will be the most recent)
-  const currentRoute = routerLocations[routerLocations.length - 1];
-  // Then find out the first time the route was visited via its key.
+  // by first getting the current route
+  const currentRoute = location;
+
+  // set up routerLocations$ to be used by ignoreCurrentPath branch if needed
+  let routerLocations$ = routerLocations;
+
+  // Ignore any history that matches the current route
+  // This is good for the Compare page, where new history is written, but the user
+  // is still on the same screen and wants to navigate to the last unique page they were on.
+  // This only works for the path after the first slash (doesn't match nested paths).
+  if (ignoreCurrentPath) {
+    const currentBasePath = get(location, 'pathname', '').split('/')[1];
+    routerLocations$ = routerLocations$.filter(f => f.pathname.split('/')[1] !== currentBasePath);
+    const index = findIndex(routerLocations, a => isEqual(last(routerLocations$), a));
+    const distance = routerLocations.length - index - 1;
+    const lastLocation = last(routerLocations$);
+    return { lastLocation, distance };
+  }
+
+  // Find out the first time the route was visited via its key.
   // The key prop is unique to an explicit navigation to a page.
   // In other words, navigating to a single page via 'Link's will return a new key,
   // but using back/forward won't affect the key
-  const lastVisitedIndex = routerLocations.indexOf(currentRoute);
-  const previousRoute = routerLocations[lastVisitedIndex - 1];
+  const lastVisitedIndex = routerLocations$.indexOf(currentRoute);
+  const previousRoute = routerLocations$[lastVisitedIndex - 1];
   // was there a previous route within this session?
   if (previousRoute && previousRoute.pathname) {
     // then use -1 to get the previous route
-    return routerLocations[lastVisitedIndex - 1];
+    return { lastLocation: routerLocations$[lastVisitedIndex - 1], distance: 1 };
   }
   // this must have been the page the user initially landed on
   return false;
 }
 
 // return just the name of that route, using the mapping
-export function getLastRouteName(routerLocations) {
-  const path = getLastRoute(routerLocations).pathname;
-  if (path) { return mapRoutesToNames(path); }
+export function getLastRouteName(location) {
+  if (location && location.pathname) { return mapRoutesToNames(location.pathname); }
   return false;
 }
 
 // return the full route, including the pathname and any search parameters
-export function getLastRouteLink(routerLocations) {
-  const text = getLastRouteName(routerLocations);
-  const lastLocation = getLastRoute(routerLocations);
+export function getLastRouteLink(routerLocations, location, ignoreCurrentPath) {
+  const { lastLocation, distance } = getLastRoute(routerLocations, location, ignoreCurrentPath);
+  const text = getLastRouteName(lastLocation);
   if (!text || !lastLocation) {
     return {};
   }
   const navigateTo = `${lastLocation.pathname}${lastLocation.search}`;
-  return { text, link: navigateTo };
+  return { text, link: navigateTo, distance };
 }

--- a/src/actions/routerLocations.test.js
+++ b/src/actions/routerLocations.test.js
@@ -1,3 +1,4 @@
+import { first, last } from 'lodash';
 import * as actions from './routerLocations';
 import routerLocations from '../__mocks__/routerLocations';
 
@@ -8,29 +9,35 @@ describe('routerLocations', () => {
     ));
   });
 
-  it('can get the last route', () => {
-    expect(actions.getLastRoute(routerLocations)).toBe(routerLocations[routerLocations.length - 2]);
+  it('returns the last route', () => {
+    expect(actions.getLastRoute(routerLocations, last(routerLocations)).lastLocation)
+      .toBe(routerLocations[routerLocations.length - 2]);
   });
 
-  it('will not return a route if there is no history', () => {
-    expect(actions.getLastRoute([])).toBe(false);
-  });
-
-  it('can get the last route name', () => {
-    expect(actions.getLastRouteName(routerLocations)).toBe('Back to Search Results');
+  it('does not return a route if there is no history', () => {
+    expect(actions.getLastRoute([], last(routerLocations))).toBe(false);
   });
 
   it('returns false if there is only one item in history', () => {
     expect(actions.getLastRoute(
-      [routerLocations[0], routerLocations[1], routerLocations[0]])).toBe(false);
+      [routerLocations[0]], last(routerLocations)))
+      .toBe(false);
   });
 
   it('returns false for arrays that do not have pathname', () => {
-    expect(actions.getLastRoute([1, 2, 3, 4])).toBe(false);
+    expect(actions.getLastRoute([1, 2, 3, 4], last(routerLocations))).toBe(false);
   });
 
-  it('can get the link object for the last route', () => {
-    expect(actions.getLastRouteLink(routerLocations).link).toBeDefined();
-    expect(actions.getLastRouteLink(routerLocations).text).toBeDefined();
+  it('returns the link object for the last route', () => {
+    expect(actions.getLastRouteLink(routerLocations, last(routerLocations)).link).toBeDefined();
+    expect(actions.getLastRouteLink(routerLocations, last(routerLocations)).text).toBeDefined();
+  });
+
+  it('returns the last route name', () => {
+    expect(actions.getLastRouteName({ pathname: '/results' })).toBe('Back to Search Results');
+  });
+
+  it('returns false if pathname is undefined', () => {
+    expect(actions.getLastRouteName({ pathname: null })).toBe(false);
   });
 });

--- a/src/reducers/routerLocations/routerLocations.js
+++ b/src/reducers/routerLocations/routerLocations.js
@@ -1,7 +1,16 @@
+import { findIndex } from 'lodash';
+
 export default function routerLocations(state = [], action) {
   switch (action.type) {
-    case '@@router/LOCATION_CHANGE':
+    case '@@router/LOCATION_CHANGE': {
+      // only write to the history if this was a new navigation change
+      // i.e. not a browser back/forward
+      const index = findIndex(state, a => a.key === action.payload.key);
+      if (index >= 0) {
+        return state.splice(0, index + 1);
+      }
       return [...state, action.payload];
+    }
     default:
       return state;
   }


### PR DESCRIPTION
Completes TM-744 by re-working the logic for the "Go back" button. This enables the button to ignore any repeated pathnames, such as when multiple `/compare` paths are pushed to the browser history. When this scenario happens, we track how many pages "back" we need to go to get the user to the last unique page they were. We make use of `window.history.go(some number)` to specify exactly how many places back in the history we need to go. This gives the user a better experience by maintaining a logical browser history (opposed to if we simply provided a normal link back to whatever page they were on originally).