### PR TITLE
Fix/back to top usability

### DIFF
--- a/src/sass/_accessibility.scss
+++ b/src/sass/_accessibility.scss
@@ -42,3 +42,10 @@ a {
     }
   }
 }
+
+// need a color that is accessible when the Compare drawer is either open or closed
+.tm-scroll-up-container {
+  &:focus {
+    outline-color: $blue-primary !important;
+  }
+}

--- a/src/sass/_scrollUp.scss
+++ b/src/sass/_scrollUp.scss
@@ -1,6 +1,7 @@
 .tm-scroll-up-container {
   // the background-color in inline-style doesn't render in some browsers (IE11, Edge), so we also set it here
   background-color: $blue-primary;
+  z-index: $back-to-top-z !important;
 
   path {
     fill: $color-white;

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -171,6 +171,7 @@ $skill-code-dropdown-z: 10500;
 $spinner-z: 100;
 $toggle-button-z: 5;
 $ribbon-z: 10;
+$back-to-top-z: 10200;
 
 //**
 //* Images


### PR DESCRIPTION
Fixes for "Back to top" button
- Adds higher z-index, as it was hidden behind Compare drawer
- Adds blue border-color on focus so that it is accessible when the Compare drawer is either open or closed