### PR TITLE
fix: Make Glossary Editor header color readable

### DIFF
--- a/src/sass/_glossaryEditor.scss
+++ b/src/sass/_glossaryEditor.scss
@@ -1,4 +1,8 @@
 .glossary-editor-page {
+  h2 {
+    color: initial;
+  }
+
   .hello-greeting {
     float: left;
   }


### PR DESCRIPTION
Header was white against gray background. Changed text to black to make it visible.