### PR TITLE
CSV Export - set uFEFF to false

### DIFF
--- a/src/Components/BidderPortfolio/ExportLink/ExportLink.jsx
+++ b/src/Components/BidderPortfolio/ExportLink/ExportLink.jsx
@@ -74,7 +74,15 @@ export class ExportLink extends Component {
     return (
       <div className="export-button-container">
         <ExportButton onClick={this.onClick} isLoading={isLoading} />
-        <CSVLink tabIndex="-1" ref={this.setCsvRef} target="_blank" filename={this.props.filename} data={data} headers={HEADERS} />
+        <CSVLink
+          tabIndex="-1"
+          ref={this.setCsvRef}
+          target="_blank"
+          filename={this.props.filename}
+          data={data}
+          headers={HEADERS}
+          uFEFF={false}
+        />
       </div>
     );
   }

--- a/src/Components/BidderPortfolio/ExportLink/__snapshots__/ExportLink.test.jsx.snap
+++ b/src/Components/BidderPortfolio/ExportLink/__snapshots__/ExportLink.test.jsx.snap
@@ -57,7 +57,7 @@ exports[`SearchResultsExportLink matches snapshot 1`] = `
     separator=","
     tabIndex="-1"
     target="_blank"
-    uFEFF={true}
+    uFEFF={false}
   />
 </div>
 `;

--- a/src/Components/PositionDetailsItem/PositionDetailsItem.jsx
+++ b/src/Components/PositionDetailsItem/PositionDetailsItem.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import { Flag } from 'flag';
+import { COMMON_PROPERTIES } from '../../Constants/EndpointParams';
 import LanguageList from '../../Components/LanguageList/LanguageList';
 import CondensedCardDataPoint from '../CondensedCardData/CondensedCardDataPoint';
 import OBCUrl from '../OBCUrl';
@@ -33,6 +34,7 @@ import {
   NO_POST_DIFFERENTIAL,
   NO_DANGER_PAY,
   NO_USER_LISTED,
+  NO_UPDATE_DATE,
 } from '../../Constants/SystemMessages';
 
 export const renderHandshake = stats => (
@@ -76,6 +78,15 @@ const PositionDetailsItem = (props) => {
 
   const incumbent = propOrDefault(details, 'current_assignment.user', NO_USER_LISTED);
 
+  const getPostedDate = () => {
+    const posted = get(details, COMMON_PROPERTIES.posted);
+    if (posted) {
+      return formatDate(posted);
+    }
+    return NO_UPDATE_DATE;
+  };
+  const postedDate = getPostedDate();
+
   const stats = getBidStatisticsObject(details.bid_statistics);
   return (
     <div className="usa-grid-full padded-main-content position-details-outer-container">
@@ -102,6 +113,7 @@ const PositionDetailsItem = (props) => {
             <CondensedCardDataPoint title="Danger pay" content={getFormattedObcData(dangerPay)} />
             <CondensedCardDataPoint title="TED" content={formattedTourEndDate} />
             <CondensedCardDataPoint title="Incumbent" content={incumbent} />
+            <CondensedCardDataPoint title="Posted" content={postedDate} />
           </div>
         </div>
         <div className="usa-width-one-third position-details-contact-container">

--- a/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
+++ b/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
@@ -111,6 +111,11 @@ exports[`PositionDetailsItem matches snapshot 1`] = `
           hasFixedTitleWidth={false}
           title="Incumbent"
         />
+        <CondensedCardDataPoint
+          content="Unknown"
+          hasFixedTitleWidth={false}
+          title="Posted"
+        />
       </div>
     </div>
     <div
@@ -334,6 +339,11 @@ exports[`PositionDetailsItem matches snapshot when there is an obc id 1`] = `
           hasFixedTitleWidth={false}
           title="Incumbent"
         />
+        <CondensedCardDataPoint
+          content="Unknown"
+          hasFixedTitleWidth={false}
+          title="Posted"
+        />
       </div>
     </div>
     <div
@@ -535,6 +545,11 @@ exports[`PositionDetailsItem matches snapshot when various data is missing from 
           content="None listed"
           hasFixedTitleWidth={false}
           title="Incumbent"
+        />
+        <CondensedCardDataPoint
+          content="Unknown"
+          hasFixedTitleWidth={false}
+          title="Posted"
         />
       </div>
     </div>

--- a/src/Components/SearchResultsExportLink/SearchResultsExportLink.jsx
+++ b/src/Components/SearchResultsExportLink/SearchResultsExportLink.jsx
@@ -93,6 +93,7 @@ class SearchResultsExportLink extends Component {
           filename={this.props.filename}
           data={data}
           headers={HEADERS}
+          uFEFF={false}
         />
       </div>
     );

--- a/src/Components/SearchResultsExportLink/__snapshots__/SearchResultsExportLink.test.jsx.snap
+++ b/src/Components/SearchResultsExportLink/__snapshots__/SearchResultsExportLink.test.jsx.snap
@@ -73,7 +73,7 @@ exports[`SearchResultsExportLink matches snapshot 1`] = `
     separator=","
     tabIndex="-1"
     target="_blank"
-    uFEFF={true}
+    uFEFF={false}
   />
 </div>
 `;


### PR DESCRIPTION
Resolves an issue where the default Save As file format in Excel was Unicode Text (.txt) instead of .csv when re-saving the exported CSV.