### PR TITLE
fix: Cancel token message in production build

### DIFF
--- a/src/actions/results.js
+++ b/src/actions/results.js
@@ -1,7 +1,7 @@
 import { CancelToken } from 'axios';
 import queryString from 'query-string';
+import { get } from 'lodash';
 import api from '../api';
-import { propOrDefault } from '../utilities';
 
 let cancel;
 
@@ -88,7 +88,7 @@ export function fetchResultData(query) {
 
 export function resultsFetchData(query) {
   return (dispatch) => {
-    if (cancel) { cancel(); dispatch(resultsIsLoading(true)); }
+    if (cancel) { cancel('cancel'); dispatch(resultsIsLoading(true)); }
     dispatch(resultsIsLoading(true));
     dispatch(resultsHasErrored(false));
     fetchResultData(query)
@@ -98,7 +98,7 @@ export function resultsFetchData(query) {
         dispatch(resultsIsLoading(false));
       })
       .catch((err) => {
-        if (propOrDefault(err, 'constructor.name') === 'Cancel') {
+        if (get(err, 'message') === 'cancel') {
           dispatch(resultsHasErrored(false));
           dispatch(resultsIsLoading(true));
         } else {


### PR DESCRIPTION
Adds a message to the cancel token, since the constructor `name` in production gets minified to a single letter, resulting in a conditional check within an action failing in production but passing in development.