### PR TITLE
fix: Error-free exporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "draft-js-plugins-editor": "^2.0.4",
     "express": "^4.16.2",
     "flag": "^3.0.0-1",
+    "flat": "^4.1.0",
     "font-awesome": "^4.7.0",
     "helmet": "^3.12.0",
     "history": "^4.7.2",

--- a/src/Components/SearchResultsExportLink/SearchResultsExportLink.jsx
+++ b/src/Components/SearchResultsExportLink/SearchResultsExportLink.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { get, mapValues } from 'lodash';
 import queryString from 'query-string';
+import flatten from 'flat';
 import { CSVLink } from '../CSV';
 import { POSITION_SEARCH_SORTS } from '../../Constants/Sort';
 import { fetchResultData } from '../../actions/results';
@@ -9,29 +10,32 @@ import { formatDate, getFormattedNumCSV, spliceStringForCSV } from '../../utilit
 import ExportButton from '../ExportButton';
 
 // Mapping columns to data fields
+// Use custom delimiter of flattened data
 const HEADERS = [
   { label: 'Position', key: 'title' },
   { label: 'Position number', key: 'position_number' },
   { label: 'Skill', key: 'skill' },
   { label: 'Grade', key: 'grade' },
   { label: 'Bureau', key: 'bureau' },
-  { label: 'Post city', key: 'post.location.city' },
-  { label: 'Post country', key: 'post.location.country' },
-  { label: 'Tour of duty', key: 'post.tour_of_duty' },
-  { label: 'Language', key: 'languages[0].representation' },
-  { label: 'Post differential', key: 'post.differential_rate' },
-  { label: 'Danger pay', key: 'post.danger_pay' },
+  { label: 'Post city', key: 'post__location.city' },
+  { label: 'Post country', key: 'post__location__country' },
+  { label: 'Tour of duty', key: 'post__tour_of_duty' },
+  { label: 'Language', key: 'languages__0__representation' },
+  { label: 'Post differential', key: 'post__differential_rate' },
+  { label: 'Danger pay', key: 'post__danger_pay' },
   { label: 'TED', key: 'estimated_end_date' },
-  { label: 'Incumbent', key: 'current_assignment.user' },
+  { label: 'Incumbent', key: 'current_assignment__user' },
 ];
 
 // Processes results before sending to the download component to allow for custom formatting.
+// Flatten data with custom delimiter.
 export const processData = data => (
   data.map((entry) => {
-    const endDate = get(entry, 'current_assignment.estimated_end_date');
+    const entry$ = flatten({ ...entry }, { delimiter: '__' });
+    const endDate = get(entry$, 'current_assignment__estimated_end_date');
     const formattedEndDate = endDate ? formatDate(endDate) : null;
     return {
-      ...mapValues(entry, x => !x ? '' : x), // eslint-disable-line no-confusing-arrow
+      ...mapValues(entry$, x => !x ? '' : x), // eslint-disable-line no-confusing-arrow
       position_number: getFormattedNumCSV(entry.position_number),
       grade: getFormattedNumCSV(entry.grade),
       estimated_end_date: formattedEndDate,
@@ -67,6 +71,7 @@ class SearchResultsExportLink extends Component {
         ordering: POSITION_SEARCH_SORTS.defaultSort,
         ...queryString.parse(this.state.query.value),
         limit: this.props.count,
+        page: 1,
       };
       fetchResultData(queryString.stringify(query))
       .then((results) => {

--- a/src/Components/SearchResultsExportLink/SearchResultsExportLink.test.jsx
+++ b/src/Components/SearchResultsExportLink/SearchResultsExportLink.test.jsx
@@ -48,7 +48,7 @@ describe('SearchResultsExportLink', () => {
     expect(output[0]).toMatchObject(
       { a: 1,
         b: 2,
-        current_assignment: { estimated_end_date: '2019-01-08T00:00:00Z' },
+        current_assignment__estimated_end_date: '2019-01-08T00:00:00Z',
         estimated_end_date: '01/07/2019' },
     );
   });

--- a/src/Components/SearchResultsExportLink/__snapshots__/SearchResultsExportLink.test.jsx.snap
+++ b/src/Components/SearchResultsExportLink/__snapshots__/SearchResultsExportLink.test.jsx.snap
@@ -37,27 +37,27 @@ exports[`SearchResultsExportLink matches snapshot 1`] = `
           "label": "Bureau",
         },
         Object {
-          "key": "post.location.city",
+          "key": "post__location.city",
           "label": "Post city",
         },
         Object {
-          "key": "post.location.country",
+          "key": "post__location__country",
           "label": "Post country",
         },
         Object {
-          "key": "post.tour_of_duty",
+          "key": "post__tour_of_duty",
           "label": "Tour of duty",
         },
         Object {
-          "key": "languages[0].representation",
+          "key": "languages__0__representation",
           "label": "Language",
         },
         Object {
-          "key": "post.differential_rate",
+          "key": "post__differential_rate",
           "label": "Post differential",
         },
         Object {
-          "key": "post.danger_pay",
+          "key": "post__danger_pay",
           "label": "Danger pay",
         },
         Object {
@@ -65,7 +65,7 @@ exports[`SearchResultsExportLink matches snapshot 1`] = `
           "label": "TED",
         },
         Object {
-          "key": "current_assignment.user",
+          "key": "current_assignment__user",
           "label": "Incumbent",
         },
       ]

--- a/src/reducers/bidderPortfolio/bidderPortfolio.js
+++ b/src/reducers/bidderPortfolio/bidderPortfolio.js
@@ -81,6 +81,7 @@ export function bidderPortfolioLastQuery(state = '/client/', action) {
       const base = '/client/';
       const q = queryString.parse(action.query);
       q.limit = action.count;
+      q.page = 1;
       const stringified = queryString.stringify(q);
       const newState = `${base}?${stringified}`;
       return newState;

--- a/src/reducers/bidderPortfolio/bidderPortfolio.test.js
+++ b/src/reducers/bidderPortfolio/bidderPortfolio.test.js
@@ -46,6 +46,6 @@ describe('lastBidderPortfolio reducers', () => {
 
   it('can set reducer SET_BIDDER_PORTFOLIO_LAST_QUERY', () => {
     expect(reducers.bidderPortfolioLastQuery(
-      {}, { type: 'SET_BIDDER_PORTFOLIO_LAST_QUERY', query: '&ordering=id', count: 5 })).toBe('/client/?limit=5&ordering=id');
+      {}, { type: 'SET_BIDDER_PORTFOLIO_LAST_QUERY', query: '&ordering=id', count: 5 })).toBe('/client/?limit=5&ordering=id&page=1');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4157,6 +4157,13 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
+flat@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/flat/-/flat-4.1.0.tgz#090bec8b05e39cba309747f1d588f04dbaf98db2"
+  integrity sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==
+  dependencies:
+    is-buffer "~2.0.3"
+
 flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
@@ -5250,6 +5257,11 @@ is-binary-path@^1.0.0:
 is-buffer@^1.0.2, is-buffer@^1.1.0, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+
+is-buffer@~2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
+  integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
 
 is-builtin-module@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- Eliminate possibility of errors by flattening position object
- Fixes another bug with exporting where exports from page >=2 failed because the `page` query param was not removed, resulting in a failed query.

Note: this is directed at staging