### PR TITLE
Update/bidder portfolio pagination

### DIFF
--- a/config/jest/setupTests.js
+++ b/config/jest/setupTests.js
@@ -24,7 +24,10 @@ Object.values = (obj) => Object.keys(obj).map(key => obj[key])
 // Avoid jest error: "Error: Not implemented: navigation (except hash changes)"
 global.window.location.assign = () => {};
 
-// mock sessionStorage - feature flags config
 beforeEach(() => {
+  // mock sessionStorage - feature flags config
   sessionStorage.setItem('config', JSON.stringify(config));
+
+  // mock querySelector
+  global.document.querySelector = () => ({ offsetParent: '50px', scrollIntoView: () => {} });
 });

--- a/src/Components/BidderPortfolio/BidderPortfolioContainer/BidderPortfolioContainer.jsx
+++ b/src/Components/BidderPortfolio/BidderPortfolioContainer/BidderPortfolioContainer.jsx
@@ -1,11 +1,13 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { BIDDER_LIST } from '../../../Constants/PropTypes';
-import { scrollToTop } from '../../../utilities';
+import { scrollToId } from '../../../utilities';
 import BidderPortfolioCardList from '../BidderPortfolioCardList';
 import BidderPortfolioGridList from '../BidderPortfolioGridList';
 import PaginationWrapper from '../../PaginationWrapper/PaginationWrapper';
 import Alert from '../../Alert/Alert';
+
+const ID = 'bidder-portfolio-container';
 
 class BidderPortfolioContainer extends Component {
   constructor(props) {
@@ -13,14 +15,16 @@ class BidderPortfolioContainer extends Component {
     this.onPageChange = this.onPageChange.bind(this);
   }
   onPageChange(q) {
-    scrollToTop();
-    this.props.queryParamUpdate(q);
+    scrollToId({ el: '.bidder-portfolio-container', config: { duration: 400 } });
+    setTimeout(() => {
+      this.props.queryParamUpdate(q);
+    }, 600);
   }
   render() {
     const { bidderPortfolio, pageSize, pageNumber, showListView, showEdit } = this.props;
     const noResults = bidderPortfolio.results.length === 0;
     return (
-      <div className="usa-grid-full user-dashboard">
+      <div className="usa-grid-full user-dashboard" id={ID}>
         {
           showListView ?
             <BidderPortfolioGridList showEdit={showEdit} results={bidderPortfolio.results} />

--- a/src/Components/BidderPortfolio/BidderPortfolioContainer/BidderPortfolioContainer.test.jsx
+++ b/src/Components/BidderPortfolio/BidderPortfolioContainer/BidderPortfolioContainer.test.jsx
@@ -16,7 +16,7 @@ describe('BidderPortfolioContainerComponent', () => {
     expect(wrapper).toBeDefined();
   });
 
-  it('can call the onPageChange function', () => {
+  it('can call the onPageChange function', (done) => {
     const spy = sinon.spy();
     const wrapper = shallow(<BidderPortfolioContainer
       bidderPortfolio={bidderListObject}
@@ -25,7 +25,10 @@ describe('BidderPortfolioContainerComponent', () => {
       queryParamUpdate={spy}
     />);
     wrapper.instance().onPageChange({});
-    sinon.assert.calledOnce(spy);
+    setTimeout(() => {
+      sinon.assert.calledOnce(spy);
+      done();
+    }, 700);
   });
 
   it('matches snapshot when the all property is greater than zero', () => {

--- a/src/Components/BidderPortfolio/BidderPortfolioContainer/__snapshots__/BidderPortfolioContainer.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidderPortfolioContainer/__snapshots__/BidderPortfolioContainer.test.jsx.snap
@@ -3,6 +3,7 @@
 exports[`BidderPortfolioContainerComponent matches snapshot when the all property is greater than zero 1`] = `
 <div
   className="usa-grid-full user-dashboard"
+  id="bidder-portfolio-container"
 >
   <BidderPortfolioCardList
     results={
@@ -223,6 +224,7 @@ exports[`BidderPortfolioContainerComponent matches snapshot when the all propert
 exports[`BidderPortfolioContainerComponent matches snapshot when the all property is zero 1`] = `
 <div
   className="usa-grid-full user-dashboard"
+  id="bidder-portfolio-container"
 >
   <BidderPortfolioCardList
     results={Array []}

--- a/src/Containers/BidTracker/BidTracker.test.jsx
+++ b/src/Containers/BidTracker/BidTracker.test.jsx
@@ -41,7 +41,8 @@ describe('BidTracker', () => {
     />);
     const spy = sinon.spy(wrapper.instance(), 'scrollToId');
     wrapper.instance().componentDidUpdate();
-    sinon.assert.calledOnce(spy);
+    // called once on mount, once after didUpdate()
+    sinon.assert.calledTwice(spy);
   });
 
   it('calls scrollIntoView when scrollToId is called', () => {

--- a/src/Containers/BidderPortfolio/BidderPortfolio.jsx
+++ b/src/Containers/BidderPortfolio/BidderPortfolio.jsx
@@ -16,7 +16,7 @@ class BidderPortfolio extends Component {
     this.state = {
       key: 0,
       query: { value: window.location.search.replace('?', '') || '' },
-      defaultPageSize: { value: 8 },
+      defaultPageSize: { value: 24 },
       defaultPageNumber: { value: 1 },
       defaultKeyword: { value: '' },
     };

--- a/src/Containers/queryParams.js
+++ b/src/Containers/queryParams.js
@@ -1,5 +1,5 @@
 import queryString from 'query-string';
-import { toString } from 'lodash';
+import { get } from 'lodash';
 
 // when we need to update an existing query string with properties from an object
 function queryParamUpdate(newQueryObject, oldQueryString, returnAsObject = false) {
@@ -16,7 +16,8 @@ function queryParamUpdate(newQueryObject, oldQueryString, returnAsObject = false
   const newQuery = Object.assign({}, parsedQuery, newQueryObject);
   // remove any params with no value
   Object.keys(newQuery).forEach((key) => {
-    if (!(toString(newQuery[key]) && toString(newQuery[key]).length)) {
+    const newQuery$ = get(newQuery, key) || '';
+    if (!(newQuery$.toString().length)) {
       delete newQuery[key];
     }
   });

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -167,6 +167,24 @@ export const scrollToTop = (config = {}) => {
   scroll.scrollToTop({ ...defaultScrollConfig, ...config });
 };
 
+export const scrollToId = ({ el, config = {} }) => {
+  // Get an element's distance from the top of the page
+  const getElemDistance = (elem) => {
+    let location = 0;
+    if (elem.offsetParent) {
+      do {
+        location += elem.offsetTop;
+        elem = elem.offsetParent; // eslint-disable-line
+      } while (elem);
+    }
+    return location >= 0 ? location : 0;
+  };
+  const elem = document.querySelector(el);
+  const location = getElemDistance(elem);
+
+  scrollTo(location, config);
+};
+
 // When we want to grab a label, but aren't sure which one exists.
 // We set custom ones first in the list.
 export const getItemLabel = itemData =>


### PR DESCRIPTION
Relies on #187 

Bidder Portfolio:
- Updates page size to 24 (works well with our grid)
- Updates scroll behavior on page change, so that the user is scrolled to the content, not the very top of the page