### PR TITLE
Add noopener back in

### DIFF
--- a/src/Components/About/Content/Content.jsx
+++ b/src/Components/About/Content/Content.jsx
@@ -24,7 +24,7 @@ const AboutContent = () => (
     <Alert
       type="info"
       title="TalentMAP Progress is Ongoing"
-      messages={[{ body: <span>For more information, visit <a target="_blank" href={getAssetPath('/about/more')}>HR Systems Online Resources</a>.</span> }]}
+      messages={[{ body: <span>For more information, visit <a rel="noopener" target="_blank" href={getAssetPath('/about/more')}>HR Systems Online Resources</a>.</span> }]}
     />
     <h2>How TalentMAP Works</h2>
     <p>

--- a/src/Components/About/Content/__snapshots__/Content.test.jsx.snap
+++ b/src/Components/About/Content/__snapshots__/Content.test.jsx.snap
@@ -46,6 +46,7 @@ exports[`Content matches snapshot 1`] = `
             For more information, visit 
             <a
               href="/about/more"
+              rel="noopener"
               target="_blank"
             >
               HR Systems Online Resources

--- a/src/Components/LinkButton/LinkButton.jsx
+++ b/src/Components/LinkButton/LinkButton.jsx
@@ -11,6 +11,7 @@ const LinkButton = ({ children, className, toLink, useDefaultClass, isExternal }
         type="submit"
         role="button"
         href={toLink}
+        rel="noopener"
         target="_blank"
       >
         {children}

--- a/src/Components/OBCUrl/OBCUrl.jsx
+++ b/src/Components/OBCUrl/OBCUrl.jsx
@@ -35,7 +35,7 @@ const OBCUrl = ({ id, type, label, isButton, altStyle }) => {
     isButton ?
       <LinkButton isExternal className={`post-data-button ${altStyle ? 'usa-button-secondary' : ''}`} toLink={url} >{text}</LinkButton>
       :
-      <a href={url} target="_blank">{text}</a>
+      <a href={url} rel="noopener" target="_blank">{text}</a>
   );
 };
 

--- a/src/Components/OBCUrl/__snapshots__/OBCUrl.test.jsx.snap
+++ b/src/Components/OBCUrl/__snapshots__/OBCUrl.test.jsx.snap
@@ -3,6 +3,7 @@
 exports[`OBCUrlComponent matches snapshot 1`] = `
 <a
   href="/talentmap/obc/post/5"
+  rel="noopener"
   target="_blank"
 >
   Post details
@@ -12,6 +13,7 @@ exports[`OBCUrlComponent matches snapshot 1`] = `
 exports[`OBCUrlComponent matches snapshot when id is a string 1`] = `
 <a
   href="/talentmap/obc/post/5A"
+  rel="noopener"
   target="_blank"
 >
   Post details
@@ -32,6 +34,7 @@ exports[`OBCUrlComponent matches snapshot when isButton is true 1`] = `
 exports[`OBCUrlComponent matches snapshot when type is "country" 1`] = `
 <a
   href="/talentmap/obc/country/5"
+  rel="noopener"
   target="_blank"
 >
   Country details
@@ -41,6 +44,7 @@ exports[`OBCUrlComponent matches snapshot when type is "country" 1`] = `
 exports[`OBCUrlComponent matches snapshot when type is "post-data" 1`] = `
 <a
   href="/talentmap/obc/post/data/5"
+  rel="noopener"
   target="_blank"
 >
   Post details


### PR DESCRIPTION
There's actually nothing wrong with having `noopener` in our external links, and if anything is good for security. It's just `noreferrer` that we needed to get rid of.