### PR TITLE
Remove comparison choices that are no longer available

### DIFF
--- a/src/actions/comparisons.js
+++ b/src/actions/comparisons.js
@@ -1,5 +1,7 @@
 import { CancelToken } from 'axios';
+import { toNumber } from 'lodash';
 import api from '../api';
+import { localStorageToggleValue } from '../utilities';
 
 let cancel;
 
@@ -25,6 +27,7 @@ export function comparisonsFetchDataSuccess(comparisons) {
 }
 
 export function comparisonsFetchData(query) {
+  const idArr = query.split(',');
   return (dispatch) => {
     if (cancel) { cancel(); }
     dispatch(comparisonsIsLoading(true));
@@ -37,6 +40,14 @@ export function comparisonsFetchData(query) {
       })
         .then((response) => {
           dispatch(comparisonsIsLoading(false));
+          // Try removing any compare IDs that no longer exist
+          try {
+            const responseIds = response.data.results.map(m => `${m.id}`);
+            const noMatches = idArr.filter(f => responseIds.indexOf(f) <= -1);
+            noMatches.forEach((f) => {
+              localStorageToggleValue('compare', toNumber(f), true, true);
+            });
+          } catch (e) {} // eslint-disable-line no-empty
           return response.data.results;
         })
         .then(comparisons => dispatch(comparisonsFetchDataSuccess(comparisons)))

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -42,19 +42,32 @@ export function localStorageSetKey(key, value) {
 }
 
 // toggling a specific value in an array
-export function localStorageToggleValue(key, value) {
+// useDispatch: only dispatch an event if true.
+// onlyDelete: don't add, only delete from the array
+export function localStorageToggleValue(key, value, useDispatch = true, onlyDelete = false) {
   const existingArray = JSON.parse(localStorage.getItem(key)) || [];
-  const indexOfId = existingArray.indexOf(value);
+  // check if the value matches, either as a string or as a number
+  let indexOfId = existingArray.indexOf(value);
+  if (indexOfId <= -1) {
+    indexOfId = existingArray.indexOf(Number(value));
+  }
+  if (indexOfId <= -1) {
+    indexOfId = existingArray.indexOf(toString(value));
+  }
   if (indexOfId !== -1) {
     existingArray.splice(indexOfId, 1);
     localStorage.setItem(key,
         JSON.stringify(existingArray));
-    dispatchLs(key);
-  } else {
+    if (useDispatch) {
+      dispatchLs(key);
+    }
+  } else if (!onlyDelete) {
     existingArray.push(value);
     localStorage.setItem(key,
         JSON.stringify(existingArray));
-    dispatchLs(key);
+    if (useDispatch) {
+      dispatchLs(key);
+    }
   }
 }
 


### PR DESCRIPTION
Once the user's compare choices have been fetched, attempt to remove any "stale" comparison IDs that were not returned in the response.