### PR TITLE
fix - PV Search

### DIFF
--- a/src/actions/results.js
+++ b/src/actions/results.js
@@ -69,10 +69,13 @@ export function fetchResultData(query) {
   if (isPV) {
     prefix = '/fsbid/projected_vacancies';
     delete parsed.projectedVacancy;
+    delete parsed.q; // TODO remove this once we have PV free text search
   }
 
+  const query$ = queryString.stringify(parsed);
+
   return api()
-  .get(`${prefix}/?${query}`, {
+  .get(`${prefix}/?${query$}`, {
     cancelToken: new CancelToken((c) => { cancel = c; }),
   })
   .then((response) => {


### PR DESCRIPTION
An update to how our search query "pulls" the latest text from the search bar resulted in this fix being needed. If the user searches for PV, then we keep the `q` query param in the browser URL, and simply delete it from the query object in the action. We also make sure to actually use that updated query object, as we weren't doing so before.