### PR TITLE
Hover button on results cards to display capsule description

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "react-scrollbar": "^0.5.4",
     "react-select": "^1.1.0",
     "react-simple-dropdown": "^3.2.0",
+    "react-spring": "4.0.0",
     "react-tippy": "^1.2.2",
     "react-toastify": "^4.5.1",
     "redux": "^3.7.1",

--- a/src/Components/ResultsCard/HoverDescription/HoverDescription.jsx
+++ b/src/Components/ResultsCard/HoverDescription/HoverDescription.jsx
@@ -1,0 +1,110 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { throttle } from 'lodash';
+import { Spring } from 'react-spring';
+import FA from 'react-fontawesome';
+import Linkify from 'react-linkify';
+import InteractiveElement from '../../InteractiveElement';
+
+class HoverDescription extends Component {
+  constructor(props) {
+    super(props);
+    this.expand = this.expand.bind(this);
+    this.close = this.close.bind(this);
+    this.toggle = this.toggle.bind(this);
+
+    // Debouncing function to 260ms and binding this.
+    // Used to create a delay and prevent multiple actions within a small
+    // time frame from firing.
+    this.toggleVisibility = throttle(this.toggleVisibility.bind(this),
+      260, { leading: false, trailing: true });
+
+    this.state = {
+      expanded: false,
+      cardHovered: false,
+    };
+  }
+
+  toggleVisibility(shouldExpand = false) {
+    this.setState({ expanded: !!shouldExpand });
+  }
+
+  toggle() {
+    this.toggleVisibility(!this.state.expanded);
+  }
+
+  expand() {
+    this.toggleVisibility(true);
+  }
+
+  close() {
+    this.toggleVisibility(false);
+  }
+
+  toggleCardHovered(cardHovered = false) {
+    this.setState({ cardHovered });
+  }
+
+  render() {
+    const { getOffsetPx, text, id } = this.props;
+    const { expanded, cardHovered } = this.state;
+
+    const getHeight = () => {
+      if (expanded) {
+        return getOffsetPx();
+      }
+      return cardHovered ? '31px' : '29px';
+    };
+
+    const height$ = getHeight();
+
+    return (
+      <Spring to={{ height: height$ }} config={{ friction: 21, tension: 175 }} >
+        {
+          ({ height }) =>
+            (
+              <div className="hover-description">
+                <InteractiveElement
+                  className="hover-button"
+                  style={{ height }}
+                  onMouseOver={this.expand}
+                  onMouseLeave={this.close}
+                  onClick={this.toggle}
+                >
+                  { !this.state.expanded && <FA name="angle-double-up" /> }
+                  <Spring from={{ opacity: expanded ? 1 : 0 }}>
+                    {
+                      ({ opacity }) => (
+                        <p style={{ opacity }}>
+                          { expanded &&
+                            <Linkify properties={{ target: '_blank' }}>
+                              {text}
+                              <Link className="position-link" to={`/details/${id}`}>View position</Link>
+                            </Linkify>
+                          }
+                        </p>
+                      )
+                    }
+                  </Spring>
+                </InteractiveElement>
+              </div>
+            )
+        }
+      </Spring>
+    );
+  }
+}
+
+
+HoverDescription.propTypes = {
+  getOffsetPx: PropTypes.func.isRequired,
+  text: PropTypes.string,
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+};
+
+HoverDescription.defaultProps = {
+  text: '',
+};
+
+export default HoverDescription;

