### PR TITLE
Hide Clear Filters link if no filters are selected

### DIFF
--- a/src/Components/ResultsFilterContainer/ResultsFilterContainer.jsx
+++ b/src/Components/ResultsFilterContainer/ResultsFilterContainer.jsx
@@ -18,14 +18,14 @@ class ResultsFilterContainer extends Component {
     const { filters, resetFilters, setAccordion, selectedAccordion, isLoading,
       fetchMissionAutocomplete, missionSearchResults, missionSearchIsLoading,
       missionSearchHasErrored, fetchPostAutocomplete, onQueryParamUpdate, onQueryParamToggle,
-      postSearchResults, postSearchIsLoading, postSearchHasErrored } = this.props;
+      postSearchResults, postSearchIsLoading, postSearchHasErrored, showClear } = this.props;
     return (
       <div className={`filter-container ${isLoading ? 'is-loading' : ''}`}>
         <div className="filter-container-bottom">
           <div className="usa-grid-full filter-control-container">
             <div className="filter-control-left">Select Filter:</div>
             <div className="filter-control-right">
-              <ResetFilters resetFilters={resetFilters} />
+              { showClear && <ResetFilters resetFilters={resetFilters} /> }
             </div>
           </div>
           <div className="usa-grid-full search-filters-container">
@@ -67,10 +67,12 @@ ResultsFilterContainer.propTypes = {
   postSearchResults: POST_DETAILS_ARRAY.isRequired,
   postSearchIsLoading: PropTypes.bool.isRequired,
   postSearchHasErrored: PropTypes.bool.isRequired,
+  showClear: PropTypes.bool,
 };
 
 ResultsFilterContainer.defaultProps = {
   selectedAccordion: ACCORDION_SELECTION,
+  showClear: false,
 };
 
 export default ResultsFilterContainer;

--- a/src/Components/ResultsFilterContainer/ResultsFilterContainer.test.jsx
+++ b/src/Components/ResultsFilterContainer/ResultsFilterContainer.test.jsx
@@ -25,6 +25,7 @@ describe('ResultsFilterContainerComponent', () => {
     postSearchHasErrored: false,
     userProfile: bidderUserObject,
     isLoading: false,
+    showClear: true,
   };
 
   it('is defined', () => {

--- a/src/Components/ResultsPage/ResultsPage.jsx
+++ b/src/Components/ResultsPage/ResultsPage.jsx
@@ -32,7 +32,7 @@ class Results extends Component {
             fetchMissionAutocomplete, missionSearchResults, missionSearchIsLoading,
             missionSearchHasErrored, fetchPostAutocomplete,
             postSearchResults, postSearchIsLoading, postSearchHasErrored, shouldShowSearchBar,
-            bidList, isProjectedVacancy, filtersIsLoading }
+            bidList, isProjectedVacancy, filtersIsLoading, showClear }
       = this.props;
     const hasLoaded = !isLoading && results.results && !!results.results.length;
     return (
@@ -66,6 +66,7 @@ class Results extends Component {
             postSearchResults={postSearchResults}
             postSearchIsLoading={postSearchIsLoading}
             postSearchHasErrored={postSearchHasErrored}
+            showClear={showClear}
           />
           <ResultsContainer
             results={results}
@@ -125,6 +126,7 @@ Results.propTypes = {
   shouldShowSearchBar: PropTypes.bool.isRequired,
   bidList: BID_RESULTS.isRequired,
   isProjectedVacancy: PropTypes.bool,
+  showClear: PropTypes.bool,
 };
 
 Results.defaultProps = {
@@ -144,6 +146,7 @@ Results.defaultProps = {
   userProfile: {},
   currentSavedSearch: {},
   isProjectedVacancy: false,
+  showClear: false,
 };
 
 Results.contextTypes = {

--- a/src/Containers/Results/Results.jsx
+++ b/src/Containers/Results/Results.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 import { withRouter } from 'react-router';
 import queryString from 'query-string';
-import { debounce, get, isString } from 'lodash';
+import { debounce, get, keys, isString, omit, pickBy } from 'lodash';
 import queryParamUpdate from '../queryParams';
 import { scrollToTop, cleanQueryParams, getAssetPath } from '../../utilities';
 import { resultsFetchData } from '../../actions/results';
@@ -32,6 +32,7 @@ class Results extends Component {
     this.onQueryParamUpdate = this.onQueryParamUpdate.bind(this);
     this.onQueryParamToggle = this.onQueryParamToggle.bind(this);
     this.resetFilters = this.resetFilters.bind(this);
+    this.getQueryExists = this.getQueryExists.bind(this);
     this.state = {
       key: 0,
       query: { value: window.location.search.replace('?', '') || '' },
@@ -121,6 +122,18 @@ class Results extends Component {
     if (newQueryString !== this.state.query.value) {
       this.updateHistory(newQueryString);
     }
+  }
+
+  // check if there are filters selected so that the clear filters button can be displayed or hidden
+  getQueryExists() {
+    const { query: { value } } = this.state;
+    let query = queryString.parse(value);
+    // omit page size and ordering
+    query = omit(query, ['limit', 'ordering']);
+    // remove any falsy props, unless it's a 0
+    query = pickBy(query, v => v || v === 0);
+    // query exists if it has keys
+    return !!keys(query).length;
   }
 
   createQueryParams() {
@@ -219,6 +232,7 @@ class Results extends Component {
             fetchPostAutocomplete, postSearchResults, postSearchIsLoading,
             postSearchHasErrored, shouldShowSearchBar, bidList } = this.props;
     const { filtersIsLoading } = this.state;
+    const showClear = this.getQueryExists();
     return (
       <div>
         <ResultsPage
@@ -253,6 +267,7 @@ class Results extends Component {
           shouldShowSearchBar={shouldShowSearchBar}
           bidList={bidList.results}
           isProjectedVacancy={results.isProjectedVacancy}
+          showClear={showClear}
         />
         <CompareDrawer />
       </div>

--- a/src/Containers/Results/Results.test.jsx
+++ b/src/Containers/Results/Results.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import TestUtils from 'react-dom/test-utils';
 import sinon from 'sinon';
+import q from 'query-string';
 import { testDispatchFunctions } from '../../testUtilities/testUtilities';
 import MockTestProvider from '../../testUtilities/MockProvider';
 import Results, { mapDispatchToProps } from './Results';
@@ -90,6 +91,26 @@ describe('Results', () => {
     wrapper.instance().storeSearch();
     expect(value.newValue).toEqual({ q: 'German' });
   });
+
+  [
+    [{ q: '', ordering: 'order' }, false],
+    [{ q: 'a' }, true],
+    [{ ordering: 'order' }, false],
+    [{ other: true, ordering: 'order' }, true],
+    [{ other: 0 }, true],
+  ].map((d, i) => (
+    it(`returns the correct value for this.getQueryExists() at index ${i}`, () => {
+      const wrapper = shallow(
+        <Results.WrappedComponent
+          {...props}
+        />,
+      );
+      const q$ = q.stringify(d[0]);
+      wrapper.instance().setState({ query: { value: q$ } });
+      const exp = wrapper.instance().getQueryExists();
+      expect(exp).toBe(d[1]);
+    })
+  ));
 
   it('can call the onQueryParamToggle function when removing a param', (done) => {
     const wrapper = shallow(


### PR DESCRIPTION
Completes TM-1063 by implementing functionality to hide the "Clear Filters" link if there are no filters selected (excludes sorting and page size).