### PR TITLE
Persist preferences

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react-toastify": "^4.5.1",
     "redux": "^3.7.1",
     "redux-form": "^7.2.0",
+    "redux-persist": "^5.10.0",
     "redux-saga": "^0.15.6",
     "redux-thunk": "^2.2.0",
     "saml2-js": "2.0.2",
@@ -148,7 +149,9 @@
       "jest-localstorage-mock",
       "mock-local-storage"
     ],
-    "setupFilesAfterEnv": ["<rootDir>/config/jest/setupTests.js"],
+    "setupFilesAfterEnv": [
+      "<rootDir>/config/jest/setupTests.js"
+    ],
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.js?(x)",
       "<rootDir>/src/**/?(*.)(spec|test).js?(x)"

--- a/src/Components/BidderPortfolio/BidControls/__snapshots__/BidControls.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidControls/__snapshots__/BidControls.test.jsx.snap
@@ -37,6 +37,7 @@ exports[`BidControlsComponent matches snapshot when isLoading is false 1`] = `
             },
           ]
         }
+        transformValue={[Function]}
       />
       <ResultsViewBy
         initial="card"
@@ -85,6 +86,7 @@ exports[`BidControlsComponent matches snapshot when isLoading is true 1`] = `
             },
           ]
         }
+        transformValue={[Function]}
       />
       <ResultsViewBy
         initial="card"

--- a/src/Components/FavoritePositions/__snapshots__/FavoritePositions.test.jsx.snap
+++ b/src/Components/FavoritePositions/__snapshots__/FavoritePositions.test.jsx.snap
@@ -65,6 +65,7 @@ exports[`FavoritePositionsComponent matches snapshot 1`] = `
             },
           ]
         }
+        transformValue={[Function]}
       />
     </div>
   </div>

--- a/src/Components/ResultsContainer/ResultsContainer.jsx
+++ b/src/Components/ResultsContainer/ResultsContainer.jsx
@@ -109,7 +109,7 @@ ResultsContainer.propTypes = {
   sortBy: SORT_BY_PARENT_OBJECT.isRequired,
   defaultSort: PropTypes.node,
   pageSizes: SORT_BY_PARENT_OBJECT.isRequired,
-  defaultPageSize: PropTypes.node,
+  defaultPageSize: PropTypes.number,
   defaultPageNumber: PropTypes.number,
   pageSize: PropTypes.number.isRequired,
   hasLoaded: PropTypes.bool.isRequired,

--- a/src/Components/ResultsControls/ResultsControls.jsx
+++ b/src/Components/ResultsControls/ResultsControls.jsx
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import TotalResults from '../TotalResults/TotalResults';
 import SelectForm from '../SelectForm/SelectForm';
 import SearchResultsExportLink from '../SearchResultsExportLink';
+import PreferenceWrapper from '../../Containers/PreferenceWrapper';
 import { POSITION_SEARCH_RESULTS, SORT_BY_PARENT_OBJECT } from '../../Constants/PropTypes';
+import { POSITION_PAGE_SIZES_TYPE } from '../../Constants/Sort';
 
 class ResultsControls extends Component {
   constructor(props) {
@@ -49,14 +51,16 @@ class ResultsControls extends Component {
               />
             </div>
             <div className="results-dropdown results-dropdown-page-size">
-              <SelectForm
-                id="pageSize"
-                label="Results:"
-                onSelectOption={this.onSelectLimit}
-                options={pageSizes.options}
-                defaultSort={defaultPageSize}
-                className="select-blue select-offset select-small"
-              />
+              <PreferenceWrapper onSelect={this.onSelectLimit} keyRef={POSITION_PAGE_SIZES_TYPE}>
+                <SelectForm
+                  id="pageSize"
+                  label="Results:"
+                  options={pageSizes.options}
+                  defaultSort={defaultPageSize}
+                  transformValue={n => parseInt(n, 10)}
+                  className="select-blue select-offset select-small"
+                />
+              </PreferenceWrapper>
             </div>
             <div className="results-download">
               <SearchResultsExportLink count={results.count} />
@@ -73,7 +77,7 @@ ResultsControls.propTypes = {
   sortBy: SORT_BY_PARENT_OBJECT.isRequired,
   defaultSort: PropTypes.node,
   pageSizes: SORT_BY_PARENT_OBJECT.isRequired,
-  defaultPageSize: PropTypes.node,
+  defaultPageSize: PropTypes.number,
   hasLoaded: PropTypes.bool,
   defaultPageNumber: PropTypes.number,
   queryParamUpdate: PropTypes.func.isRequired,

--- a/src/Components/ResultsControls/ResultsControls.test.jsx
+++ b/src/Components/ResultsControls/ResultsControls.test.jsx
@@ -1,10 +1,10 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 import TestUtils from 'react-dom/test-utils';
-import { MemoryRouter } from 'react-router-dom';
 import toJSON from 'enzyme-to-json';
 import sinon from 'sinon';
 import ResultsControls from './ResultsControls';
+import MockTestProvider from '../../testUtilities/MockProvider';
 import resultsObject from '../../__mocks__/resultsObject';
 
 describe('ResultsControlsComponent', () => {
@@ -24,7 +24,7 @@ describe('ResultsControlsComponent', () => {
     sortBy, pageSizes, pageCount, hasLoaded, onToggle } = config;
 
   it('is defined', () => {
-    wrapper = TestUtils.renderIntoDocument(<MemoryRouter>
+    wrapper = TestUtils.renderIntoDocument(<MockTestProvider>
       <ResultsControls
         results={resultsObject}
         isLoading={isLoading}
@@ -35,7 +35,7 @@ describe('ResultsControlsComponent', () => {
         hasLoaded={hasLoaded}
         onToggle={onToggle}
       />
-    </MemoryRouter>);
+    </MockTestProvider>);
     expect(wrapper).toBeDefined();
   });
 

--- a/src/Components/ResultsControls/__snapshots__/ResultsControls.test.jsx.snap
+++ b/src/Components/ResultsControls/__snapshots__/ResultsControls.test.jsx.snap
@@ -40,30 +40,37 @@ exports[`ResultsControlsComponent matches snapshot 1`] = `
               },
             ]
           }