--- a/src/Components/ResultsCard/HoverDescription/HoverDescription.test.jsx
+++ b/src/Components/ResultsCard/HoverDescription/HoverDescription.test.jsx
@@ -1,0 +1,116 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import toJSON from 'enzyme-to-json';
+import HoverDescription from './HoverDescription';
+
+describe('HoverDescriptionComponent', () => {
+  const timeout = 500;
+  const props = {
+    getOffsetPx: () => '5px',
+    text: 'Capsule description',
+    id: 1,
+  };
+
+  it('is defined', () => {
+    const wrapper = shallow(
+      <HoverDescription
+        {...props}
+      />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('sets state on toggleVisibility()', (done) => {
+    const wrapper = shallow(
+      <HoverDescription
+        {...props}
+      />);
+    const instance = wrapper.instance();
+    instance.toggleVisibility(true);
+    setTimeout(() => {
+      expect(instance.state.expanded).toBe(true);
+      done();
+    }, timeout);
+  });
+
+  it('sets state on toggle()', (done) => {
+    const wrapper = shallow(
+      <HoverDescription
+        {...props}
+      />);
+    const instance = wrapper.instance();
+    instance.toggle();
+    setTimeout(() => {
+      expect(instance.state.expanded).toBe(true);
+      done();
+    }, timeout);
+  });
+
+  it('sets state to true on expand()', (done) => {
+    const wrapper = shallow(
+      <HoverDescription
+        {...props}
+      />);
+    const instance = wrapper.instance();
+    instance.expand();
+    setTimeout(() => {
+      expect(instance.state.expanded).toBe(true);
+      done();
+    }, timeout);
+  });
+
+  it('sets state to close on close()', (done) => {
+    const wrapper = shallow(
+      <HoverDescription
+        {...props}
+      />);
+    const instance = wrapper.instance();
+    instance.close();
+    setTimeout(() => {
+      expect(instance.state.expanded).toBe(false);
+      done();
+    }, timeout);
+  });
+
+  it('sets state on toggle()', (done) => {
+    const wrapper = shallow(
+      <HoverDescription
+        {...props}
+      />);
+    const instance = wrapper.instance();
+    instance.toggle();
+    setTimeout(() => {
+      expect(instance.state.expanded).toBe(true);
+      done();
+    }, timeout);
+  });
+
+  it('sets state on toggleCardHovered()', (done) => {
+    const wrapper = shallow(
+      <HoverDescription
+        {...props}
+      />);
+    const instance = wrapper.instance();
+    instance.toggleCardHovered(true);
+    setTimeout(() => {
+      expect(instance.state.cardHovered).toBe(true);
+      done();
+    }, timeout);
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(
+      <HoverDescription
+        {...props}
+      />);
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
+  it('matches snapshot when expanded === true', () => {
+    const wrapper = shallow(
+      <HoverDescription
+        {...props}
+      />);
+    wrapper.instance().setState({ expanded: true });
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/ResultsCard/HoverDescription/__snapshots__/HoverDescription.test.jsx.snap
+++ b/src/Components/ResultsCard/HoverDescription/__snapshots__/HoverDescription.test.jsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HoverDescriptionComponent matches snapshot 1`] = `
+<e
+  config={
+    Object {
+      "friction": 21,
+      "tension": 175,
+    }
+  }
+  from={Object {}}
+  immediate={false}
+  native={false}
+  reset={false}
+  to={
+    Object {
+      "height": "29px",
+    }
+  }
+/>
+`;
+
+exports[`HoverDescriptionComponent matches snapshot when expanded === true 1`] = `
+<e
+  config={
+    Object {
+      "friction": 21,
+      "tension": 175,
+    }
+  }
+  from={Object {}}
+  immediate={false}
+  native={false}
+  reset={false}
+  to={
+    Object {
+      "height": "5px",
+    }
+  }
+/>
+`;

--- a/src/Components/ResultsCard/HoverDescription/index.js
+++ b/src/Components/ResultsCard/HoverDescription/index.js
@@ -1,0 +1,1 @@
+export { default } from './HoverDescription';

--- a/src/Components/ResultsCard/ResultsCard.jsx
+++ b/src/Components/ResultsCard/ResultsCard.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { get, isNumber } from 'lodash';
@@ -13,23 +13,14 @@ import LanguageList from '../LanguageList';
 import BidCount from '../BidCount';
 import BoxShadow from '../BoxShadow';
 import Handshake from '../Ribbon/Handshake';
+import HoverDescription from './HoverDescription';
 
-import { formatDate, propOrDefault, getPostName, getBidStatisticsObject } from '../../utilities';
+import { formatDate, propOrDefault, getPostName, getBidStatisticsObject, shortenString } from '../../utilities';
 
 import { POSITION_DETAILS, FAVORITE_POSITIONS_ARRAY } from '../../Constants/PropTypes';
 import {
-  NO_BUREAU,
-  NO_BID_CYCLE,
-  NO_DANGER_PAY,
-  NO_GRADE,
-  NO_POST_DIFFERENTIAL,
-  NO_POSITION_NUMBER,
-  NO_POST,
-  NO_SKILL,
-  NO_TOUR_OF_DUTY,
-  NO_UPDATE_DATE,
-  NO_DATE,
-  NO_USER_LISTED,
+  NO_BUREAU, NO_BID_CYCLE, NO_DANGER_PAY, NO_GRADE, NO_POST_DIFFERENTIAL, NO_POSITION_NUMBER,
+  NO_POST, NO_SKILL, NO_TOUR_OF_DUTY, NO_UPDATE_DATE, NO_DATE, NO_USER_LISTED,
 } from '../../Constants/SystemMessages';
 
 const getResult = (result, path, defaultValue, isRate = false) => {
@@ -56,89 +47,122 @@ export const renderBidCount = stats => (
   </Column>
 );
 
-const ResultsCard = (props) => {
-  const options = {};
-  const {
-    id,
-    result,
-    favorites,
-    isProjectedVacancy,
-  } = props;
+class ResultsCard extends Component {
+  constructor(props) {
+    super(props);
+    this.getOffsetPx = this.getOffsetPx.bind(this);
+    this.getInnerId = this.getInnerId.bind(this);
+  }
 
-  const title = propOrDefault(result, 'title');
-  const position = getResult(result, 'position_number', NO_POSITION_NUMBER);
-  const languages = getResult(result, 'languages', []);
+  getInnerId() {
+    const { id } = this.props;
+    return `${id}-inner`;
+  }
 
-  const language = (<LanguageList languages={languages} propToUse="representation" />);
+  getOffsetPx() {
+    const { id } = this.props;
+    const innerId = this.getInnerId();
+    const maxHeightOffset = document.getElementById(innerId).offsetTop;
+    const cardHeight = document.getElementById(id).offsetHeight;
 
-  const post = `${getPostName(result.post, NO_POST)}${result.organization ? `: ${result.organization}` : ''}`;
+    const offset = cardHeight - maxHeightOffset;
 
-  const stats = getBidStatisticsObject(result.bid_statistics);
+    return `${offset}px`;
+  }
+
+  render() {
+    const options = {};
+    const {
+      id,
+      result,
+      favorites,
+      isProjectedVacancy,
+    } = this.props;
+
+    const title = propOrDefault(result, 'title');
+    const position = getResult(result, 'position_number', NO_POSITION_NUMBER);
+    const languages = getResult(result, 'languages', []);
+
+    const language = (<LanguageList languages={languages} propToUse="representation" />);
+
+    const post = `${getPostName(result.post, NO_POST)}${result.organization ? `: ${result.organization}` : ''}`;
+
+    const stats = getBidStatisticsObject(result.bid_statistics);
+
+    const description = shortenString(get(result, 'description.content') || 'No description.', 750);
+
+    const innerId = this.getInnerId();
 
   // TODO - update this to a real property once API is updateds
-  const recentlyAvailable = result.recently_available;
+    const recentlyAvailable = result.recently_available;
 
-  const sections = [
+    const sections = [
     /* eslint-disable quote-props */
-    {
-      'TED': getResult(result, 'current_assignment.estimated_end_date', NO_DATE),
-      'Bid cycle': getResult(result, 'latest_bidcycle.name', NO_BID_CYCLE),
-      'Skill': getResult(result, 'skill', NO_SKILL),
-      'Grade': getResult(result, 'grade', NO_GRADE),
-      'Bureau': getResult(result, 'bureau', NO_BUREAU),
-    },
-    {
-      'Tour of duty': getResult(result, 'post.tour_of_duty', NO_TOUR_OF_DUTY),
-      'Language': language,
-      'Post differential': getResult(result, 'post.differential_rate', NO_POST_DIFFERENTIAL, true),
-      'Danger pay': getResult(result, 'post.danger_pay', NO_DANGER_PAY, true),
-      'Incumbent': getResult(result, 'current_assignment.user', NO_USER_LISTED),
-    },
-    {
-      'Posted': getResult(result, COMMON_PROPERTIES.posted, NO_UPDATE_DATE),
-      'Position number': position,
-    },
+      {
+        'TED': getResult(result, 'current_assignment.estimated_end_date', NO_DATE),
+        'Bid cycle': getResult(result, 'latest_bidcycle.name', NO_BID_CYCLE),
+        'Skill': getResult(result, 'skill', NO_SKILL),
+        'Grade': getResult(result, 'grade', NO_GRADE),
+        'Bureau': getResult(result, 'bureau', NO_BUREAU),
+      },
+      {
+        'Tour of duty': getResult(result, 'post.tour_of_duty', NO_TOUR_OF_DUTY),
+        'Language': language,
+        'Post differential': getResult(result, 'post.differential_rate', NO_POST_DIFFERENTIAL, true),
+        'Danger pay': getResult(result, 'post.danger_pay', NO_DANGER_PAY, true),
+        'Incumbent': getResult(result, 'current_assignment.user', NO_USER_LISTED),
+      },
+      {
+        'Posted': getResult(result, COMMON_PROPERTIES.posted, NO_UPDATE_DATE),
+        'Position number': position,
+      },
     /* eslint-enable quote-props */
-  ];
+    ];
 
-  options.favorite = {
-    compareArray: favorites,
-    refKey: result.id,
-    hasBorder: true,
-    useButtonClass: true,
-    useLongText: true,
-  };
+    options.favorite = {
+      compareArray: favorites,
+      refKey: result.id,
+      hasBorder: true,
+      useButtonClass: true,
+      useLongText: true,
+    };
 
-  options.compare = {
-    as: 'div',
-    refKey: position,
-  };
+    options.compare = {
+      as: 'div',
+      refKey: position,
+    };
 
-  return (
-    <MediaQueryWrapper breakpoint="screenMdMax" widthType="max">
-      {() => (
-        <BoxShadow>
-          <div id={id} className={`results-card ${isProjectedVacancy ? 'results-card--secondary' : ''}`}>
-            <Row className="header" fluid>
-              <Column columns="8">
-                <Column columns="12" className="results-card-title-link">
-                  <h3>{title}</h3>
-                  <Link to={`/details/${result.id}`}>View position</Link>
-                  {recentlyAvailable && <span className="available-alert">Now available!</span>}
+    return (
+      <MediaQueryWrapper breakpoint="screenMdMax" widthType="max">
+        {() => (
+          <BoxShadow>
+            <div
+              id={id}
+              style={{ position: 'relative', overflow: 'hidden' }}
+              className={`results-card ${isProjectedVacancy ? 'results-card--secondary' : ''}`}
+              onMouseOver={() => this.hover.toggleCardHovered(true)}
+              onMouseLeave={() => this.hover.toggleCardHovered(false)}
+            >
+              <Row className="header" fluid>
+                <Column columns="8">
+                  <Column columns="12" className="results-card-title-link">
+                    <h3>{title}</h3>
+                    <Link to={`/details/${result.id}`}>View position</Link>
+                    {recentlyAvailable && <span className="available-alert">Now available!</span>}
+                  </Column>
+                  <Column columns="12" className="results-card-title-link">
+                    <dt>Post:</dt><dd>{post}</dd>
+                  </Column>
                 </Column>
-                <Column columns="12" className="results-card-title-link">
-                  <dt>Post:</dt><dd>{post}</dd>
-                </Column>
-              </Column>
+                <Flag
+                  name="flags.bidding"
+                  render={() => renderBidCount(stats)}
+                />
+              </Row>
               <Flag
                 name="flags.bidding"
-                render={() => renderBidCount(stats)}
-              />
-            </Row>
-            <Flag
-              name="flags.bidding"
-              render={() =>
-                (<Row id={`${id}-inner`} fluid>
+                render={() =>
+                (<Row id={innerId} fluid>
                   <Column columns="6">
                     <DefinitionList items={sections[0]} />
                   </Column>
@@ -152,7 +176,7 @@ const ResultsCard = (props) => {
                   </Column>
                 </Row>)
               }
-              fallbackRender={() =>
+                fallbackRender={() =>
                 (<Row id={`${id}-inner`} fluid>
                   <Column columns="6">
                     <DefinitionList items={sections[0]} />
@@ -162,27 +186,34 @@ const ResultsCard = (props) => {
                   </Column>
                 </Row>)
               }
-            />
-            <Row className="footer results-card-padded-section" fluid>
-              <Column columns="6" as="section">
-                {
+              />
+              <Row className="footer results-card-padded-section" fluid>
+                <Column columns="6" as="section">
+                  {
                 !!favorites &&
                   <Favorite {...options.favorite} />
               }
-                <CompareCheck {...options.compare} />
-              </Column>
-              <Column columns="6" as="section">
-                <div>
-                  <DefinitionList items={sections[2]} />
-                </div>
-              </Column>
-            </Row>
-          </div>
-        </BoxShadow>
+                  <CompareCheck {...options.compare} />
+                </Column>
+                <Column columns="6" as="section">
+                  <div>
+                    <DefinitionList items={sections[2]} />
+                  </div>
+                </Column>
+              </Row>
+              <HoverDescription
+                ref={(x) => { this.hover = x; }}
+                text={description}
+                getOffsetPx={this.getOffsetPx}
+                id={result.id}
+              />
+            </div>
+          </BoxShadow>
       )}
-    </MediaQueryWrapper>
-  );
-};
+      </MediaQueryWrapper>
+    );
+  }
+}
 
 
 ResultsCard.propTypes = {

--- a/src/sass/_hoverDescription.scss
+++ b/src/sass/_hoverDescription.scss
@@ -1,0 +1,32 @@
+.hover-description {
+  bottom: 0;
+  left: 0;
+  padding: 0 8px;
+  position: absolute;
+  width: 100%;
+
+  .hover-button {
+    background-color: $bg-gray-medium-4;
+    border-radius: 10px 10px 0 0;
+    box-shadow: 0 0 2px 2px $bg-gray-medium-1;
+    display: flex;
+    justify-content: center;
+    padding: 0 1em 1em;
+    position: relative;
+
+    p {
+      font-size: .9em;
+      padding: .2em;
+    }
+
+    .position-link {
+      margin-left: 5px;
+    }
+
+    .fa {
+      color: $primary-blue;
+      font-size: 1.5em;
+      margin-top: 2px;
+    }
+  }
+}

--- a/src/sass/_results.scss
+++ b/src/sass/_results.scss
@@ -44,7 +44,7 @@ $results-container-width: 100% - $filter-container-width;
   border: 1px solid $results-card-border;
   border-left: 8px solid $results-card-accent;
   margin-bottom: 2rem;
-  padding: 1.1rem;
+  padding: 1.1rem 1.1rem 3.3rem;
 
   dl {
     dt,
@@ -110,6 +110,7 @@ $results-container-width: 100% - $filter-container-width;
   }
 
   .footer {
+    margin-bottom: rem(10px);
     margin-top: rem(14px);
     padding-top: rem(4px);
 

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -54,7 +54,8 @@ $bg-gray-dark-4: #F1F1F1; //# Lightest
 $bg-gray-medium-0: #B1B1B1; //# Base
 $bg-gray-medium-1: #CCCCCC;
 $bg-gray-medium-2: #E0E0E0;
-$bg-gray-medium-3: #F0F0F0; //# Lightest
+$bg-gray-medium-3: #F0F0F0;
+$bg-gray-medium-4: #F2F2F2; //# Lightest
 
 $bg-blue-dark-0: #112E51; //# Base
 $bg-blue-dark-1: #00293F;

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -89,5 +89,6 @@
 @import 'toggle';
 @import 'picker';
 @import 'scrollUp';
+@import 'hoverDescription';
 @import 'overrides';
 @import 'accessibility';

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -181,7 +181,7 @@ export const shortenString = (string, shortenTo = 250, suffix = '...') => {
   if (shortenTo < newSuffix.length) {
     return suffix;
   }
-  if (string.length > shortenTo) {
+  if (string && string.length > shortenTo) {
     // shorten to the shortenTo param, less the length of our suffix
     newString = string.slice(0, shortenTo - newSuffix.length);
     // in case the last character(s) was whitespace

--- a/yarn.lock
+++ b/yarn.lock
@@ -7271,6 +7271,11 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
+normalize-css-color@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/normalize-css-color/-/normalize-css-color-1.0.2.tgz#02991e97cccec6623fe573afbbf0de6a1f3e9f8d"
+  integrity sha1-Apkel8zOxmI/5XOvu/Deah8+n40=
+
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
@@ -8793,6 +8798,13 @@ react-simple-dropdown@^3.2.0:
   dependencies:
     classnames "^2.1.2"
     prop-types "^15.5.8"
+
+react-spring@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-4.0.0.tgz#eaddd6ec51b77900646bb489ccb93734157420e7"
+  integrity sha512-5Rr2xOzc+EGZmtsy4V5m8k3aVv23i+iZzesAksMDrF6YrGwILtBQ/54S/InE4EQnDw5wA2hUEv+FHv0Ntk8vxA==
+  dependencies:
+    normalize-css-color "^1.0.2"
 
 react-test-renderer@^15.6.1:
   version "15.6.2"


### PR DESCRIPTION
Relies on API PR https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/67

Completes TM-772 by adding a button to the Results cards which can be hovered or clicked on to display the capsule description.

- Makes use of [react-spring](https://github.com/react-spring/react-spring) to perform animation (though I had to use an older version of react-spring, since React 15 uses a different `ref` API)

![Apr-29-2019 11-32-13](https://user-images.githubusercontent.com/11576347/56907558-80b9ff80-6a72-11e9-90eb-5c068ff5364d.gif)
