### PR TITLE
Integrate react-scroll-up-button to scroll to top on the Results page

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react-router-redux": "^5.0.0-alpha.9",
     "react-router-scroll-4": "^1.0.0-beta.1",
     "react-scroll": "^1.7.5",
+    "react-scroll-up-button": "^1.6.4",
     "react-scrollbar": "^0.5.4",
     "react-select": "^1.1.0",
     "react-simple-dropdown": "^3.2.0",
@@ -148,7 +149,9 @@
       "jest-localstorage-mock",
       "mock-local-storage"
     ],
-    "setupFilesAfterEnv": ["<rootDir>/config/jest/setupTests.js"],
+    "setupFilesAfterEnv": [
+      "<rootDir>/config/jest/setupTests.js"
+    ],
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.js?(x)",
       "<rootDir>/src/**/?(*.)(spec|test).js?(x)"

--- a/src/Components/ResultsContainer/ResultsContainer.jsx
+++ b/src/Components/ResultsContainer/ResultsContainer.jsx
@@ -94,7 +94,7 @@ class ResultsContainer extends Component {
              onPageChange={this.onPageChange}
              forcePage={defaultPageNumber}
            />
-           <ScrollUpButton ContainerClassName="tm-scroll-up-container" style={{ backgroundColor: 'rgb(0,113,188,.8)', border: '1px solid white', padding: '4px 5px 5px' }} />
+           <ScrollUpButton />
          </div>
         }
       </div>

