### PR TITLE
Increase limit for glossary terms to load

### DIFF
--- a/src/actions/glossary.js
+++ b/src/actions/glossary.js
@@ -87,7 +87,7 @@ export function glossaryFetchData(bypassLoading = false) {
     }
 
     api()
-      .get('/glossary/?is_archived=false')
+      .get('/glossary/?is_archived=false&limit=500')
       .then(({ data }) => {
         dispatch(glossaryFetchDataSuccess(data));
         dispatch(glossaryIsLoading(false));
@@ -109,7 +109,7 @@ export function glossaryEditorFetchData(bypassLoading = false) {
     }
 
     api()
-      .get('/glossary/')
+      .get('/glossary/?limit=500')
       .then(({ data }) => {
         dispatch(glossaryEditorFetchDataSuccess(data));
         dispatch(glossaryEditorIsLoading(false));

--- a/src/actions/glossary.test.js
+++ b/src/actions/glossary.test.js
@@ -6,11 +6,11 @@ const { mockStore, mockAdapter } = setupAsyncMocks();
 
 describe('async actions', () => {
   beforeEach(() => {
-    mockAdapter.onGet('http://localhost:8000/api/v1/glossary/').reply(200,
+    mockAdapter.onGet('http://localhost:8000/api/v1/glossary/?limit=500').reply(200,
       { results: glossaryItems },
     );
 
-    mockAdapter.onGet('http://localhost:8000/api/v1/glossary/?is_archived=false').reply(200,
+    mockAdapter.onGet('http://localhost:8000/api/v1/glossary/?is_archived=false&limit=500').reply(200,
       { results: glossaryItems },
     );
 


### PR DESCRIPTION
Glossary terms were loading at the default limit of 100. This PR increases the limit.