### PR TITLE
Use the word "Bid Season" when using projected vacancy search

### DIFF
--- a/src/Components/ResultsCard/HoverDescription/HoverDescription.jsx
+++ b/src/Components/ResultsCard/HoverDescription/HoverDescription.jsx
@@ -47,6 +47,7 @@ class HoverDescription extends Component {
   }
 
   render() {
+    const { isProjectedVacancy } = this.context;
     const { getOffsetPx, text, id } = this.props;
     const { expanded, cardHovered } = this.state;
 
@@ -80,7 +81,7 @@ class HoverDescription extends Component {
                           { expanded &&
                             <Linkify properties={{ target: '_blank' }}>
                               {text}
-                              <Link className="position-link" to={`/details/${id}`}>View position</Link>
+                              { !isProjectedVacancy && <Link className="position-link" to={`/details/${id}`}>View position</Link> }
                             </Linkify>
                           }
                         </p>
@@ -96,6 +97,9 @@ class HoverDescription extends Component {
   }
 }
 
+HoverDescription.contextTypes = {
+  isProjectedVacancy: PropTypes.bool,
+};
 
 HoverDescription.propTypes = {
   getOffsetPx: PropTypes.func.isRequired,

--- a/src/Components/ResultsCard/ResultsCard.jsx
+++ b/src/Components/ResultsCard/ResultsCard.jsx
@@ -96,11 +96,13 @@ class ResultsCard extends Component {
   // TODO - update this to a real property once API is updateds
     const recentlyAvailable = result.recently_available;
 
+    const bidTypeTitle = isProjectedVacancy ? 'Bid season' : 'Bid cycle';
+
     const sections = [
     /* eslint-disable quote-props */
       {
         'TED': getResult(result, 'current_assignment.estimated_end_date', NO_DATE),
-        'Bid cycle': getResult(result, 'latest_bidcycle.name', NO_BID_CYCLE),
+        [bidTypeTitle]: getResult(result, 'latest_bidcycle.name', NO_BID_CYCLE),
         'Skill': getResult(result, 'skill', NO_SKILL),
         'Grade': getResult(result, 'grade', NO_GRADE),
         'Bureau': getResult(result, 'bureau', NO_BUREAU),


### PR DESCRIPTION
Results cards should use correct term depending on whether the user is performing a regular or a projected vacancy search.

Also, hide the "View position" link in the hover description if the position is a projected vacancy.