+          transformValue={[Function]}
         />
       </div>
       <div
         className="results-dropdown results-dropdown-page-size"
       >
-        <SelectForm
-          className="select-blue select-offset select-small"
-          defaultSort={10}
-          disabled={false}
-          emptyOptionText="- Select -"
-          id="pageSize"
-          includeFirstEmptyOption={false}
-          label="Results:"
-          languages={Array []}
-          onSelectOption={[Function]}
-          options={
-            Array [
-              Object {
-                "text": "10",
-                "value": 10,
-              },
-            ]
-          }
-        />
+        <Connect(PreferenceWrapper)
+          keyRef="POSITION_PAGE_SIZES"
+          onSelect={[Function]}
+        >
+          <SelectForm
+            className="select-blue select-offset select-small"
+            defaultSort={10}
+            disabled={false}
+            emptyOptionText="- Select -"
+            id="pageSize"
+            includeFirstEmptyOption={false}
+            label="Results:"
+            languages={Array []}
+            onSelectOption={[Function]}
+            options={
+              Array [
+                Object {
+                  "text": "10",
+                  "value": 10,
+                },
+              ]
+            }
+            transformValue={[Function]}
+          />
+        </Connect(PreferenceWrapper)>
       </div>
       <div
         className="results-download"

--- a/src/Components/ResultsMultiSearchHeader/__snapshots__/ResultsMultiSearchHeader.test.jsx.snap
+++ b/src/Components/ResultsMultiSearchHeader/__snapshots__/ResultsMultiSearchHeader.test.jsx.snap
@@ -100,6 +100,7 @@ exports[`ResultsMultiSearchHeaderComponent matches snapshot 1`] = `
                     },
                   ]
                 }
+                transformValue={[Function]}
               />
             </div>
             <div
@@ -125,6 +126,7 @@ exports[`ResultsMultiSearchHeaderComponent matches snapshot 1`] = `
                     },
                   ]
                 }
+                transformValue={[Function]}
               />
             </div>
             <div