--- a/src/Components/ResultsContainer/ResultsContainer.jsx
+++ b/src/Components/ResultsContainer/ResultsContainer.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import ScrollUpButton from '../ScrollUpButton';
 import PaginationWrapper from '../PaginationWrapper/PaginationWrapper';
 import ResultsList from '../ResultsList/ResultsList';
 import { POSITION_SEARCH_RESULTS, EMPTY_FUNCTION, SAVED_SEARCH_MESSAGE, SAVED_SEARCH_OBJECT,
@@ -93,6 +94,7 @@ class ResultsContainer extends Component {
              onPageChange={this.onPageChange}
              forcePage={defaultPageNumber}
            />
+           <ScrollUpButton ContainerClassName="tm-scroll-up-container" style={{ backgroundColor: 'rgb(0,113,188,.8)', border: '1px solid white', padding: '4px 5px 5px' }} />
          </div>
         }
       </div>

--- a/src/Components/ResultsContainer/__snapshots__/ResultsContainer.test.jsx.snap
+++ b/src/Components/ResultsContainer/__snapshots__/ResultsContainer.test.jsx.snap
@@ -423,16 +423,7 @@ exports[`ResultsContainerComponent matches snapshot 1`] = `
       subContainerClassName="pages pagination"
       totalResults={0}
     />
-    <ScrollUpButton
-      ContainerClassName="tm-scroll-up-container"
-      style={
-        Object {
-          "backgroundColor": "rgb(0,113,188,.8)",
-          "border": "1px solid white",
-          "padding": "4px 5px 5px",
-        }
-      }
-    />
+    <ScrollUpButton />
   </div>
 </div>
 `;

--- a/src/Components/ResultsContainer/__snapshots__/ResultsContainer.test.jsx.snap
+++ b/src/Components/ResultsContainer/__snapshots__/ResultsContainer.test.jsx.snap
@@ -423,6 +423,16 @@ exports[`ResultsContainerComponent matches snapshot 1`] = `
       subContainerClassName="pages pagination"
       totalResults={0}
     />
+    <ScrollUpButton
+      ContainerClassName="tm-scroll-up-container"
+      style={
+        Object {
+          "backgroundColor": "rgb(0,113,188,.8)",
+          "border": "1px solid white",
+          "padding": "4px 5px 5px",
+        }
+      }
+    />
   </div>
 </div>
 `;

--- a/src/Components/ScrollUpButton/ScrollUpButton.jsx
+++ b/src/Components/ScrollUpButton/ScrollUpButton.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { TinyButton } from 'react-scroll-up-button';
+
+// style is the only way to override most defaults
+const style = {
+  backgroundColor: 'rgb(0, 113, 188, .8)', // this is $primary-blue converted to rgb, with some transparency
+  border: '1px solid white',
+  padding: '4px 5px 5px',
+};
+
+const ScrollUpButton = props => (
+  <TinyButton
+    ContainerClassName="tm-scroll-up-container"
+    style={style}
+    {...props}
+  />
+);
+
+export default ScrollUpButton;

--- a/src/Components/ScrollUpButton/ScrollUpButton.test.jsx
+++ b/src/Components/ScrollUpButton/ScrollUpButton.test.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import ScrollUpButton from './ScrollUpButton';
+
+describe('ScrollUpButton', () => {
+  it('is defined', () => {
+    const wrapper = shallow(<ScrollUpButton />);
+    expect(wrapper).toBeDefined();
+  });
+});

--- a/src/Components/ScrollUpButton/index.js
+++ b/src/Components/ScrollUpButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './ScrollUpButton';

--- a/src/sass/_scrollUp.scss
+++ b/src/sass/_scrollUp.scss
@@ -1,0 +1,11 @@
+.tm-scroll-up-container {
+  // the background-color in inline-style doesn't render in some browsers (IE11, Edge), so we also set it here
+  background-color: $blue-primary;
+
+  path {
+    fill: $color-white;
+    padding-left: 5px;
+    padding-right: 5px;
+    padding-top: 4px;
+  }
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -88,5 +88,6 @@
 @import 'ribbon';
 @import 'toggle';
 @import 'picker';
+@import 'scrollUp';
 @import 'overrides';
 @import 'accessibility';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3055,6 +3055,11 @@ detect-node@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.3.tgz#a2033c09cc8e158d37748fbde7507832bd6ce127"
 
+detect-passive-events@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/detect-passive-events/-/detect-passive-events-1.0.4.tgz#6ed477e6e5bceb79079735dcd357789d37f9a91a"
+  integrity sha1-btR35uW863kHlzXc01d4nTf5qRo=
+
 detect-port-alt@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/detect-port-alt/-/detect-port-alt-1.1.3.tgz#a4d2f061d757a034ecf37c514260a98750f2b131"
@@ -8743,6 +8748,15 @@ react-router@^4.2.0:
     prop-types "^15.5.4"
     warning "^3.0.0"
 
+react-scroll-up-button@^1.6.4:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/react-scroll-up-button/-/react-scroll-up-button-1.6.4.tgz#9c4c45d1b58f2e4fcf60e44817a170becd25c7ba"
+  integrity sha512-ou/ZLbjAXgXnszmNp9g17XlZBat48V3Oz40ssEcu6dEIM2CVn/yWxej3Y4Fx1LyUtQ1cc/MoWOSXC2dufaiACg==
+  dependencies:
+    detect-passive-events "^1.0.4"
+    prop-types "^15.6.2"
+    tween-functions "^1.2.0"
+
 react-scroll@^1.7.5:
   version "1.7.7"
   resolved "https://registry.yarnpkg.com/react-scroll/-/react-scroll-1.7.7.tgz#948c40c9a189b62bf4a53ee0fd50e5d89d37260a"
@@ -10560,6 +10574,11 @@ tunnel-agent@^0.6.0:
 tunnel-agent@~0.4.1:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.4.3.tgz#6373db76909fe570e08d73583365ed828a74eeeb"
+
+tween-functions@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tween-functions/-/tween-functions-1.2.0.tgz#1ae3a50e7c60bb3def774eac707acbca73bbc3ff"
+  integrity sha1-GuOlDnxguz3vd06scHrLynO7w/8=
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
Completes TM-743 by adding a "Scroll to Top" button to the Results page using [react-scroll-up-button](https://github.com/dirtyredz/react-scroll-up-button).