### PR TITLE
Login redirect fix

### DIFF
--- a/src/Containers/Routes/RoutesMap.jsx
+++ b/src/Containers/Routes/RoutesMap.jsx
@@ -8,8 +8,19 @@ import LoginRedirect from '../../Containers/LoginRedirect';
 import Compare from '../../Containers/Compare/Compare';
 import About from '../../Containers/About';
 import RoutesArray from '../../routes';
+import TokenValidation from '../../login/Components/TokenValidation';
 
-const Components = { Home, Profile, Results, Position, Login, LoginRedirect, About, Compare };
+const Components = {
+  Home,
+  Profile,
+  Results,
+  Position,
+  Login,
+  LoginRedirect,
+  About,
+  Compare,
+  TokenValidation,
+};
 
 const mappedRoutesArray = RoutesArray.map((Route) => {
   const Component = Components[Route.componentName];

--- a/src/login/Components/TokenValidation.jsx
+++ b/src/login/Components/TokenValidation.jsx
@@ -1,10 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
+import { connect } from 'react-redux';
 
 import { EMPTY_FUNCTION } from '../../Constants/PropTypes';
 import Alert from '../../Components/Alert/Alert';
 import { auth } from '../sagas';
+import { tokenValidationRequest } from '../../login/actions';
 
 import { initialState } from '../reducer';
 
@@ -76,4 +78,14 @@ TokenValidation.defaultProps = {
   login: initialState,
 };
 
-export default TokenValidation;
+const mapStateToProps = state => ({
+  login: state.login,
+});
+
+export const mapDispatchToProps = dispatch => ({
+  tokenValidationRequest: token => dispatch(tokenValidationRequest(token)),
+});
+
+const connected = connect(mapStateToProps, mapDispatchToProps)(TokenValidation);
+
+export default connected;

--- a/src/login/Components/TokenValidation.test.jsx
+++ b/src/login/Components/TokenValidation.test.jsx
@@ -1,6 +1,15 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-import { TokenValidation } from './TokenValidation';
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import TestUtils from 'react-dom/test-utils';
+import thunk from 'redux-thunk';
+import TokenValidation, { mapDispatchToProps } from './TokenValidation';
+import { testDispatchFunctions } from '../../testUtilities/testUtilities';
+
+const middlewares = [thunk];
+const mockStore = configureStore(middlewares)({});
 
 describe('TokenValidation', () => {
   const loginObject = {
@@ -18,16 +27,37 @@ describe('TokenValidation', () => {
   ];
 
   it('can render', () => {
-    const wrapper = shallow(<TokenValidation login={loginObject} />);
+    const wrapper = TestUtils.renderIntoDocument(
+      <Provider store={mockStore}>
+        <MemoryRouter>
+          <TokenValidation login={loginObject} />
+        </MemoryRouter>
+      </Provider>,
+    );
+
+    expect(wrapper).toBeDefined();
+  });
+
+  it('is defined', () => {
+    const wrapper = shallow(
+      <TokenValidation.WrappedComponent login={loginObject} />,
+    );
     expect(wrapper).toBeDefined();
   });
 
   it('can handle other props', () => {
     const wrapper = shallow(
-      <TokenValidation
+      <TokenValidation.WrappedComponent
         login={{ ...loginObject, requesting: false, errors, messages: errors }}
       />,
     );
     expect(wrapper).toBeDefined();
   });
+});
+
+describe('mapDispatchToProps', () => {
+  const config = {
+    tokenValidationRequest: ['token'],
+  };
+  testDispatchFunctions(mapDispatchToProps, config);
 });

--- a/src/login/index.jsx
+++ b/src/login/index.jsx
@@ -1,32 +1,8 @@
 import React from 'react';
 import { Redirect } from 'react-router';
-import { connect } from 'react-redux';
 
-import TokenValidation from './Components/TokenValidation';
+const Login = () => (
+  <Redirect to="/" />
+);
 
-import { tokenValidationRequest } from './actions';
-import { auth } from './sagas';
-
-const Login = (props) => {
-  const isSignedIn = !!auth.get();
-
-  return (!isSignedIn ?
-    <TokenValidation {...props} /> :
-    <Redirect to="/" />
-  );
-};
-
-Login.propTypes = TokenValidation.propTypes;
-Login.defaultProps = TokenValidation.defaultProps;
-
-const mapStateToProps = state => ({
-  login: state.login,
-});
-
-export const mapDispatchToProps = dispatch => ({
-  tokenValidationRequest: token => dispatch(tokenValidationRequest(token)),
-});
-
-const connected = connect(mapStateToProps, mapDispatchToProps)(Login);
-
-export default connected;
+export default Login;

--- a/src/login/index.test.jsx
+++ b/src/login/index.test.jsx
@@ -1,67 +1,13 @@
 import React from 'react';
-import configureStore from 'redux-mock-store';
-import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
-import TestUtils from 'react-dom/test-utils';
-import thunk from 'redux-thunk';
-import { testDispatchFunctions } from '../testUtilities/testUtilities';
+import { shallow } from 'enzyme';
 
-import Login, { mapDispatchToProps } from './index';
-
-const middlewares = [thunk];
-const mockStore = configureStore(middlewares)({});
+import Login from './index';
 
 describe('Login', () => {
-  const loginObject = {
-    requesting: true,
-    successful: false,
-    messages: [],
-    errors: [],
-  };
-
-  const errors = [
-    {
-      body: 'Request failed with status code 400',
-      time: '2017-07-27T20:02:27.683Z',
-    },
-  ];
-
-  it('can render', () => {
-    const wrapper = TestUtils.renderIntoDocument(
-      <Provider store={mockStore}>
-        <MemoryRouter>
-          <Login login={loginObject} />
-        </MemoryRouter>
-      </Provider>,
+  it('is defined', () => {
+    const wrapper = shallow(
+      <Login />,
     );
-
     expect(wrapper).toBeDefined();
   });
-
-  it('can render with errors', () => {
-    const mock = {
-      ...loginObject,
-      requesting: false,
-      errors,
-      messages: errors,
-    };
-
-    const wrapper = TestUtils.renderIntoDocument(
-      <Provider store={mockStore}>
-        <MemoryRouter>
-          <Login login={mock} />
-        </MemoryRouter>
-      </Provider>,
-    );
-
-    expect(wrapper).toBeDefined();
-  });
-});
-
-describe('mapDispatchToProps', () => {
-  const config = {
-    onSubmit: [{ username: 'u', password: 'p' }],
-    tokenValidationRequest: ['token'],
-  };
-  testDispatchFunctions(mapDispatchToProps, config);
 });

--- a/src/routes.js
+++ b/src/routes.js
@@ -7,7 +7,7 @@ const routesArray = [
   { path: '/compare/:ids', key: 'compareID', componentName: 'Compare', pageTitle: 'Compare Positions' },
   { path: '/compare', key: 'compareNoID', componentName: 'Compare', pageTitle: 'Compare Positions' },
   { path: '/about', exact: true, componentName: 'About', pageTitle: 'About' },
-  { path: '/tokenValidation', componentName: 'Login', pageTitle: 'Token Validation' },
+  { path: '/tokenValidation', componentName: 'TokenValidation', pageTitle: 'Token Validation' },
   { path: '/loginRedirect', componentName: 'LoginRedirect', pageTitle: 'Login Redirect' },
 ];
 


### PR DESCRIPTION
Fixes the login in the deployed environment by updating how the `/tokenValidation` route works.

Basically, we were ignoring the `tmApiToken` query parameter if a token already existed in localStorage. However, that token didn't have to actually be valid. This resulted in the login flow completing most of the way, but when the user was finally directed to the homepage, the stale token caused 401s on any API requests, resulting in the logout flow being initiated. The logout flow unsets the token from localStorage, which is why a subsequent login would be successful.

This PR updates the logic to always take the `tmApiToken` from the `/tokenValidation` route, even if a token already exists in localStorage.