### PR TITLE
Make use of cycleposition model for compare and favoriting

### DIFF
--- a/src/Components/CompareDrawer/CompareDrawerContainer.jsx
+++ b/src/Components/CompareDrawer/CompareDrawerContainer.jsx
@@ -79,8 +79,8 @@ export class Compare extends Component {
     /* sort based on any prior compare list, so the cards don't get jumbled
     after one is removed, as it persists until the new request completes */
     const sortedComparisons = comparisons.sort((a, b) =>
-    (comparisonsToUse.indexOf(a.position_number) >
-        comparisonsToUse.indexOf(b.position_number) ? 1 : -1),
+    (comparisonsToUse.indexOf(a.id) >
+        comparisonsToUse.indexOf(b.id) ? 1 : -1),
     );
 
     const isHidden$ = isHidden || !sortedComparisons.length;

--- a/src/Components/CompareList/CompareList.jsx
+++ b/src/Components/CompareList/CompareList.jsx
@@ -119,15 +119,15 @@ class CompareList extends Component {
                       </th>
                       {
                         compareArray.map((c) => {
-                          const { position } = c;
+                          const { id, position } = c;
                           return (
                             <td key={shortId.generate()}>
                               <div className="usa-grid-full">
                                 <div className="column-title-main">{position.title}</div>
                                 <div className="close-button-container">
                                   <CompareCheck
-                                    onToggle={() => onToggle(position.position_number)}
-                                    refKey={position.position_number}
+                                    onToggle={() => onToggle(id)}
+                                    refKey={id}
                                     customElement={<FA name="close" />}
                                     interactiveElementProps={{ title: 'Remove this comparison' }}
                                   />

--- a/src/Components/CompareList/__snapshots__/CompareList.test.jsx.snap
+++ b/src/Components/CompareList/__snapshots__/CompareList.test.jsx.snap
@@ -97,7 +97,7 @@ exports[`CompareListComponent matches snapshot 1`] = `
                     }
                     limit={5}
                     onToggle={[Function]}
-                    refKey="10034001"
+                    refKey={1}
                     type="compare"
                   />
                 </div>
@@ -135,7 +135,7 @@ exports[`CompareListComponent matches snapshot 1`] = `
                     }
                     limit={5}
                     onToggle={[Function]}
-                    refKey="56082000"
+                    refKey={2}
                     type="compare"
                   />
                 </div>
@@ -603,7 +603,7 @@ exports[`CompareListComponent matches snapshot when there is an obc id 1`] = `
                     }
                     limit={5}
                     onToggle={[Function]}
-                    refKey="10034001"
+                    refKey={1}
                     type="compare"
                   />
                 </div>
@@ -641,7 +641,7 @@ exports[`CompareListComponent matches snapshot when there is an obc id 1`] = `
                     }
                     limit={5}
                     onToggle={[Function]}
-                    refKey="56082000"
+                    refKey={2}
                     type="compare"
                   />
                 </div>

--- a/src/Components/Favorite/Favorite.jsx
+++ b/src/Components/Favorite/Favorite.jsx
@@ -51,13 +51,7 @@ class Favorite extends Component {
     };
   }
 
-  shouldComponentUpdate(nextProps, nextState) {
-    let isUpdate = true;
-
-    const { compareArray, refKey } = nextProps;
-    const oldState = this.getSavedState();
-    const newState = existsInArray(refKey, compareArray);
-
+  componentWillReceiveProps(nextProps) {
     if (this.state.loading && !nextProps.isLoading) {
       // Only update the loading state if current state.loading
       // and prop change detected is turning it off
@@ -65,6 +59,14 @@ class Favorite extends Component {
         loading: nextProps.isLoading,
       });
     }
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    let isUpdate = true;
+
+    const { compareArray, refKey } = nextProps;
+    const oldState = this.getSavedState();
+    const newState = existsInArray(refKey, compareArray);
 
     isUpdate = (oldState !== newState) ||
                (this.state.loading !== nextState.isLoading) ||

--- a/src/Components/Favorite/Favorite.test.jsx
+++ b/src/Components/Favorite/Favorite.test.jsx
@@ -52,11 +52,11 @@ describe('Favorite', () => {
     sinon.assert.calledOnce(spy);
   });
 
-  it('sets state on shouldComponentUpdate() when this.state.loading && !nextProps.isLoading', () => {
+  it('sets state on componentWillReceiveProps() when this.state.loading && !nextProps.isLoading', () => {
     const spy = sinon.spy();
     const wrapper = shallow(<Favorite onToggle={spy} compareArray={[]} refKey={refKey} />);
     wrapper.setState({ loading: true });
-    wrapper.instance().shouldComponentUpdate({ isLoading: false, compareArray: [] }, {});
+    wrapper.instance().componentWillReceiveProps({ isLoading: false, compareArray: [] }, {});
     expect(wrapper.instance().state.loading).toBe(false);
   });
 

--- a/src/Containers/Compare/Compare.jsx
+++ b/src/Containers/Compare/Compare.jsx
@@ -34,7 +34,8 @@ export class Compare extends Component {
 
   onToggle(id) {
     let compareArray = this.props.match.params.ids.split(',');
-    compareArray = compareArray.filter(f => f !== id);
+    console.log(compareArray, String(id));
+    compareArray = compareArray.filter(f => f !== String(id));
     const compareString = compareArray.toString();
     this.props.onNavigateTo(`/compare/${compareString}`);
     this.getComparisons(`${compareString}`);

--- a/src/Containers/Compare/Compare.jsx
+++ b/src/Containers/Compare/Compare.jsx
@@ -34,7 +34,6 @@ export class Compare extends Component {
 
   onToggle(id) {
     let compareArray = this.props.match.params.ids.split(',');
-    console.log(compareArray, String(id));
     compareArray = compareArray.filter(f => f !== String(id));
     const compareString = compareArray.toString();
     this.props.onNavigateTo(`/compare/${compareString}`);

--- a/src/Containers/Favorite/Favorite.jsx
+++ b/src/Containers/Favorite/Favorite.jsx
@@ -14,7 +14,7 @@ const FavoriteContainer = ({
   ...rest }) => (
     <Favorite
       onToggle={onToggle}
-      isLoading={isLoading.has(refKey)}
+      isLoading={!!isLoading.has(refKey)}
       hasErrored={hasErrored}
       refKey={refKey}
       {...rest}


### PR DESCRIPTION
Fixes issue with removing compare items from the full Compare page when using the new model.