### PR TITLE
Integrate data sync editor form with API

### DIFF
--- a/src/Components/AdministratorPage/AdministratorPage.jsx
+++ b/src/Components/AdministratorPage/AdministratorPage.jsx
@@ -21,6 +21,8 @@ const AdministratorPage = (props) => {
     syncJobs,
     syncJobsIsLoading,
     runAllJobs,
+    patchSyncJob,
+    patchSyncIsLoading,
   } = props;
 
   const dashboardProps = {
@@ -30,6 +32,8 @@ const AdministratorPage = (props) => {
     syncJobs,
     syncJobsIsLoading,
     runAllJobs,
+    patchSyncJob,
+    patchSyncIsLoading,
   };
 
   const logsProps = {
@@ -68,6 +72,8 @@ AdministratorPage.propTypes = {
   syncJobs: PropTypes.arrayOf(PropTypes.shape({})),
   syncJobsIsLoading: PropTypes.bool,
   runAllJobs: PropTypes.func,
+  patchSyncIsLoading: PropTypes.bool,
+  patchSyncJob: PropTypes.func,
 };
 
 AdministratorPage.defaultProps = {
@@ -85,6 +91,8 @@ AdministratorPage.defaultProps = {
   syncJobs: [],
   syncJobsIsLoading: false,
   runAllJobs: EMPTY_FUNCTION,
+  patchSyncIsLoading: false,
+  patchSyncJob: EMPTY_FUNCTION,
 };
 
 export default AdministratorPage;

--- a/src/Components/AdministratorPage/Dashboard/Dashboard.jsx
+++ b/src/Components/AdministratorPage/Dashboard/Dashboard.jsx
@@ -16,6 +16,8 @@ const AdministratorPage = (props) => {
     syncJobs,
     syncJobsIsLoading,
     runAllJobs,
+    patchSyncJob,
+    patchSyncIsLoading,
   } = props;
 
   const getLink = (link, title) => (
@@ -53,6 +55,8 @@ const AdministratorPage = (props) => {
                           syncJobs={syncJobs}
                           isLoading={syncJobsIsLoading}
                           runAllJobs={runAllJobs}
+                          patchSyncJob={patchSyncJob}
+                          patchSyncIsLoading={patchSyncIsLoading}
                         />
                         <div className="usa-grid-full padding-section button-container">
                           <LinkButton className="unstyled-button" toLink="/profile/administrator/logs">Review Logs</LinkButton>
@@ -88,6 +92,8 @@ AdministratorPage.propTypes = {
   syncJobs: PropTypes.arrayOf(PropTypes.shape({})),
   syncJobsIsLoading: PropTypes.bool,
   runAllJobs: PropTypes.func,
+  patchSyncIsLoading: PropTypes.bool,
+  patchSyncJob: PropTypes.func,
 };
 
 AdministratorPage.defaultProps = {
@@ -95,6 +101,8 @@ AdministratorPage.defaultProps = {
   syncJobs: [],
   syncJobsIsLoading: false,
   runAllJobs: EMPTY_FUNCTION,
+  patchSyncIsLoading: false,
+  patchSyncJob: EMPTY_FUNCTION,
 };
 
 export default AdministratorPage;

--- a/src/Components/AdministratorPage/Dashboard/DataSync/DataSync.jsx
+++ b/src/Components/AdministratorPage/Dashboard/DataSync/DataSync.jsx
@@ -1,8 +1,15 @@
+/*
+TODO - server-side - next_synchronization is calculated server-side
+using the last_synchronization + delta. We may want this field exposed for patching in the future
+so that next_sync can be updated independently. Relevant components for this have been commented
+out with "TODO server-side".
+*/
+
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { get, orderBy } from 'lodash';
+import { get, isNull, omit, orderBy, startsWith, toString } from 'lodash';
 import FA from 'react-fontawesome';
-import { format, differenceInCalendarDays, parse } from 'date-fns';
+import { addHours, format, parse, subHours } from 'date-fns';
 import DayPickerInput from 'react-day-picker/DayPickerInput';
 import { DateUtils } from 'react-day-picker';
 import TimeInput from 'time-input';
@@ -13,8 +20,10 @@ import RadioList from '../../../RadioList';
 import Spinner from '../../../Spinner';
 import { EMPTY_FUNCTION } from '../../../../Constants/PropTypes';
 import { focusById } from '../../../../utilities';
+import ExportButton from '../../../ExportButton';
 
-export const FORMAT = 'MM-DD-YY HH:MM';
+export const FORMAT = 'MM-DD-YY hh:mm A';
+export const FORMAT_TIME = 'hh:mm A';
 
 export const formatDate = (date, format$ = FORMAT, locale) => format(date, format$, { locale });
 
@@ -28,14 +37,14 @@ export const parseDate = (str, format$, locale) => {
   return undefined;
 };
 
-const getScheduledJob = (jobs = [], prop = 'next_sync', ordering = 'desc') => {
+const getScheduledJob = (jobs = [], prop = 'next_synchronization', ordering = 'desc') => {
   let sync;
   if (jobs.length) {
     const orderedJobs = orderBy(jobs, prop, ordering);
     sync = get(orderedJobs, '[0]');
   }
   if (sync) {
-    return { ...sync, next_sync: formatDate(sync.next_sync) };
+    return { ...sync, next_synchronization: formatDate(sync.next_synchronization) };
   }
   return null;
 };
@@ -43,28 +52,87 @@ const getScheduledJob = (jobs = [], prop = 'next_sync', ordering = 'desc') => {
 class DataSync extends Component {
   constructor(props) {
     super(props);
+    this.setJob = this.setJob.bind(this);
     this.showForm = this.showForm.bind(this);
     this.closeForm = this.closeForm.bind(this);
-    this.updateOccurrence = this.updateOccurrence.bind(this);
-    this.updateFrequency = this.updateFrequency.bind(this);
     this.updateTime = this.updateTime.bind(this);
     this.updateDate = this.updateDate.bind(this);
     this.dateIsValid = this.dateIsValid.bind(this);
     this.formIsValid = this.formIsValid.bind(this);
+    this.updateBool = this.updateBool.bind(this);
+    this.updateVal = this.updateVal.bind(this);
+    this.submitSync = this.submitSync.bind(this);
     this.state = {
       showForm: false,
       formValues: {
-        recurring: 'once',
-        frequency: 'weekly',
-        date: new Date(),
-        time: '12:00:00 PM',
+        id: null,
+        last_synchronization: null,
+        delta_synchronization: 86400,
+        running: 'false',
+        talentmap_model: '',
+        next_synchronization: null,
+        priority: 0,
+        use_last_date_updated: 'false',
       },
     };
   }
 
+  setJob(job) {
+    const job$ = {
+      ...job,
+      last_synchronization: parseDate(new Date(job.last_synchronization)),
+      last_synchronization_time: format(job.last_synchronization, FORMAT_TIME),
+
+      // TODO - server-side
+      // next_synchronization: parseDate(new Date(job.next_synchronization)),
+      // next_synchronization_time: format(job.next_synchronization, FORMAT_TIME),
+
+      running: job.running ? 'true' : 'false',
+      use_last_date_updated: job.use_last_date_updated ? 'true' : 'false',
+    };
+    this.setState({ formValues: job$ }, () => this.showForm());
+  }
+
+  submitSync() {
+    const { patchSyncJob } = this.props;
+    const { formValues: f } = this.state;
+
+    // Combine date with time since they're separated into two form fields, but
+    // one on the API.
+    const parseDateTime = (date, time) => {
+      let date$ = parse(
+        `${format(date, 'YYYY-MM-DD')} ${time}`,
+        `YYYY-MM-DD ${FORMAT_TIME}`,
+      );
+      // date-fns can format TO am/pm but can't parse FROM it,
+      // so we check whether or not we need to add an extra 12 hours
+      // by looking for PM/pm in the time string.
+      // This might be possible in date-fns 2.0, but it's in beta
+      // and has breaking changes.
+      const isPM = time.includes('PM') || time.includes('pm');
+      const is12 = startsWith(time, '12:');
+      if (isPM && !is12) {
+        date$ = addHours(date$, 12);
+      }
+      if (!isPM && is12) {
+        date$ = subHours(date$, 12);
+      }
+      return date$;
+    };
+
+    const formValues$ = {
+      ...omit(f, ['next_synchronization', 'last_synchronization_time']), // TODO - server-side
+      last_synchronization: parseDateTime(f.last_synchronization, f.last_synchronization_time),
+      running: f.running === 'true',
+      use_last_date_updated: f.use_last_date_updated === 'true',
+    };
+
+    patchSyncJob(formValues$);
+  }
+
   showForm() {
     this.setState({ showForm: true });
-    focusById('once', 1);
+    focusById('form-header', 1);
   }
 
   closeForm() {
@@ -72,47 +140,52 @@ class DataSync extends Component {
     focusById('new-sync-button', 1);
   }
 
-  updateOccurrence(recurring) {
+  updateTime(value, field = 'next_synchronization_time') {
     const { formValues } = this.state;
-    formValues.recurring = recurring;
+    formValues[field] = value;
     this.setState({ formValues });
   }
 
-  updateFrequency(frequency) {
+  updateBool(value = false, field) {
     const { formValues } = this.state;
-    formValues.frequency = frequency;
+    if (field) {
+      formValues[field] = toString(value);
+      this.setState({ formValues });
+    }
+  }
+
+  updateVal(value = null, field) {
+    const v$ = get(value, 'target.value');
+    const { formValues } = this.state;
+    if (!isNull(v$)) {
+      formValues[field] = v$;
+      this.setState({ formValues });
+    }
+  }
+
+  updateDate(value, field = 'next_synchronization') {
+    const { formValues } = this.state;
+    formValues[field] = value;
     this.setState({ formValues });
   }
 
-  updateTime(time) {
-    const { formValues } = this.state;
-    formValues.time = time;
-    this.setState({ formValues });
-  }
-
-  updateDate(date) {
-    const { formValues } = this.state;
-    formValues.date = date;
-    this.setState({ formValues });
-  }
-
-  dateIsValid() {
-    const { formValues: { date } } = this.state;
-    return date && differenceInCalendarDays(date, new Date()) >= 0;
+  dateIsValid(field = 'next_synchronization') {
+    const { formValues: { [field]: field$ } } = this.state;
+    return !!field$;
   }
 
   formIsValid() {
-    const { formValues: { recurring, frequency, time } } = this.state;
-    return recurring && frequency && this.dateIsValid() && time;
+    return this.dateIsValid('next_synchronization') && this.dateIsValid('last_synchronization');
   }
 
   render() {
     const { showForm, formValues } = this.state;
-    const { syncJobs, isLoading, runAllJobs } = this.props; // eslint-disable-line
+    const { syncJobs, isLoading, patchSyncIsLoading, runAllJobs } = this.props;
     const formIsValid = this.formIsValid();
-    const dateIsValid = this.dateIsValid();
+    // const dateIsValid = this.dateIsValid('next_synchronization'); TODO server-side
+    const dateLastIsValid = this.dateIsValid('last_synchronization');
     const nextScheduled = getScheduledJob(syncJobs);
-    const lastRun = getScheduledJob(syncJobs, 'last_sync');
+    const lastRun = getScheduledJob(syncJobs, 'last_synchronization');
     return (
       <div className="usa-grid-full padded-section data-sync-section">
         <h3>TalentMAP Data Sync</h3>
@@ -127,21 +200,22 @@ class DataSync extends Component {
                 nextScheduled &&
                 <div>
                   <strong>Next sync scheduled: </strong>
-                  <span>{nextScheduled.talentmap_model}: {nextScheduled.next_sync}</span>
+                  <span>{nextScheduled.talentmap_model}: {nextScheduled.next_synchronization}</span>
                 </div>
               }
               <div className="usa-grid-full sync-job-container">
                 {
                   syncJobs.map((n) => {
-                    const nextSyncDate = format(n.next_sync, FORMAT);
+                    const nextSyncDate = format(n.next_synchronization, FORMAT);
                     return (
                       <div key={n.id} className="usa-grid-full sync-job-item">
                         <div>
                           <strong>{n.talentmap_model}: </strong>
                           <span>Next sync at {nextSyncDate}</span>
                         </div>
-                        <FA name="trash-o" />
-                        <FA name="pencil" />
+                        <InteractiveElement title="Edit details for this job" type="span" onClick={() => this.setJob(n)}>
+                          <FA name="pencil" />
+                        </InteractiveElement>
                       </div>
                     );
                   })
@@ -150,26 +224,49 @@ class DataSync extends Component {
               {
                 !showForm &&
                   <div className="usa-grid-full new-sync-container">
-                    <InteractiveElement id="new-sync-button" type="a" onClick={this.showForm}>Schedule New Sync +</InteractiveElement>
+                    Click the pencil next to one of the jobs above to edit its details.
                   </div>
               }
               {
                 showForm &&
                 <div className="usa-grid-full new-sync-container new-sync-container--form">
                   <div className="usa-grid-full new-sync-form">
-                    <h4>Schedule New Sync</h4>
+                    <h4 id="form-header" tabIndex="-1">Update Sync Details</h4>
                     <Form id="sync-form" onFormSubmit={(e) => { e.preventDefault(); }}>
-                      <FieldSet legend="Sync Occurrence" legendSrOnly>
-                        <RadioList
-                          options={[
-                            { id: 'once', label: 'Once' },
-                            { id: 'recurring', label: 'Recurring' },
-                          ]}
-                          value={formValues.recurring}
-                          onChange={this.updateOccurrence}
-                        />
+                      <FieldSet legend="Last Synchronization">
+                        <div className="date-time-forms">
+                          <div className={`date-time-form date-time-form--date ${dateLastIsValid ? '' : 'usa-input-error'}`}>
+                            <label
+                              htmlFor={`day-picker-input ${dateLastIsValid ? 'input-type-text' : 'usa-input-error-label'}`}
+                              className="label"
+                            >
+                              Date:
+                            </label>
+                            {!dateLastIsValid && <span className="usa-input-error-message usa-sr-only" id="input-error-message" role="alert">Must be a valid, present or future date</span>}
+                            <DayPickerInput
+                              containerProps={{ id: 'day-picker-input', ariaDescribedBy: 'input-error-message' }}
+                              onDayChange={e => this.updateDate(e, 'last_synchronization')}
+                              value={formValues.last_synchronization}
+                              format={'MM/DD/YYYY'}
+                              formatDate={formatDate}
+                              parseDate={parseDate}
+                            />
+                          </div>
+                          <div className="date-time-form date-time-form--time">
+                            <label htmlFor="time-input" className="label">Time:</label>
+                            <TimeInput
+                              id="time-input"
+                              value={formValues.last_synchronization_time}
+                              onChange={e => this.updateTime(e, 'last_synchronization_time')}
+                            />
+                          </div>
+                        </div>
                       </FieldSet>
-                      <FieldSet legend="Starts">
+
+                      {
+                       /* eslint-disable */
+                       /* TODO - server-side
+                      <FieldSet legend="Next Synchronization">
                         <div className="date-time-forms">
                           <div className={`date-time-form date-time-form--date ${dateIsValid ? '' : 'usa-input-error'}`}>
                             <label
@@ -181,8 +278,8 @@ class DataSync extends Component {
                             {!dateIsValid && <span className="usa-input-error-message usa-sr-only" id="input-error-message" role="alert">Must be a valid, present or future date</span>}
                             <DayPickerInput
                               containerProps={{ id: 'day-picker-input', ariaDescribedBy: 'input-error-message' }}
-                              onDayChange={this.updateDate}
-                              value={formValues.date}
+                              onDayChange={e => this.updateDate(e, 'next_synchronization')}
+                              value={formValues.next_synchronization}
                               format={'MM/DD/YYYY'}
                               formatDate={formatDate}
                               parseDate={parseDate}
@@ -190,26 +287,59 @@ class DataSync extends Component {
                           </div>
                           <div className="date-time-form date-time-form--time">
                             <label htmlFor="time-input" className="label">Time:</label>
-                            <TimeInput id="time-input" value={formValues.time} onChange={this.updateTime} />
+                            <TimeInput
+                              id="time-input"
+                              value={formValues.next_synchronization_time}
+                              onChange={e => this.updateTime(e, 'next_synchronization_time')}
+                            />
                           </div>
                         </div>
                       </FieldSet>
-                      {
-                        formValues.recurring === 'recurring' &&
-                        <FieldSet legend="Frequency">
-                          <RadioList
-                            options={[
-                              { id: 'daily', label: 'Daily' },
-                              { id: 'weekly', label: 'Weekly' },
-                              { id: 'monthly', label: 'Monthly' },
-                            ]}
-                            value={formValues.frequency}
-                            onChange={this.updateFrequency}
-                          />
-                        </FieldSet>
+                      */
+                      /* eslint-enable */
                       }
+
+                      <FieldSet legend="TalentMAP Model">
+                        <input type="string" value={formValues.talentmap_model} onChange={e => this.updateVal(e, 'talentmap_model')} />
+                      </FieldSet>
+                      <FieldSet legend="Priority">
+                        <input type="number" value={formValues.priority} onChange={e => this.updateVal(e, 'priority')} />
+                      </FieldSet>
+                      <FieldSet legend="Delta">
+                        <input type="number" value={formValues.delta_synchronization} onChange={e => this.updateVal(e, 'delta_synchronization')} />
+                      </FieldSet>
+                      <FieldSet legend="Use last updated date">
+                        <RadioList
+                          options={[
+                            { id: 'lastdate-true', value: 'true', label: 'True' },
+                            { id: 'lastdate-false', value: 'false', label: 'False' },
+                          ]}
+                          value={formValues.use_last_date_updated}
+                          onChange={e => this.updateBool(e, 'use_last_date_updated')}
+                        />
+                      </FieldSet>
+                      <FieldSet legend="Running">
+                        <RadioList
+                          options={[
+                            { id: 'running-true', value: 'true', label: 'True' },
+                            { id: 'running-false', value: 'false', label: 'False' },
+                          ]}
+                          value={formValues.running}
+                          onChange={e => this.updateBool(e, 'running')}
+                        />
+                      </FieldSet>
                     </Form>
-                    <button disabled={!formIsValid} type="submit" form="sync-form" value="Create sync">Create sync</button>
+                    <div className="export-button-container">
+                      <ExportButton
+                        disabled={!formIsValid}
+                        type="submit"
+                        form="sync-form"
+                        value="Update sync"
+                        onClick={this.submitSync}
+                        isLoading={patchSyncIsLoading}
+                        text="Update sync"
+                      />
+                    </div>
                     <button
                       title="Close form"
                       className="feedback-close unstyled-button"
@@ -226,7 +356,7 @@ class DataSync extends Component {
               <div className="usa-grid-full status-container--inner">
                 { lastRun && <div>
                   <strong>Last sync: </strong>
-                  <span>{nextScheduled.talentmap_model}: {nextScheduled.next_sync}</span>
+                  <span>{nextScheduled.talentmap_model}: {nextScheduled.next_synchronization}</span>
                 </div> }
               </div>
               <button className="usa-button-secondary" onClick={runAllJobs}>Run sync now</button>
@@ -242,12 +372,16 @@ DataSync.propTypes = {
   syncJobs: PropTypes.arrayOf(PropTypes.shape({})),
   isLoading: PropTypes.bool,
   runAllJobs: PropTypes.func,
+  patchSyncIsLoading: PropTypes.bool,
+  patchSyncJob: PropTypes.func,
 };
 
 DataSync.defaultProps = {
   syncJobs: [],
   isLoading: false,
   runAllJobs: EMPTY_FUNCTION,
+  patchSyncIsLoading: false,
+  patchSyncJob: EMPTY_FUNCTION,
 };
 
 export default DataSync;

--- a/src/Components/AdministratorPage/Dashboard/DataSync/DataSync.test.jsx
+++ b/src/Components/AdministratorPage/Dashboard/DataSync/DataSync.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { get } from 'lodash';
 import DataSync, { parseDate } from './DataSync';
 
 describe('DataSync', () => {
@@ -7,11 +8,11 @@ describe('DataSync', () => {
     syncJobs: [
       {
         id: 7,
-        last_sync: '2019-05-29T19:10:43.131897Z',
+        last_synchronization: '2019-05-29T19:10:43.131897Z',
         delta_sync: 604800,
         running: false,
         talentmap_model: 'organization.Country',
-        next_sync: '2019-06-05T19:10:43.131897Z',
+        next_synchronization: '2019-06-05T19:10:43.131897Z',
         priority: 0,
         use_last_date_updated: false,
       },
@@ -44,11 +45,23 @@ describe('DataSync', () => {
     }),
   );
 
-  [['updateOccurrence', 'recurring'], ['updateFrequency', 'frequency'], ['updateTime', 'time'], ['updateDate', 'date']].map(m =>
+  [['updateTime', 'next_synchronization_time'], ['updateDate', 'next_synchronization']].map(m =>
     it(`updates formValues.${m[1]} on ${m[0]}()`, () => {
       const wrapper = shallow(<DataSync {...props} />);
       wrapper.instance()[m[0]]('a');
-      expect(wrapper.instance().state.formValues[m[1]]).toBe('a');
+      expect(get(wrapper.instance().state.formValues, [m[1]])).toBe('a');
     }),
   );
+
+  it('updates state with updateBool()', () => {
+    const wrapper = shallow(<DataSync {...props} />);
+    wrapper.instance().updateBool('a', 'fieldA');
+    expect(wrapper.instance().state.formValues.fieldA).toBe('a');
+  });
+
+  it('updates state with updateVal()', () => {
+    const wrapper = shallow(<DataSync {...props} />);
+    wrapper.instance().updateVal({ target: { value: 'a' } }, 'fieldA');
+    expect(wrapper.instance().state.formValues.fieldA).toBe('a');
+  });
 });

--- a/src/Components/ExportButton/ExportButton.jsx
+++ b/src/Components/ExportButton/ExportButton.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { EMPTY_FUNCTION } from '../../Constants/PropTypes';
 
-const ExportButton = ({ onClick, text, className, isLoading, primaryClass }) => (
-  <button className={`${primaryClass} ${className}`} onClick={onClick}>
+const ExportButton = ({ onClick, text, className, isLoading, primaryClass, ...rest }) => (
+  <button className={`${primaryClass} ${className}`} onClick={onClick} {...rest}>
     {isLoading && <span className="ds-c-spinner spinner-blue" />}<span>{text}</span>
   </button>
 );

--- a/src/Containers/Administrator/Administrator.jsx
+++ b/src/Containers/Administrator/Administrator.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import AdministratorPage from '../../Components/AdministratorPage';
 import { getLogs, getLogsList, getLog, getLogToDownload } from '../../actions/logs';
-import { syncsFetchData, putAllSyncs } from '../../actions/synchronizations';
+import { syncsFetchData, putAllSyncs, patchSync } from '../../actions/synchronizations';
 import { EMPTY_FUNCTION } from '../../Constants/PropTypes';
 
 export const downloadFile = (text) => {
@@ -45,6 +45,10 @@ class AdministratorContainer extends Component {
       && nextProps.logToDownload) {
       downloadFile(nextProps.logToDownload);
     }
+    if (this.props.patchSyncIsLoading && !nextProps.patchSyncIsLoading
+      && !nextProps.patchSyncHasErrored) {
+      this.props.getSyncJobs();
+    }
   }
 
   onDownloadClick() {
@@ -71,7 +75,7 @@ class AdministratorContainer extends Component {
   }
 
   render() {
-    const { logs, logsIsLoading, logsHasErrored,
+    const { logs, logsIsLoading, logsHasErrored, patchSyncJob, patchSyncIsLoading,
     logsList, logsListIsLoading, logsListHasErrored,
     log, logIsLoading, logHasErrored, syncJobs, syncJobsIsLoading } = this.props;
     const props = {
@@ -90,6 +94,8 @@ class AdministratorContainer extends Component {
       syncJobs,
       syncJobsIsLoading,
       runAllJobs: this.runAllJobs,
+      patchSyncJob,
+      patchSyncIsLoading,
     };
     return (
       <AdministratorPage {...props} />
@@ -121,6 +127,9 @@ AdministratorContainer.propTypes = {
   syncsJobsHasErrored: PropTypes.bool,
   putAllSyncJobs: PropTypes.func,
   putAllSyncsIsLoading: PropTypes.bool,
+  patchSyncIsLoading: PropTypes.bool,
+  patchSyncJob: PropTypes.func,
+  patchSyncHasErrored: PropTypes.bool,
 };
 
 AdministratorContainer.defaultProps = {
@@ -147,6 +156,9 @@ AdministratorContainer.defaultProps = {
   syncsJobsHasErrored: false,
   putAllSyncsIsLoading: false,
   putAllSyncJobs: EMPTY_FUNCTION,
+  patchSyncIsLoading: false,
+  patchSyncJob: EMPTY_FUNCTION,
+  patchSyncHasErrored: false,
 };
 
 const mapStateToProps = state => ({
@@ -166,6 +178,8 @@ const mapStateToProps = state => ({
   syncJobsIsLoading: state.syncsIsLoading,
   syncsJobsHasErrored: state.syncsHasErrored,
   putAllSyncsIsLoading: state.putAllSyncsIsLoading,
+  patchSyncIsLoading: state.patchSyncIsLoading,
+  patchSyncHasErrored: state.patchSyncHasErrored,
 });
 
 export const mapDispatchToProps = dispatch => ({
@@ -175,6 +189,7 @@ export const mapDispatchToProps = dispatch => ({
   getLogToDownload: id => dispatch(getLogToDownload(id)),
   getSyncJobs: () => dispatch(syncsFetchData()),
   putAllSyncJobs: () => dispatch(putAllSyncs()),
+  patchSyncJob: data => dispatch(patchSync(data)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)((AdministratorContainer));

--- a/src/actions/synchronizations.js
+++ b/src/actions/synchronizations.js
@@ -1,4 +1,5 @@
 import Q from 'q';
+import { omit } from 'lodash';
 import api from '../api';
 import { toastSuccess, toastError, toastWarning } from './toast';
 
@@ -44,6 +45,20 @@ export function putAllSyncsSuccess(bool) {
   };
 }
 
+export function patchSyncIsLoading(bool) {
+  return {
+    type: 'PATCH_SYNC_IS_LOADING',
+    isLoading: bool,
+  };
+}
+
+export function patchSyncHasErrored(bool) {
+  return {
+    type: 'PATCH_SYNC_HAS_ERRORED',
+    hasErrored: bool,
+  };
+}
+
 export function syncsFetchData() {
   return (dispatch) => {
     dispatch(syncsIsLoading(true));
@@ -58,6 +73,27 @@ export function syncsFetchData() {
         dispatch(syncsHasErrored(true));
         dispatch(syncsIsLoading(false));
       });
+  };
+}
+
+export function patchSync(data = {}) {
+  const { id } = data;
+  const data$ = omit(data, 'id');
+  return (dispatch) => {
+    if (id) {
+      dispatch(patchSyncIsLoading(true));
+      api().patch(`/data_sync/schedule/${id}/`, data$)
+        .then(() => {
+          dispatch(toastSuccess('Synchronization job has been updated', 'Success'));
+          dispatch(patchSyncHasErrored(false));
+          dispatch(patchSyncIsLoading(false));
+        })
+        .catch(() => {
+          dispatch(toastError('There was an error updating this synchronization job. Please try again.', 'Error'));
+          dispatch(patchSyncHasErrored(true));
+          dispatch(patchSyncIsLoading(false));
+        });
+    }
   };
 }
 

--- a/src/reducers/synchronizations/index.js
+++ b/src/reducers/synchronizations/index.js
@@ -1,5 +1,5 @@
-import { syncs, syncsHasErrored, syncsIsLoading,
-  putAllSyncsSuccess, putAllSyncsHasErrored, putAllSyncsIsLoading } from './synchronizations';
+import { syncs, syncsHasErrored, syncsIsLoading, patchSyncHasErrored,
+  putAllSyncsSuccess, putAllSyncsHasErrored, putAllSyncsIsLoading, patchSyncIsLoading } from './synchronizations';
 
 export default {
   syncs,
@@ -8,4 +8,6 @@ export default {
   putAllSyncsSuccess,
   putAllSyncsHasErrored,
   putAllSyncsIsLoading,
+  patchSyncIsLoading,
+  patchSyncHasErrored,
 };

--- a/src/reducers/synchronizations/synchronizations.js
+++ b/src/reducers/synchronizations/synchronizations.js
@@ -51,3 +51,21 @@ export function putAllSyncsSuccess(state = false, action) {
       return state;
   }
 }
+
+export function patchSyncIsLoading(state = false, action) {
+  switch (action.type) {
+    case 'PATCH_SYNC_IS_LOADING':
+      return action.isLoading;
+    default:
+      return state;
+  }
+}
+
+export function patchSyncHasErrored(state = false, action) {
+  switch (action.type) {
+    case 'PATCH_SYNC_HAS_ERRORED':
+      return action.hasErrored;
+    default:
+      return state;
+  }
+}

--- a/src/sass/_administrator.scss
+++ b/src/sass/_administrator.scss
@@ -263,13 +263,19 @@
 
     button {
       margin-bottom: 0;
+      margin-left: 0;
+      margin-top: .5em;
     }
 
-    fieldset:nth-of-type(2) {
-      margin: 1em 0;
+    fieldset {
+      margin-bottom: 1em;
 
       legend {
-        margin-bottom: .5em;
+        margin-bottom: .25em;
+      }
+
+      &:first-of-type {
+        margin-top: 1em;
       }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2828,8 +2828,9 @@ dasherize@2.0.0:
   resolved "https://registry.yarnpkg.com/dasherize/-/dasherize-2.0.0.tgz#6d809c9cd0cf7bb8952d80fc84fa13d47ddb1308"
 
 date-fns@^1.29.0:
-  version "1.29.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
+  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
 date-now@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
Updates existing data sync editor form to work with new PATCH data sync API endpoint.

Left some comments around how the PATCH endpoint calculates the `next_synchronization` property automatically based on `last_synchronization` + `delta`, and that because we might want to change that in the future, I've left in some commented components and functionality that would support the ability to edit the `next_synchronization` field should the API support it in the future.