--- a/src/Components/SavedSearches/__snapshots__/SavedSearches.test.jsx.snap
+++ b/src/Components/SavedSearches/__snapshots__/SavedSearches.test.jsx.snap
@@ -46,6 +46,7 @@ exports[`SavedSearchesComponent matches snapshot 1`] = `
             },
           ]
         }
+        transformValue={[Function]}
       />
     </div>
   </div>

--- a/src/Components/SelectForm/SelectForm.jsx
+++ b/src/Components/SelectForm/SelectForm.jsx
@@ -23,9 +23,11 @@ class SelectForm extends Component {
   }
 
   selectOption(e) {
+    const { transformValue } = this.props;
+
     const selection = e.target.value;
     this.setState({ selection });
-    this.props.onSelectOption(e);
+    this.props.onSelectOption({ target: { value: transformValue(selection) } });
   }
   render() {
     const { id, label, options, includeFirstEmptyOption, emptyOptionText,
@@ -76,11 +78,12 @@ SelectForm.propTypes = {
   label: PropTypes.node.isRequired,
   defaultSort: PropTypes.node,
   options: SORT_BY_ARRAY.isRequired,
-  onSelectOption: PropTypes.func.isRequired,
+  onSelectOption: PropTypes.func,
   includeFirstEmptyOption: PropTypes.bool,
   emptyOptionText: PropTypes.string,
   disabled: PropTypes.bool,
   className: PropTypes.string,
+  transformValue: PropTypes.func,
 };
 
 SelectForm.defaultProps = {
@@ -91,6 +94,7 @@ SelectForm.defaultProps = {
   emptyOptionText: '- Select -',
   disabled: false,
   className: 'select-offset select-black',
+  transformValue: n => n,
 };
 
 export default SelectForm;

--- a/src/Constants/Sort.js
+++ b/src/Constants/Sort.js
@@ -48,3 +48,23 @@ export const SAVED_SEARCH_SORTS = {
 };
 
 SAVED_SEARCH_SORTS.defaultSort = SAVED_SEARCH_SORTS.options[0].value;
+
+export const POSITION_SEARCH_SORTS_TYPE = 'POSITION_SEARCH_SORTS';
+export const POSITION_PAGE_SIZES_TYPE = 'POSITION_PAGE_SIZES';
+export const BID_PORTFOLIO_SORTS_TYPE = 'BID_PORTFOLIO_SORTS';
+export const SAVED_SEARCH_SORTS_TYPE = 'SAVED_SEARCH_SORTS';
+
+const SORT_OPTIONS = [
+  [POSITION_SEARCH_SORTS, POSITION_SEARCH_SORTS_TYPE],
+  [POSITION_PAGE_SIZES, POSITION_PAGE_SIZES_TYPE],
+  [BID_PORTFOLIO_SORTS, BID_PORTFOLIO_SORTS_TYPE],
+  [SAVED_SEARCH_SORTS, SAVED_SEARCH_SORTS_TYPE],
+];
+
+// sort config based on SORT_OPTIONS
+export default Object.assign(
+  {},
+  ...SORT_OPTIONS.map(p => (
+    { [p[1]]: { key: p[1], defaultSort: p[0].defaultSort, options: p[0].options } }
+  )),
+);

--- a/src/Containers/PreferenceWrapper/PreferenceWrapper.jsx
+++ b/src/Containers/PreferenceWrapper/PreferenceWrapper.jsx
@@ -1,0 +1,46 @@
+import React, { Component } from 'react';
+import { get } from 'lodash';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { setSortPreference } from '../../actions/sortPreferences';
+
+class PreferenceWrapper extends Component {
+  constructor(props) {
+    super(props);
+    this.cb = this.cb.bind(this);
+  }
+  cb(e) {
+    const { keyRef, onSelect, setPreference } = this.props;
+    onSelect(e);
+    setPreference(keyRef, e.target.value);
+  }
+  render() {
+    const { children, childCallback } = this.props;
+    return (
+      React.cloneElement(children, { [childCallback]: this.cb })
+    );
+  }
+}
+
+PreferenceWrapper.propTypes = {
+  keyRef: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+  onSelect: PropTypes.func.isRequired,
+  childCallback: PropTypes.string,
+  setPreference: PropTypes.func.isRequired,
+};
+
+PreferenceWrapper.defaultProps = {
+  sortPreference: '',
+  childCallback: 'onSelectOption',
+};
+
+export const mapStateToProps = (state, ownProps) => ({
+  sortPreference: get(state, `sortPreferences[${ownProps.keyRef}].defaultValue`),
+});
+
+export const mapDispatchToProps = dispatch => ({
+  setPreference: (key, value) => dispatch(setSortPreference(key, value)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(PreferenceWrapper);

--- a/src/Containers/PreferenceWrapper/PreferenceWrapper.test.jsx
+++ b/src/Containers/PreferenceWrapper/PreferenceWrapper.test.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import TestUtils from 'react-dom/test-utils';
+import { testDispatchFunctions } from '../../testUtilities/testUtilities';
+import MockTestProvider from '../../testUtilities/MockProvider';
+import PreferenceWrapper, { mapDispatchToProps } from './PreferenceWrapper';
+
+describe('PreferenceWrapper', () => {
+  it('is defined', () => {
+    const results = TestUtils.renderIntoDocument(<MockTestProvider>
+      <PreferenceWrapper
+        keyRef="key"
+        onSelect={() => {}}
+        childCallback="onClick"
+        setPreference={() => {}}
+      >
+        <button />
+      </PreferenceWrapper>
+    </MockTestProvider>);
+    expect(results).toBeDefined();
+  });
+});
+
+describe('mapDispatchToProps', () => {
+  const config = {
+    setPreference: ['key', 5],
+  };
+  testDispatchFunctions(mapDispatchToProps, config);
+});

--- a/src/Containers/PreferenceWrapper/index.js
+++ b/src/Containers/PreferenceWrapper/index.js
@@ -1,0 +1,1 @@
+export { default } from './PreferenceWrapper';

--- a/src/Containers/Results/Results.jsx
+++ b/src/Containers/Results/Results.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 import { withRouter } from 'react-router';
 import queryString from 'query-string';
-import debounce from 'lodash/debounce';
+import { debounce, get } from 'lodash';
 import queryParamUpdate from '../queryParams';
 import { scrollToTop, cleanQueryParams, getAssetPath } from '../../utilities';
 import { resultsFetchData } from '../../actions/results';
@@ -23,7 +23,7 @@ SAVED_SEARCH_OBJECT, MISSION_DETAILS_ARRAY, POST_DETAILS_ARRAY,
 EMPTY_FUNCTION, BID_LIST } from '../../Constants/PropTypes';
 import { ACCORDION_SELECTION } from '../../Constants/DefaultProps';
 import { LOGIN_REDIRECT } from '../../login/routes';
-import { POSITION_SEARCH_SORTS, POSITION_PAGE_SIZES } from '../../Constants/Sort';
+import { POSITION_SEARCH_SORTS, POSITION_PAGE_SIZES, POSITION_PAGE_SIZES_TYPE } from '../../Constants/Sort';
 
 const DEFAULT_PAGE_NUMBER = 1;
 
@@ -38,7 +38,7 @@ class Results extends Component {
       key: 0,
       query: { value: window.location.search.replace('?', '') || '' },
       defaultSort: { value: POSITION_SEARCH_SORTS.defaultSort },
-      defaultPageSize: { value: 0 },
+      defaultPageSize: { value: props.defaultPageSize },
       defaultPageNumber: { value: DEFAULT_PAGE_NUMBER },
       defaultKeyword: { value: '' },
     };
@@ -129,7 +129,7 @@ class Results extends Component {
       ordering || POSITION_SEARCH_SORTS.defaultSort;
     // set our default page size
     defaultPageSize.value =
-      parseInt(limit, 10) || POSITION_PAGE_SIZES.defaultSort;
+      parseInt(limit, 10) || this.props.defaultPageSize;
     // set our default page number
     defaultPageNumber.value =
       parseInt(page, 10) || DEFAULT_PAGE_NUMBER;
@@ -288,6 +288,7 @@ Results.propTypes = {
   debounceTimeInMs: PropTypes.number,
   bidList: BID_LIST.isRequired,
   bidListFetchData: PropTypes.func.isRequired,
+  defaultPageSize: PropTypes.number.isRequired,
 };
 
 Results.defaultProps = {
@@ -343,6 +344,7 @@ const mapStateToProps = state => ({
   postSearchHasErrored: state.postSearchHasErrored,
   shouldShowSearchBar: state.shouldShowSearchBar,
   bidList: state.bidListFetchDataSuccess,
+  defaultPageSize: get(state, `sortPreferences.${POSITION_PAGE_SIZES_TYPE}.defaultSort`, POSITION_PAGE_SIZES.defaultSort),
 });
 
 export const mapDispatchToProps = dispatch => ({

--- a/src/Containers/Results/Results.test.jsx
+++ b/src/Containers/Results/Results.test.jsx
@@ -27,6 +27,7 @@ describe('Results', () => {
         postSearchIsLoading={false}
         postSearchHasErrored={false}
         bidListFetchData={() => {}}
+        defaultPageSize={5}
       />
     </MockTestProvider>);
     expect(results).toBeDefined();
@@ -50,6 +51,7 @@ describe('Results', () => {
         postSearchIsLoading={false}
         postSearchHasErrored={false}
         bidListFetchData={() => {}}
+        defaultPageSize={5}
       />
     </MockTestProvider>);
     expect(results).toBeDefined();
@@ -75,6 +77,7 @@ describe('Results', () => {
         postSearchIsLoading={false}
         postSearchHasErrored={false}
         bidListFetchData={() => {}}
+        defaultPageSize={5}
       />,
     );
     // define the instance
@@ -107,6 +110,7 @@ describe('Results', () => {
         postSearchIsLoading={false}
         postSearchHasErrored={false}
         bidListFetchData={() => {}}
+        defaultPageSize={5}
       />,
     );
     expect(wrapper.instance().props.filters.hasFetched).toBe(true);
@@ -133,6 +137,7 @@ describe('Results', () => {
         postSearchIsLoading={false}
         postSearchHasErrored={false}
         bidListFetchData={() => {}}
+        defaultPageSize={5}
       />,
     );
     wrapper.instance().saveSearch('test', 1);
@@ -161,6 +166,7 @@ describe('Results', () => {
         pageTitle="Results"
         debounceTimeInMs={debounceTimeInMs}
         bidListFetchData={() => {}}
+        defaultPageSize={5}
       />,
     );
     // define the instance
@@ -200,6 +206,7 @@ describe('Results', () => {
         pageTitle="Results"
         debounceTimeInMs={debounceTimeInMs}
         bidListFetchData={() => {}}
+        defaultPageSize={5}
       />,
     );
     // define the instance
@@ -239,6 +246,7 @@ describe('Results', () => {
         pageTitle="Results"
         debounceTimeInMs={debounceTimeInMs}
         bidListFetchData={() => {}}
+        defaultPageSize={5}
       />,
     );
     // define the instance
@@ -276,6 +284,7 @@ describe('Results', () => {
         postSearchIsLoading={false}
         postSearchHasErrored={false}
         bidListFetchData={() => {}}
+        defaultPageSize={5}
       />,
     );
     const history = { value: { search: null } };

--- a/src/actions/sortPreferences.js
+++ b/src/actions/sortPreferences.js
@@ -1,0 +1,13 @@
+export function sortPreference(key, value) {
+  return {
+    type: 'SET_SORT_PREFERENCE',
+    key,
+    value,
+  };
+}
+
+export function setSortPreference(key, value) {
+  return (dispatch) => {
+    dispatch(sortPreference(key, value));
+  };
+}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -36,6 +36,7 @@ import showFeedback from './showFeedback';
 import feedback from './feedback';
 import features from './features';
 import toast from './toast';
+import sortPreferences from './sortPreferences';
 
 export default combineReducers({
   ...results,
@@ -69,6 +70,7 @@ export default combineReducers({
   ...feedback,
   ...features,
   ...toast,
+  ...sortPreferences,
   router,
   form,
   client,

--- a/src/reducers/sortPreferences/index.js
+++ b/src/reducers/sortPreferences/index.js
@@ -1,0 +1,3 @@
+import sortPreferences from './sortPreferences';
+
+export default { sortPreferences };

--- a/src/reducers/sortPreferences/sortPreferences.js
+++ b/src/reducers/sortPreferences/sortPreferences.js
@@ -1,0 +1,29 @@
+import { findIndex } from 'lodash';
+import SORT_PREFERENCES from '../../Constants/Sort';
+
+// no need to store options in localStorage
+const SORT_PREFERENCES_WITHOUT_OPTIONS = Object.assign(
+  {},
+  ...Object.keys(SORT_PREFERENCES).map(key => (
+    { [key]: { ...SORT_PREFERENCES[key], options: undefined } }
+  )),
+);
+
+export default function sortPreferences(state = SORT_PREFERENCES_WITHOUT_OPTIONS, action) {
+  switch (action.type) {
+    case 'SET_SORT_PREFERENCE': {
+      const { key, value } = action;
+      if (key && SORT_PREFERENCES[key] &&
+        findIndex(SORT_PREFERENCES[key].options, (f) => {
+          const value$ = `${value}`;
+          const optionValue$ = `${f.value}`;
+          return value$ === optionValue$;
+        }) > -1) {
+        return { ...state, [key]: { ...SORT_PREFERENCES[key], defaultSort: value } };
+      }
+      return state;
+    }
+    default:
+      return state;
+  }
+}

--- a/src/reducers/sortPreferences/sortPreferences.test.js
+++ b/src/reducers/sortPreferences/sortPreferences.test.js
@@ -1,0 +1,9 @@
+import sortPreferences from './sortPreferences';
+import { POSITION_SEARCH_SORTS_TYPE } from '../../Constants/Sort';
+
+describe('reducers', () => {
+  it('can set reducer SET_SORT_PREFERENCE', () => {
+    expect(sortPreferences({}, { type: 'SET_SORT_PREFERENCE', key: POSITION_SEARCH_SORTS_TYPE, value: 'title' }))
+      .toBeDefined();
+  });
+});

--- a/src/store.js
+++ b/src/store.js
@@ -1,6 +1,9 @@
 import { createStore, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
 
+import { persistStore, persistReducer } from 'redux-persist';
+import storage from 'redux-persist/lib/storage'; // defaults to localStorage
+
 import { routerMiddleware } from 'react-router-redux';
 
 import createSagaMiddleware from 'redux-saga';
@@ -10,6 +13,12 @@ import createHistory from 'history/createBrowserHistory';
 import rootReducer from './reducers';
 
 import IndexSagas from './index-sagas';
+
+const persistConfig = {
+  key: 'root',
+  storage,
+  whitelist: ['sortPreferences'], // only persist sortPreferences reducer
+};
 
 // Setup the middleware to watch between the Reducers and the Actions
 const sagaMiddleware = createSagaMiddleware();
@@ -26,9 +35,11 @@ const composeEnhancers = (
 ) || compose;
 /* eslint-enable no-underscore-dangle */
 
+const persistedReducer = persistReducer(persistConfig, rootReducer);
+
 function configureStore(initialState) {
   return createStore(
-    rootReducer,
+    persistedReducer,
     initialState,
     composeEnhancers(
       applyMiddleware(thunk, middleware, sagaMiddleware),
@@ -38,7 +49,9 @@ function configureStore(initialState) {
 
 const store = configureStore();
 
+const persistor = persistStore(store);
+
 // Begin our Index Saga
 sagaMiddleware.run(IndexSagas);
 
-export { store, history };
+export { store, persistor, history };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9027,6 +9027,11 @@ redux-mock-store@^1.4.0:
   dependencies:
     lodash.isplainobject "^4.0.6"
 
+redux-persist@^5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-5.10.0.tgz#5d8d802c5571e55924efc1c3a9b23575283be62b"
+  integrity sha512-sSJAzNq7zka3qVHKce1hbvqf0Vf5DuTVm7dr4GtsqQVOexnrvbV47RWFiPxQ8fscnyiuWyD2O92DOxPl0tGCRg==
+
 redux-saga-test-plan@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/redux-saga-test-plan/-/redux-saga-test-plan-3.5.0.tgz#0f0cf82569fc5c3a6ba81ac2f41e1861ab71e767"


### PR DESCRIPTION
Completes TM-745 by integrating [redux-persist](https://github.com/rt2zz/redux-persist) to store redux state to localStorage (only the `sortPreferences` reducer for now, but others could be added). Using this and a wrapper component, the page size selection on the Results page is persisted to local storage for the next time the user accesses that page. However, if the page size is explicitly set in the URL query params, the local storage value will be ignored and the query param will be used.