### PR TITLE
Fork react-CSV and add ability to transform data

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "rc-steps": "^3.1.0",
     "react": "^15.6.2",
     "react-autosuggest": "^9.3.2",
-    "react-csv": "^1.1.1",
     "react-dom": "^15.6.2",
     "react-fontawesome": "^1.6.1",
     "react-helmet": "^5.2.0",
@@ -141,7 +140,8 @@
       "!src/Components/**/index.js",
       "!src/Components/StaticDevContent/*",
       "!src/actions/showStaticContent.js",
-      "!src/reducers/showStaticContent.js"
+      "!src/reducers/showStaticContent.js",
+      "!src/Components/CSV/**/*.{js,jsx}"
     ],
     "coverageReporters": [
       "text-summary",

--- a/src/Components/BidderPortfolio/ExportLink/ExportLink.jsx
+++ b/src/Components/BidderPortfolio/ExportLink/ExportLink.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
+import { get, mapValues } from 'lodash';
 import { CSVLink } from '../../CSV';
 import { bidderPortfolioFetchDataFromLastQuery } from '../../../actions/bidderPortfolio';
 import { EMPTY_FUNCTION } from '../../../Constants/PropTypes';
@@ -24,7 +24,7 @@ const HEADERS = [
 // Processes results before sending to the download component to allow for custom formatting.
 const processData = data => (
   data.map(entry => ({
-    ...entry,
+    ...mapValues(entry, x => !x ? '' : x), // eslint-disable-line no-confusing-arrow
     grade: getFormattedNumCSV(entry.grade),
     // any other processing we may want to do here
   }))

--- a/src/Components/BidderPortfolio/ExportLink/ExportLink.jsx
+++ b/src/Components/BidderPortfolio/ExportLink/ExportLink.jsx
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { CSVLink } from 'react-csv';
 import { get } from 'lodash';
+import { CSVLink } from '../../CSV';
 import { bidderPortfolioFetchDataFromLastQuery } from '../../../actions/bidderPortfolio';
 import { EMPTY_FUNCTION } from '../../../Constants/PropTypes';
 import ExportButton from '../../ExportButton';
+import { getFormattedNumCSV, spliceStringForCSV } from '../../../utilities';
 
 // Mapping columns to data fields
 const HEADERS = [
@@ -24,6 +25,7 @@ const HEADERS = [
 const processData = data => (
   data.map(entry => ({
     ...entry,
+    grade: getFormattedNumCSV(entry.grade),
     // any other processing we may want to do here
   }))
 );
@@ -74,7 +76,15 @@ export class ExportLink extends Component {
     return (
       <div className="export-button-container">
         <ExportButton onClick={this.onClick} isLoading={isLoading} />
-        <CSVLink tabIndex="-1" ref={this.setCsvRef} target="_blank" filename={this.props.filename} data={data} headers={HEADERS} />
+        <CSVLink
+          transform={spliceStringForCSV}
+          tabIndex="-1"
+          ref={this.setCsvRef}
+          target="_blank"
+          filename={this.props.filename}
+          data={data}
+          headers={HEADERS}
+        />
       </div>
     );
   }

--- a/src/Components/BidderPortfolio/ExportLink/__snapshots__/ExportLink.test.jsx.snap
+++ b/src/Components/BidderPortfolio/ExportLink/__snapshots__/ExportLink.test.jsx.snap
@@ -58,7 +58,7 @@ exports[`SearchResultsExportLink matches snapshot 1`] = `
     tabIndex="-1"
     target="_blank"
     transform={[Function]}
-    uFEFF={true}
+    uFEFF={false}
   />
 </div>
 `;

--- a/src/Components/BidderPortfolio/ExportLink/__snapshots__/ExportLink.test.jsx.snap
+++ b/src/Components/BidderPortfolio/ExportLink/__snapshots__/ExportLink.test.jsx.snap
@@ -57,6 +57,7 @@ exports[`SearchResultsExportLink matches snapshot 1`] = `
     separator=","
     tabIndex="-1"
     target="_blank"
+    transform={[Function]}
     uFEFF={true}
   />
 </div>

--- a/src/Components/CSV/components/Download.js
+++ b/src/Components/CSV/components/Download.js
@@ -1,0 +1,50 @@
+/* eslint-disable */
+import React from 'react';
+import {buildURI} from '../core';
+import {
+   defaultProps as commonDefaultProps,
+   propTypes as commonPropTypes} from '../metaProps';
+const defaultProps = {
+  target: '_blank'
+};
+
+/**
+ *
+ * @example ../../sample-site/csvdownload.example.md
+ */
+class CSVDownload extends React.Component {
+
+  static defaultProps = Object.assign(
+    commonDefaultProps,
+    defaultProps
+  );
+
+  static propTypes = commonPropTypes;
+
+  constructor(props) {
+    super(props);
+    this.state={};
+  }
+
+  buildURI() {
+    return buildURI(...arguments);
+  }
+
+  componentDidMount(){
+    const {data, headers, separator, enclosingCharacter, uFEFF, target, specs, replace, transform} = this.props;
+    this.state.page = window.open(
+        this.buildURI(data, uFEFF, headers, separator, enclosingCharacter), target, specs, replace, transform
+    );
+  }
+
+  getWindow() {
+    return this.state.page;
+  }
+
+  render(){
+    return (null)
+  }
+}
+
+export default CSVDownload;
+/* eslint-enable */

--- a/src/Components/CSV/components/Link.js
+++ b/src/Components/CSV/components/Link.js
@@ -1,0 +1,116 @@
+/* eslint-disable */
+import React from 'react';
+import { buildURI, toCSV } from '../core';
+import {
+  defaultProps as commonDefaultProps,
+  propTypes as commonPropTypes
+} from '../metaProps';
+
+/**
+ *
+ * @example ../../sample-site/csvlink.example.md
+ */
+class CSVLink extends React.Component {
+  static defaultProps = commonDefaultProps;
+  static propTypes = commonPropTypes;
+
+  constructor(props) {
+    super(props);
+    this.buildURI = this.buildURI.bind(this);
+    this.state = { href: '' };
+  }
+
+  componentDidMount() {
+    const {data, headers, separator, uFEFF, enclosingCharacter, transform} = this.props;
+    this.setState({ href: this.buildURI(data, uFEFF, headers, separator, enclosingCharacter, transform) });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { data, headers, separator, transform, uFEFF, enclosingCharacter } = nextProps;
+    this.setState({ href: this.buildURI(data, uFEFF, headers, separator, enclosingCharacter, transform) });
+  }
+
+  buildURI() {
+    return buildURI(...arguments);
+  }
+
+  /**
+   * In IE11 this method will trigger the file download
+   */
+  handleLegacy(event, data, headers, separator, filename, enclosingCharacter, transform) {
+    // If this browser is IE 11, it does not support the `download` attribute
+    if (window.navigator.msSaveOrOpenBlob) {
+      // Stop the click propagation
+      event.preventDefault();
+
+      let blob = new Blob([toCSV(data, headers, separator, enclosingCharacter, transform)]);
+      window.navigator.msSaveBlob(blob, filename);
+
+      return false;
+    }
+  }
+
+  handleAsyncClick(event, ...args) {
+    const done = proceed => {
+      if (proceed === false) {
+        event.preventDefault();
+        return;
+      }
+      this.handleLegacy(event, ...args);
+    };
+
+    this.props.onClick(event, done);
+  }
+
+  handleSyncClick(event, ...args) {
+    const stopEvent = this.props.onClick(event) === false;
+    if (stopEvent) {
+      event.preventDefault();
+      return;
+    }
+    this.handleLegacy(event, ...args);
+  }
+
+  handleClick(...args) {
+    return event => {
+      if (typeof this.props.onClick === 'function') {
+        return this.props.asyncOnClick
+          ? this.handleAsyncClick(event, ...args)
+          : this.handleSyncClick(event, ...args);
+      }
+      this.handleLegacy(event, ...args);
+    };
+  }
+
+  render() {
+    const {
+      data,
+      headers,
+      separator,
+      filename,
+      uFEFF,
+      children,
+      onClick,
+      asyncOnClick,
+      enclosingCharacter,
+      transform,
+      ...rest
+    } = this.props;
+
+    return (
+      <a
+        download={filename}
+        {...rest}
+        ref={link => (this.link = link)}
+        target="_self"
+        href={this.state.href}
+        onClick={this.handleClick(data, headers, separator, filename, enclosingCharacter, transform)}
+      >
+        {children}
+      </a>
+    );
+  }
+}
+
+export default CSVLink;
+/* eslint-enable */

--- a/src/Components/CSV/core.js
+++ b/src/Components/CSV/core.js
@@ -1,0 +1,98 @@
+/* eslint-disable */
+/**
+ * Simple safari detection based on user agent test
+ */
+export const isSafari = () => /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
+const returnVal = v => v;
+
+export const isJsons = ((array) => Array.isArray(array) && array.every(
+ row => (typeof row === 'object' && !(row instanceof Array))
+));
+
+export const isArrays = ((array) => Array.isArray(array) && array.every(
+ row => Array.isArray(row)
+));
+
+export const jsonsHeaders = ((array) => Array.from(
+ array.map(json => Object.keys(json))
+ .reduce((a, b) => new Set([...a, ...b]), [])
+));
+
+export const jsons2arrays = (jsons, headers) => {
+  headers = headers || jsonsHeaders(jsons);
+
+  // allow headers to have custom labels, defaulting to having the header data key be the label
+  let headerLabels = headers;
+  let headerKeys = headers;
+  if (isJsons(headers)) {
+    headerLabels = headers.map((header) => header.label);
+    headerKeys = headers.map((header) => header.key);
+  }
+
+  const data = jsons.map((object) => headerKeys.map((header) => getHeaderValue(header, object)));
+  return [headerLabels, ...data];
+};
+
+export const getHeaderValue = (property, obj) => {
+  const foundValue = property
+    .replace(/\[([^\]]+)]/g, ".$1")
+    .split(".")
+    .reduce(function(o, p, i, arr) {
+      // if at any point the nested keys passed do not exist, splice the array so it doesnt keep reducing
+      if (o[p] === undefined) {
+        arr.splice(1);
+      } else {
+        return o[p];
+      }
+    }, obj);
+
+  return (foundValue === undefined) ? '' : foundValue;
+}
+
+export const elementOrEmpty = (element) => element || element === 0 ? element : '';
+
+export const joiner = ((data, separator = ',', enclosingCharacter = '"', transform = returnVal) => {
+  return data
+    .filter(e => e)
+    .map(
+      row => row
+        .map((element) => elementOrEmpty(element))
+        .map(column => transform(`${enclosingCharacter}${column}${enclosingCharacter}`))
+        .join(separator)
+    )
+    .join(`\n`);
+});
+
+export const arrays2csv = ((data, headers, separator, enclosingCharacter, transform = returnVal) =>
+ joiner(headers ? [headers, ...data] : data, separator, enclosingCharacter, transform)
+);
+
+export const jsons2csv = ((data, headers, separator, enclosingCharacter, transform = returnVal) =>
+ joiner(jsons2arrays(data, headers), separator, enclosingCharacter, transform)
+);
+
+export const string2csv = ((data, headers, separator, enclosingCharacter) =>
+  (headers) ? `${headers.join(separator)}\n${data}`: data
+);
+
+export const toCSV = (data, headers, separator, enclosingCharacter, transform = returnVal) => {
+ if (isJsons(data)) return jsons2csv(data, headers, separator, enclosingCharacter, transform);
+ if (isArrays(data)) return arrays2csv(data, headers, separator, enclosingCharacter, transform);
+ if (typeof data ==='string') return string2csv(data, headers, separator);
+ throw new TypeError(`Data should be a "String", "Array of arrays" OR "Array of objects" `);
+};
+
+export const buildURI = ((data, uFEFF, headers, separator, enclosingCharacter, transform = returnVal) => {
+  const csv = toCSV(data, headers, separator, enclosingCharacter, transform);
+  const type = isSafari() ? 'application/csv' : 'text/csv';
+  const blob = new Blob([uFEFF ? '\uFEFF' : '', csv], {type});
+  const dataURI = `data:${type};charset=utf-8,${uFEFF ? '\uFEFF' : ''}${csv}`;
+
+  const URL = window.URL || window.webkitURL;
+
+  return (typeof URL.createObjectURL === 'undefined')
+    ? dataURI
+    : URL.createObjectURL(blob);
+});
+/* eslint-enable */

--- a/src/Components/CSV/index.js
+++ b/src/Components/CSV/index.js
@@ -1,0 +1,5 @@
+import Download from './components/Download';
+import Link from './components/Link';
+
+export const CSVDownload = Download;
+export const CSVLink = Link;

--- a/src/Components/CSV/metaProps.js
+++ b/src/Components/CSV/metaProps.js
@@ -1,0 +1,39 @@
+/* eslint-disable */
+import React from 'react';
+import { string, array, oneOfType, bool, func } from 'prop-types';
+
+
+export const propTypes = {
+  data: oneOfType([string, array]).isRequired,
+  headers: array,
+  target: string,
+  separator: string,
+  filename: string,
+  uFEFF: bool,
+  onClick: func,
+  asyncOnClick: bool,
+  transform: func
+};
+
+export const defaultProps = {
+  separator: ',',
+  filename: 'generatedBy_react-csv.csv',
+  uFEFF: true,
+  asyncOnClick: false,
+  transform: v => v,
+};
+
+export const PropsNotForwarded = [
+  `data`,
+  `headers`
+];
+
+// export const DownloadPropTypes = Object.assign(
+//   {},
+//   PropTypes,
+//   {
+//     : ,
+//   }
+// );
+
+/* eslint-enable */

--- a/src/Components/CSV/readme.md
+++ b/src/Components/CSV/readme.md
@@ -1,0 +1,3 @@
+Fork of react-csv
+
+Waiting for https://github.com/react-csv/react-csv/pull/155 to be approved and merged. Once done, revert to the node module and delete this folder.

--- a/src/Components/SearchResultsExportLink/SearchResultsExportLink.jsx
+++ b/src/Components/SearchResultsExportLink/SearchResultsExportLink.jsx
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
-import { CSVLink } from 'react-csv';
 import queryString from 'query-string';
+import { CSVLink } from '../CSV';
 import { POSITION_SEARCH_SORTS } from '../../Constants/Sort';
 import { fetchResultData } from '../../actions/results';
-import { formatDate } from '../../utilities';
+import { formatDate, getFormattedNumCSV, spliceStringForCSV } from '../../utilities';
 import ExportButton from '../ExportButton';
 
 // Mapping columns to data fields
@@ -32,6 +32,8 @@ export const processData = data => (
     const formattedEndDate = endDate ? formatDate(endDate) : null;
     return {
       ...entry,
+      position_number: getFormattedNumCSV(entry.position_number),
+      grade: getFormattedNumCSV(entry.grade),
       estimated_end_date: formattedEndDate,
     };
   })
@@ -88,6 +90,7 @@ class SearchResultsExportLink extends Component {
         <ExportButton onClick={this.onClick} isLoading={isLoading} />
         <CSVLink
           tabIndex="-1"
+          transform={spliceStringForCSV}
           ref={(x) => { this.csvLink = x; }}
           target="_blank"
           filename={this.props.filename}

--- a/src/Components/SearchResultsExportLink/SearchResultsExportLink.jsx
+++ b/src/Components/SearchResultsExportLink/SearchResultsExportLink.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { get } from 'lodash';
+import { get, mapValues } from 'lodash';
 import queryString from 'query-string';
 import { CSVLink } from '../CSV';
 import { POSITION_SEARCH_SORTS } from '../../Constants/Sort';
@@ -31,7 +31,7 @@ export const processData = data => (
     const endDate = get(entry, 'current_assignment.estimated_end_date');
     const formattedEndDate = endDate ? formatDate(endDate) : null;
     return {
-      ...entry,
+      ...mapValues(entry, x => !x ? '' : x), // eslint-disable-line no-confusing-arrow
       position_number: getFormattedNumCSV(entry.position_number),
       grade: getFormattedNumCSV(entry.grade),
       estimated_end_date: formattedEndDate,

--- a/src/Components/SearchResultsExportLink/SearchResultsExportLink.test.jsx
+++ b/src/Components/SearchResultsExportLink/SearchResultsExportLink.test.jsx
@@ -45,12 +45,12 @@ describe('SearchResultsExportLink', () => {
   it('processes data correctly', () => {
     const data = [{ a: 1, b: 2, current_assignment: { estimated_end_date: '2019-01-08T00:00:00Z' } }];
     const output = processData(data);
-    expect(output).toEqual([
+    expect(output[0]).toMatchObject(
       { a: 1,
         b: 2,
         current_assignment: { estimated_end_date: '2019-01-08T00:00:00Z' },
         estimated_end_date: '01/07/2019' },
-    ]);
+    );
   });
 
   it('matches snapshot', () => {

--- a/src/Components/SearchResultsExportLink/__snapshots__/SearchResultsExportLink.test.jsx.snap
+++ b/src/Components/SearchResultsExportLink/__snapshots__/SearchResultsExportLink.test.jsx.snap
@@ -73,6 +73,7 @@ exports[`SearchResultsExportLink matches snapshot 1`] = `
     separator=","
     tabIndex="-1"
     target="_blank"
+    transform={[Function]}
     uFEFF={true}
   />
 </div>

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -547,3 +547,13 @@ export const getScrollDistanceFromBottom = () => {
   const bodyHeight = document.body.offsetHeight;
   return (Math.max(bodyHeight - (scrollPosition + windowSize), 0));
 };
+
+// eslint-disable-next-line no-confusing-arrow
+export const getFormattedNumCSV = v => !isNaN(v) ? `=${v}` : v;
+
+export const spliceStringForCSV = (v) => {
+  if (v[1] === '=') {
+    return `=${v.slice(0, 1)}${v.slice(2)}`;
+  }
+  return v;
+};

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -567,7 +567,13 @@ export const getScrollDistanceFromBottom = () => {
 };
 
 // eslint-disable-next-line no-confusing-arrow
-export const getFormattedNumCSV = v => !isNaN(v) ? `=${v}` : v;
+export const getFormattedNumCSV = (v) => {
+  if (v === null || v === undefined) {
+    return '';
+  }
+  // else
+  return !isNaN(v) ? `=${v}` : v;
+};
 
 export const spliceStringForCSV = (v) => {
   if (v[1] === '=') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8550,11 +8550,6 @@ react-autowhatever@^10.1.0:
     react-themeable "^1.1.0"
     section-iterator "^2.0.0"
 
-react-csv@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/react-csv/-/react-csv-1.1.1.tgz#718dadd2607a1795bfc8dbd32ca282a043739634"
-  integrity sha512-eQSrkEfzPN+1IeXT58kJaDNmpFr3RhdjfE09jTrw+jdTEp0g0Ig9NOI+TpvMBbCukE1HQhOf4dyrLDRFKgZzbA==
-
 react-dev-utils@^3.1.0, react-dev-utils@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-3.1.1.tgz#09ae7209a81384248db56547e718e65bd3b20eb5"


### PR DESCRIPTION
Forks the react-csv library and adds the ability to transform data before its turned into a CSV. This gives us the ability to add an `=` sign before numbers in order to force Excel to treat them as strings. I've opened PR with the library, so once/if that is merged, we can pull the react-csv library back in.