### PR TITLE
CSV Export - set uFEFF to false

### DIFF
--- a/src/Components/BidderPortfolio/ExportLink/ExportLink.jsx
+++ b/src/Components/BidderPortfolio/ExportLink/ExportLink.jsx
@@ -74,7 +74,15 @@ export class ExportLink extends Component {
     return (
       <div className="export-button-container">
         <ExportButton onClick={this.onClick} isLoading={isLoading} />
-        <CSVLink tabIndex="-1" ref={this.setCsvRef} target="_blank" filename={this.props.filename} data={data} headers={HEADERS} />
+        <CSVLink
+          tabIndex="-1"
+          ref={this.setCsvRef}
+          target="_blank"
+          filename={this.props.filename}
+          data={data}
+          headers={HEADERS}
+          uFEFF={false}
+        />
       </div>
     );
   }

--- a/src/Components/BidderPortfolio/ExportLink/__snapshots__/ExportLink.test.jsx.snap
+++ b/src/Components/BidderPortfolio/ExportLink/__snapshots__/ExportLink.test.jsx.snap
@@ -57,7 +57,7 @@ exports[`SearchResultsExportLink matches snapshot 1`] = `
     separator=","
     tabIndex="-1"
     target="_blank"
-    uFEFF={true}
+    uFEFF={false}
   />
 </div>
 `;

--- a/src/Components/SearchResultsExportLink/SearchResultsExportLink.jsx
+++ b/src/Components/SearchResultsExportLink/SearchResultsExportLink.jsx
@@ -93,6 +93,7 @@ class SearchResultsExportLink extends Component {
           filename={this.props.filename}
           data={data}
           headers={HEADERS}
+          uFEFF={false}
         />
       </div>
     );

--- a/src/Components/SearchResultsExportLink/__snapshots__/SearchResultsExportLink.test.jsx.snap
+++ b/src/Components/SearchResultsExportLink/__snapshots__/SearchResultsExportLink.test.jsx.snap
@@ -73,7 +73,7 @@ exports[`SearchResultsExportLink matches snapshot 1`] = `
     separator=","
     tabIndex="-1"
     target="_blank"
-    uFEFF={true}
+    uFEFF={false}
   />
 </div>
 `;


### PR DESCRIPTION
Resolves an issue where the default Save As file format in Excel was Unicode Text (.txt) instead of .csv when re-saving the exported CSV.