### PR TITLE
Set global context as bidder

### DIFF
--- a/src/Components/BidderPortfolio/BidderPortfolioStatCard/BidderPortfolioStatCard.jsx
+++ b/src/Components/BidderPortfolio/BidderPortfolioStatCard/BidderPortfolioStatCard.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { get, orderBy } from 'lodash';
-import FA from 'react-fontawesome';
 import { BIDDER_OBJECT } from '../../../Constants/PropTypes';
 import BoxShadow from '../../BoxShadow';
 import SkillCodeList from '../../SkillCodeList';
@@ -9,6 +7,8 @@ import { getPostName } from '../../../utilities';
 import { NO_POST, NO_GRADE } from '../../../Constants/SystemMessages';
 import ClientBadgeList from '../ClientBadgeList';
 import StaticDevContent from '../../StaticDevContent';
+import SearchAsClientButton from '../SearchAsClientButton';
+import LinkButton from '../../LinkButton';
 
 const BidderPortfolioStatCard = ({ userProfile }) => {
   const sortedAssignments = orderBy(userProfile.assignments, 'start_date', 'desc');
@@ -19,10 +19,7 @@ const BidderPortfolioStatCard = ({ userProfile }) => {
       <div className="bidder-portfolio-stat-card-top">
         <div>
           <h3>
-            <Link to={`/profile/public/${userProfile.id}`}>
-              {`${userProfile.user.first_name} ${userProfile.user.last_name}`}
-              <FA name="angle-right" />
-            </Link>
+            {`${userProfile.user.first_name} ${userProfile.user.last_name}`}
           </h3>
         </div>
         <div className="stat-card-data-point">
@@ -37,7 +34,7 @@ const BidderPortfolioStatCard = ({ userProfile }) => {
       </div>
       <div className="bidder-portfolio-stat-card-bottom">
         <div>
-          <span>Updates</span>
+          <span className="updates">Updates</span>
           <StaticDevContent>
             <ClientBadgeList
               statuses={{
@@ -48,6 +45,10 @@ const BidderPortfolioStatCard = ({ userProfile }) => {
               }}
             />
           </StaticDevContent>
+        </div>
+        <div className="button-container" style={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between' }}>
+          <LinkButton toLink={`/profile/public/${userProfile.id}`} className="usa-button-secondary">View Profile</LinkButton>
+          <SearchAsClientButton id={userProfile.id} />
         </div>
       </div>
     </BoxShadow>

--- a/src/Components/BidderPortfolio/BidderPortfolioStatCard/__snapshots__/BidderPortfolioStatCard.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidderPortfolioStatCard/__snapshots__/BidderPortfolioStatCard.test.jsx.snap
@@ -17,15 +17,7 @@ exports[`BidderPortfolioStatCard matches snapshot 1`] = `
   >
     <div>
       <h3>
-        <Link
-          replace={false}
-          to="/profile/public/5"
-        >
-          Kara Batisak
-          <FontAwesome
-            name="angle-right"
-          />
-        </Link>
+        Kara Batisak
       </h3>
     </div>
     <div
@@ -74,7 +66,9 @@ exports[`BidderPortfolioStatCard matches snapshot 1`] = `
     className="bidder-portfolio-stat-card-bottom"
   >
     <div>
-      <span>
+      <span
+        className="updates"
+      >
         Updates
       </span>
       <Connect(StaticDevContent)>
@@ -89,6 +83,28 @@ exports[`BidderPortfolioStatCard matches snapshot 1`] = `
           }
         />
       </Connect(StaticDevContent)>
+    </div>
+    <div
+      className="button-container"
+      style={
+        Object {
+          "display": "flex",
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+        }
+      }
+    >
+      <LinkButton
+        className="usa-button-secondary"
+        isExternal={false}
+        toLink="/profile/public/5"
+        useDefaultClass={true}
+      >
+        View Profile
+      </LinkButton>
+      <Connect(withRouter(SearchAsClientButton))
+        id={5}
+      />
     </div>
   </div>
 </BoxShadow>

--- a/src/Components/BidderPortfolio/BidderPortfolioStatRow/BidderPortfolioStatRow.jsx
+++ b/src/Components/BidderPortfolio/BidderPortfolioStatRow/BidderPortfolioStatRow.jsx
@@ -10,6 +10,7 @@ import StaticDevContent from '../../StaticDevContent';
 import LinkButton from '../../LinkButton';
 import Avatar from '../../Avatar';
 import CheckboxList from '../CheckboxList';
+import SearchAsClientButton from '../SearchAsClientButton';
 
 const BidderPortfolioStatRow = ({ userProfile, showEdit }) => {
   const sortedAssignments = orderBy(userProfile.assignments, 'start_date', 'desc');
@@ -57,8 +58,9 @@ const BidderPortfolioStatRow = ({ userProfile, showEdit }) => {
       }
       {
         !showEdit &&
-        <div>
+        <div className="button-container">
           <LinkButton className="usa-button-secondary" toLink={`/profile/public/${userProfile.id}`}>View Details</LinkButton>
+          <SearchAsClientButton id={userProfile.id} />
         </div>
       }
       {

--- a/src/Components/BidderPortfolio/BidderPortfolioStatRow/__snapshots__/BidderPortfolioStatRow.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidderPortfolioStatRow/__snapshots__/BidderPortfolioStatRow.test.jsx.snap
@@ -78,7 +78,9 @@ exports[`BidderPortfolioStatRow matches snapshot 1`] = `
       />
     </Connect(StaticDevContent)>
   </div>
-  <div>
+  <div
+    className="button-container"
+  >
     <LinkButton
       className="usa-button-secondary"
       isExternal={false}
@@ -87,6 +89,9 @@ exports[`BidderPortfolioStatRow matches snapshot 1`] = `
     >
       View Details
     </LinkButton>
+    <Connect(withRouter(SearchAsClientButton))
+      id={5}
+    />
   </div>
 </div>
 `;

--- a/src/Components/BidderPortfolio/SearchAsClientButton/SearchAsClientButton.jsx
+++ b/src/Components/BidderPortfolio/SearchAsClientButton/SearchAsClientButton.jsx
@@ -1,0 +1,80 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import { setClient } from '../../../actions/clientView';
+import { scrollTo } from '../../../utilities';
+import { ID } from '../../ClientHeader';
+
+export class SearchAsClientButton extends Component {
+  constructor(props) {
+    super(props);
+    this.onClick = this.onClick.bind(this);
+    this.state = {
+      hasPushed: false,
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { hasPushed } = this.state;
+    const { client, isLoading, hasErrored, history, id } = nextProps;
+    if (client.id === id && client && client.id && !isLoading && !hasErrored && !hasPushed) {
+      this.setState({ hasPushed: true }, () => {
+        setTimeout(() => {
+          history.push('/results');
+          const offset = document.getElementById(ID).offsetTop;
+          scrollTo(offset);
+        }, 0);
+      });
+    }
+  }
+
+  onClick() {
+    const { set, id, isLoading } = this.props;
+    if (!isLoading) {
+      set(id);
+    }
+  }
+
+  render() {
+    const { buttonProps, className } = this.props;
+    return (
+      <button
+        className={`usa-button-primary ${className}`}
+        onClick={this.onClick}
+        {...buttonProps}
+      >
+        Search as Client
+      </button>
+    );
+  }
+}
+
+SearchAsClientButton.propTypes = {
+  id: PropTypes.number.isRequired,
+  buttonProps: PropTypes.shape({}),
+  className: PropTypes.string,
+  client: PropTypes.shape({}),
+  isLoading: PropTypes.bool,
+  hasErrored: PropTypes.bool,
+  set: PropTypes.func.isRequired,
+  history: PropTypes.shape({}).isRequired,
+};
+
+SearchAsClientButton.defaultProps = {
+  buttonProps: {},
+  className: '',
+  client: {},
+  isLoading: false,
+  hasErrored: false,
+};
+
+const mapStateToProps = ({ clientView: { client, isLoading, hasErrored } }) => ({
+  client, isLoading, hasErrored,
+});
+
+export const mapDispatchToProps = dispatch => ({
+  set: id => dispatch(setClient(id)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(withRouter(SearchAsClientButton));

--- a/src/Components/BidderPortfolio/SearchAsClientButton/SearchAsClientButton.test.jsx
+++ b/src/Components/BidderPortfolio/SearchAsClientButton/SearchAsClientButton.test.jsx
@@ -1,0 +1,56 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import toJSON from 'enzyme-to-json';
+import TestUtils from 'react-dom/test-utils';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import sinon from 'sinon';
+import SearchAsClientButtonContainer, { SearchAsClientButton, mapDispatchToProps } from './SearchAsClientButton';
+import { testDispatchFunctions } from '../../../testUtilities/testUtilities';
+
+const middlewares = [thunk];
+const mockStore = configureStore(middlewares);
+
+describe('SearchAsClientButton', () => {
+  const props = {
+    id: 1,
+    set: () => {},
+    history: {},
+  };
+
+  it('is defined', () => {
+    const wrapper = shallow(<SearchAsClientButton {...props} />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('calls set() on click', () => {
+    const spy = sinon.spy();
+    const wrapper = shallow(<SearchAsClientButton {...props} set={spy} />);
+    wrapper.find('button').simulate('click');
+    sinon.assert.calledOnce(spy);
+  });
+
+  it('it mounts', () => {
+    const wrapper = TestUtils.renderIntoDocument(
+      <Provider store={mockStore({ clientView: {} })}>
+        <MemoryRouter>
+          <SearchAsClientButtonContainer {...props} />
+        </MemoryRouter>
+      </Provider>);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(<SearchAsClientButton {...props} />);
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});
+
+describe('mapDispatchToProps', () => {
+  const config = {
+    set: [1],
+  };
+  testDispatchFunctions(mapDispatchToProps, config);
+});

--- a/src/Components/BidderPortfolio/SearchAsClientButton/__snapshots__/SearchAsClientButton.test.jsx.snap
+++ b/src/Components/BidderPortfolio/SearchAsClientButton/__snapshots__/SearchAsClientButton.test.jsx.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SearchAsClientButton matches snapshot 1`] = `
+<button
+  className="usa-button-primary "
+  onClick={[Function]}
+>
+  Search as Client
+</button>
+`;

--- a/src/Components/BidderPortfolio/SearchAsClientButton/index.js
+++ b/src/Components/BidderPortfolio/SearchAsClientButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './SearchAsClientButton';

--- a/src/Components/ClientHeader/ClientHeader.jsx
+++ b/src/Components/ClientHeader/ClientHeader.jsx
@@ -1,0 +1,117 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { withRouter } from 'react-router';
+import FA from 'react-fontawesome';
+import { BIDDER_OBJECT } from '../../Constants/PropTypes';
+import { unsetClient } from '../../actions/clientView';
+import { isCurrentPath } from '../ProfileMenu/navigation';
+
+export const ID = 'client-header';
+
+export class ClientHeader extends Component {
+  constructor(props) {
+    super(props);
+    this.unsetClient = this.unsetClient.bind(this);
+    this.state = {
+      showReturnLink: true,
+      useResultsExitFunction: false,
+    };
+  }
+
+  componentWillMount() {
+    this.checkPath();
+  }
+
+  setExitAction(historyObject) {
+    // hide if on the public profile
+    const pathMatches = isCurrentPath('/results', historyObject.pathname);
+    this.setState({ useResultsExitFunction: pathMatches });
+  }
+
+  unsetClient() {
+    const { history } = this.props;
+    const { useResultsExitFunction } = this.state;
+    this.props.unset();
+
+    if (useResultsExitFunction) {
+      history.push('/results');
+    }
+  }
+
+  matchCurrentPath(historyObject) {
+    // hide if on the public profile
+    const pathMatches = isCurrentPath('/profile/public/:id', historyObject.pathname);
+    this.setState({
+      showReturnLink: !pathMatches,
+    });
+  }
+
+  checkPath() {
+    const { history } = this.props;
+    history.listen((historyObject) => {
+      this.matchCurrentPath(historyObject);
+      this.setExitAction(historyObject);
+    });
+  }
+
+  render() {
+    const { showReturnLink } = this.state;
+    const { client, isLoading, hasErrored } = this.props;
+    const name = client && client.user ? `${client.user.first_name} ${client.user.last_name}` : 'Unknown user';
+
+    const isSuccess = client && !!client.id && !isLoading && !hasErrored;
+
+    const renderHeader = () => (
+      <div className="usa-banner client-header">
+        <div className="usa-grid usa-banner-inner">
+          <div className={!showReturnLink ? 'hidden' : ''}>
+            <Link to={`/profile/public/${client.id}`}>
+              <FA name="chevron-left" />
+              <span>Client Dashboard</span>
+            </Link>
+          </div>
+          <div>
+            <FA name="clipboard" />
+            <span>Position Search for {name}</span>
+          </div>
+          <div>
+            <button className="unstyled-button" onClick={this.unsetClient}>
+              <FA name="close" />
+              <span>Exit client view</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+    return (
+      <div id={ID}>
+        {isSuccess && renderHeader()}
+      </div>
+    );
+  }
+}
+
+ClientHeader.propTypes = {
+  client: BIDDER_OBJECT.isRequired,
+  unset: PropTypes.func.isRequired,
+  isLoading: PropTypes.bool,
+  hasErrored: PropTypes.bool,
+  history: PropTypes.shape({}).isRequired,
+};
+
+ClientHeader.defaultProps = {
+  isLoading: false,
+  hasErrored: false,
+};
+
+const mapStateToProps = ({ clientView: { client, isLoading, hasErrored } }) => ({
+  client, isLoading, hasErrored,
+});
+
+export const mapDispatchToProps = dispatch => ({
+  unset: () => dispatch(unsetClient()),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(withRouter(ClientHeader));

--- a/src/Components/ClientHeader/ClientHeader.test.jsx
+++ b/src/Components/ClientHeader/ClientHeader.test.jsx
@@ -1,0 +1,54 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import toJSON from 'enzyme-to-json';
+import TestUtils from 'react-dom/test-utils';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import sinon from 'sinon';
+import ClientHeaderContainer, { ClientHeader, mapDispatchToProps } from './ClientHeader';
+import { testDispatchFunctions } from '../../testUtilities/testUtilities';
+
+const middlewares = [thunk];
+const mockStore = configureStore(middlewares);
+
+describe('ClientHeader', () => {
+  const props = {
+    id: 1,
+    unset: () => {},
+    history: { listen: () => {} },
+    client: {},
+  };
+
+  it('is defined', () => {
+    const wrapper = shallow(<ClientHeader {...props} />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('calls unset() on click', () => {
+    const spy = sinon.spy();
+    const wrapper = shallow(<ClientHeader {...props} unset={spy} client={{ id: 1 }} />);
+    wrapper.find('button').simulate('click');
+    sinon.assert.calledOnce(spy);
+  });
+
+  it('it mounts', () => {
+    const wrapper = TestUtils.renderIntoDocument(
+      <Provider store={mockStore({ clientView: { client: {} } })}>
+        <MemoryRouter>
+          <ClientHeaderContainer {...props} />
+        </MemoryRouter>
+      </Provider>);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(<ClientHeader {...props} client={{ id: 1 }} />);
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});
+
+describe('mapDispatchToProps', () => {
+  testDispatchFunctions(mapDispatchToProps);
+});

--- a/src/Components/ClientHeader/__snapshots__/ClientHeader.test.jsx.snap
+++ b/src/Components/ClientHeader/__snapshots__/ClientHeader.test.jsx.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ClientHeader matches snapshot 1`] = `
+<div
+  id="client-header"
+>
+  <div
+    className="usa-banner client-header"
+  >
+    <div
+      className="usa-grid usa-banner-inner"
+    >
+      <div
+        className=""
+      >
+        <Link
+          replace={false}
+          to="/profile/public/1"
+        >
+          <FontAwesome
+            name="chevron-left"
+          />
+          <span>
+            Client Dashboard
+          </span>
+        </Link>
+      </div>
+      <div>
+        <FontAwesome
+          name="clipboard"
+        />
+        <span>
+          Position Search for 
+          Unknown user
+        </span>
+      </div>
+      <div>
+        <button
+          className="unstyled-button"
+          onClick={[Function]}
+        >
+          <FontAwesome
+            name="close"
+          />
+          <span>
+            Exit client view
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/Components/ClientHeader/index.js
+++ b/src/Components/ClientHeader/index.js
@@ -1,0 +1,1 @@
+export { default, ID } from './ClientHeader';

--- a/src/Components/Header/Header.jsx
+++ b/src/Components/Header/Header.jsx
@@ -21,6 +21,7 @@ import { getAssetPath, propOrDefault, focusByFirstOfHeader } from '../../utiliti
 import MediaQuery from '../MediaQuery';
 import InteractiveElement from '../InteractiveElement';
 import BetaHeader from './BetaHeader';
+import ClientHeader from '../ClientHeader';
 
 export class Header extends Component {
   constructor(props) {
@@ -141,6 +142,7 @@ export class Header extends Component {
           />
           <StateBanner />
           <BetaHeader />
+          <ClientHeader />
           <div className="usa-navbar padded-main-content padded-main-content--header">
             <button className="usa-menu-btn">Menu</button>
             <div className="usa-logo" id="logo">

--- a/src/Components/Header/__snapshots__/Header.test.jsx.snap
+++ b/src/Components/Header/__snapshots__/Header.test.jsx.snap
@@ -23,6 +23,7 @@ exports[`Header matches snapshot when logged in 1`] = `
     />
     <StateBanner />
     <BetaHeader />
+    <Connect(withRouter(ClientHeader)) />
     <div
       className="usa-navbar padded-main-content padded-main-content--header"
     >
@@ -108,6 +109,7 @@ exports[`Header matches snapshot when logged out 1`] = `
     />
     <StateBanner />
     <BetaHeader />
+    <Connect(withRouter(ClientHeader)) />
     <div
       className="usa-navbar padded-main-content padded-main-content--header"
     >

--- a/src/Constants/SystemMessages.js
+++ b/src/Constants/SystemMessages.js
@@ -68,3 +68,8 @@ export const CANNOT_BID_DEFAULT = `This position is not available to bid on${CAN
 export const GET_NOW_AVAILABLE = n => `${n} Now available!`;
 export const GET_POSITIONS_ADDED = n => `${n} Position${n !== 1 ? 's' : ''} added`;
 
+export const SET_CLIENT_SUCCESS = 'Success';
+export const SET_CLIENT_ERROR = 'Error setting client';
+export const GET_CLIENT_SUCCESS_MESSAGE = user => `You are now searching as ${user.first_name} ${user.last_name}.`;
+export const UNSET_CLIENT_SUCCESS = SET_CLIENT_SUCCESS;
+export const UNSET_CLIENT_SUCCESS_MESSAGE = 'You have exited client view.';

--- a/src/actions/clientView.js
+++ b/src/actions/clientView.js
@@ -1,0 +1,44 @@
+import api from '../api';
+import { toastSuccess, toastError } from './toast';
+import { SET_CLIENT_SUCCESS, GET_CLIENT_SUCCESS_MESSAGE, SET_CLIENT_ERROR,
+  UNSET_CLIENT_SUCCESS, UNSET_CLIENT_SUCCESS_MESSAGE } from '../Constants/SystemMessages';
+
+export function setClientViewAs({ loadingId, client, isLoading, hasErrored }) {
+  return {
+    type: 'SET_CLIENT_VIEW_AS',
+    config: {
+      loadingId,
+      client,
+      isLoading,
+      hasErrored,
+    },
+  };
+}
+
+export function unsetClientView() {
+  return {
+    type: 'UNSET_CLIENT_VIEW',
+  };
+}
+
+export function setClient(id) {
+  return (dispatch) => {
+    dispatch(setClientViewAs({ client: {}, isLoading: true, hasErrored: false }));
+    api().get(`/client/${id}/`)
+      .then(({ data }) => {
+        dispatch(setClientViewAs({ client: data, isLoading: false, hasErrored: false }));
+        dispatch(toastSuccess(GET_CLIENT_SUCCESS_MESSAGE(data.user), SET_CLIENT_SUCCESS));
+      })
+      .catch(() => {
+        dispatch(setClientViewAs({ client: {}, isLoading: false, hasErrored: true }));
+        dispatch(toastError('Please try again.', SET_CLIENT_ERROR));
+      });
+  };
+}
+
+export function unsetClient() {
+  return (dispatch) => {
+    dispatch(unsetClientView());
+    dispatch(toastSuccess(UNSET_CLIENT_SUCCESS_MESSAGE, UNSET_CLIENT_SUCCESS));
+  };
+}

--- a/src/reducers/clientView/clientView.js
+++ b/src/reducers/clientView/clientView.js
@@ -1,0 +1,17 @@
+export const INITIAL_STATE = {
+  loadingId: '',
+  client: {},
+  isLoading: false,
+  hasErrored: false,
+};
+
+export default function clientViewAs(state = INITIAL_STATE, action) {
+  switch (action.type) {
+    case 'SET_CLIENT_VIEW_AS':
+      return { ...state, ...action.config };
+    case 'UNSET_CLIENT_VIEW':
+      return INITIAL_STATE;
+    default:
+      return state;
+  }
+}

--- a/src/reducers/clientView/clientView.test.js
+++ b/src/reducers/clientView/clientView.test.js
@@ -1,0 +1,11 @@
+import clientViewAs, { INITIAL_STATE } from './clientView';
+
+describe('clientView reducer', () => {
+  it('can set reducer SET_CLIENT_VIEW_AS', () => {
+    expect(clientViewAs(INITIAL_STATE, { type: 'SET_CLIENT_VIEW_AS', config: { isLoading: true } }).isLoading).toBe(true);
+  });
+
+  it('can set reducer UNSET_CLIENT_VIEW', () => {
+    expect(clientViewAs({ ...INITIAL_STATE, isLoading: true }, { type: 'UNSET_CLIENT_VIEW' })).toEqual(INITIAL_STATE);
+  });
+});

--- a/src/reducers/clientView/index.js
+++ b/src/reducers/clientView/index.js
@@ -1,0 +1,3 @@
+import clientView from './clientView';
+
+export default { clientView };

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -36,6 +36,7 @@ import showFeedback from './showFeedback';
 import feedback from './feedback';
 import features from './features';
 import toast from './toast';
+import clientView from './clientView';
 
 export default combineReducers({
   ...results,
@@ -69,6 +70,7 @@ export default combineReducers({
   ...feedback,
   ...features,
   ...toast,
+  ...clientView,
   router,
   form,
   client,

--- a/src/sass/_bidderPortfolio.scss
+++ b/src/sass/_bidderPortfolio.scss
@@ -78,7 +78,7 @@
 
   > div:nth-child(3) {
     display: flex;
-    flex: 8 0 225px;
+    flex: 6 0 100px;
     justify-content: flex-end;
   }
 
@@ -136,12 +136,33 @@
     flex-direction: row;
     line-height: 1.3em;
   }
+
+  .button-container {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 0;
+
+    > span {
+      margin-right: 10px;
+    }
+
+    span,
+    a,
+    button {
+      margin: 0;
+      margin-bottom: 0;
+    }
+
+    .link-button-wrapper {
+      margin-right: 10px;
+    }
+  }
 }
 
 .bidder-portfolio-stat-card {
   display: flex;
   flex-direction: column;
-  height: 299px;
+  height: 331px;
   margin-bottom: 15px;
   margin-left: 15px;
   margin-right: auto;
@@ -186,23 +207,52 @@
     border-top: 1px solid $color-gray-lighter;
     display: flex;
     flex: 4;
+    flex-direction: column;
+    padding-bottom: 20px;
 
     > div {
       display: flex;
       flex-direction: column;
       justify-content: space-between;
-      padding: 10px 16px 20px;
+      padding: 10px 16px 0;
       width: 100%;
 
-      > span {
+      .updates {
         font-weight: bold;
+        margin-bottom: 5px;
       }
+    }
+
+    > div:nth-child(2) {
+      padding-bottom: 0;
     }
   }
 
   .stat-card-data-point {
     display: flex;
     flex-direction: row;
+  }
+
+  .button-container {
+    margin-top: 10px;
+
+    span,
+    a,
+    button {
+      margin: 0;
+      margin-bottom: 0;
+    }
+
+    > span,
+    > button {
+      width: 48%;
+    }
+
+    a,
+    button {
+      font-size: .9em;
+      padding: 10px 5px;
+    }
   }
 }
 
@@ -319,6 +369,17 @@ $cdo-search-container-padding: 10px;
       justify-content: center;
       margin-left: 10px;
       min-width: 100px;
+    }
+  }
+
+  .client-as-button-container {
+    display: inherit;
+
+    button {
+      margin: 0;
+      margin-left: 0;
+      min-width: 120px;
+      padding: 10px 5px;
     }
   }
 

--- a/src/sass/_clientView.scss
+++ b/src/sass/_clientView.scss
@@ -1,0 +1,45 @@
+.client-header {
+  background-color: $tertiary-cool-blue-lightest;
+
+  a {
+    color: $color-black;
+  }
+
+  .fa {
+    margin-right: 5px;
+  }
+
+  > div {
+    display: flex;
+  }
+
+  .hidden {
+    visibility: hidden;
+  }
+
+  .usa-banner-inner {
+    display: flex;
+    padding: 1.6rem 0;
+
+    > div:nth-child(1) {
+      flex: 1;
+      font-size: 1.6rem;
+    }
+
+    > div:nth-child(2) {
+      display: flex;
+      flex: 1;
+      font-size: 1.8rem;
+      justify-content: center;
+    }
+
+    > div:nth-child(3) {
+      display: flex;
+      flex: 1;
+      flex-direction: row-reverse;
+      font-size: 1.4rem;
+      font-weight: bold;
+      justify-content: right;
+    }
+  }
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -88,5 +88,6 @@
 @import 'ribbon';
 @import 'toggle';
 @import 'picker';
+@import 'clientView';
 @import 'overrides';
 @import 'accessibility';

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -159,8 +159,12 @@ const defaultScrollConfig = {
   smooth: 'easeOutQuad',
 };
 
-export const scrollToTop = (config = defaultScrollConfig) => {
-  scroll.scrollToTop(config);
+export const scrollTo = (num, config = {}) => {
+  scroll.scrollTo(num, { ...defaultScrollConfig, ...config });
+};
+
+export const scrollToTop = (config = {}) => {
+  scroll.scrollToTop({ ...defaultScrollConfig, ...config });
 };
 
 // When we want to grab a label, but aren't sure which one exists.


### PR DESCRIPTION
Completes TM-768 by allowing CDOs to set the global context as a bidder. Has no effect on bidding/favoriting for now.