### PR TITLE
Add link to Saved Search success message

### DIFF
--- a/src/Components/SavedSearchMessages/Success.jsx
+++ b/src/Components/SavedSearchMessages/Success.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+
+const Success = ({ name, isUpdated }) => {
+  let prefix = 'New';
+  let suffix = 'saved';
+  if (isUpdated) {
+    prefix = 'Your saved';
+    suffix = 'updated';
+  }
+  return (
+    <span>{prefix} search with the name {name} has been {suffix}! <Link to="/profile/searches/">Go to Saved Searches</Link>.</span>
+  );
+};
+
+Success.propTypes = {
+  name: PropTypes.string.isRequired,
+  isUpdated: PropTypes.bool,
+};
+
+Success.defaultProps = {
+  isUpdated: false,
+};
+
+export default Success;

--- a/src/Components/SavedSearchMessages/Success.test.jsx
+++ b/src/Components/SavedSearchMessages/Success.test.jsx
@@ -1,0 +1,15 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import Success from './Success';
+
+describe('Success', () => {
+  it('is defined', () => {
+    const wrapper = shallow(<Success name="Test Search" />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('is defined when isUpdated is true', () => {
+    const wrapper = shallow(<Success name="Test Search" isUpdated />);
+    expect(wrapper).toBeDefined();
+  });
+});

--- a/src/Constants/SystemMessages.js
+++ b/src/Constants/SystemMessages.js
@@ -1,5 +1,6 @@
 import FavoriteSuccess from '../Components/FavoriteMessages/Success';
 import BidAddSuccess from '../Components/BidListMessages/Success';
+import SavedSearchSuccess from '../Components/SavedSearchMessages/Success';
 
 export const DEFAULT_TEXT = 'None listed';
 
@@ -58,10 +59,8 @@ export const SUBMIT_BID_ERROR = 'Error trying to submit this bid.';
 export const NEW_SAVED_SEARCH_SUCCESS_TITLE = 'Success';
 export const UPDATED_SAVED_SEARCH_SUCCESS_TITLE = 'Saved search updated';
 
-export const NEW_SAVED_SEARCH_SUCCESS = name =>
-  `New search with the name "${name}" has been saved! You can go to your profile to view all of your saved searches.`;
-export const UPDATED_SAVED_SEARCH_SUCCESS = name =>
-  `Your saved search with the name "${name}" has been updated! You can go to your profile to view all of your saved searches.`;
+export const NEW_SAVED_SEARCH_SUCCESS = name => SavedSearchSuccess({ name });
+export const UPDATED_SAVED_SEARCH_SUCCESS = name => SavedSearchSuccess({ name, isUpdated: true });
 
 export const CANNOT_BID_SUFFIX = ', but can be favorited for the future.';
 export const CANNOT_BID_DEFAULT = `This position is not available to bid on${CANNOT_BID_SUFFIX}`;

--- a/src/Constants/SystemMessages.test.js
+++ b/src/Constants/SystemMessages.test.js
@@ -53,14 +53,13 @@ describe('SystemMessages', () => {
   });
 
   it('should have all expected messages that accept parameters defined', () => {
-    const textToCheck = 'test_word';
     const messages = [
       'UPDATED_SAVED_SEARCH_SUCCESS',
       'NEW_SAVED_SEARCH_SUCCESS',
     ];
 
     messages.forEach((message) => {
-      expect(SystemMessages[message](textToCheck).indexOf(textToCheck)).toBeDefined();
+      expect(SystemMessages[message]('name')).toBeDefined();
     });
   });
 


### PR DESCRIPTION
Completes TM-762 by updating the new/updated saved search message to include a link to the user's saved searches.