### PR TITLE
Projected Vacancy Search - Show all filter choices

### DIFF
--- a/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
+++ b/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
@@ -56,8 +56,6 @@ class SearchFiltersContainer extends Component {
         ...config,
         is_available_in_bidcycle: null,
         is_available_in_current_bidcycle: null,
-        is_domestic: null,
-        position__post__in: null,
         projectedVacancy: value,
         ordering: 'ted',
       };

--- a/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
+++ b/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
@@ -67,7 +67,15 @@ class SearchFiltersContainer extends Component {
 
   render() {
     const { isProjectedVacancy } = this.context;
-    const { fetchPostAutocomplete, postSearchResults } = this.props;
+    const { fetchPostAutocomplete, postSearchResults, filters } = this.props;
+
+    const filters$ = filters
+    .filter((f) => {
+      if (isProjectedVacancy) {
+        return f.item.onlyProjectedVacancy || !f.item.onlyAvailablePositions;
+      }
+      return f.item.onlyAvailablePositions || !f.item.onlyProjectedVacancy;
+    });
 
     // Get our boolean filter names.
     // We use the "description" property because these are less likely
@@ -81,7 +89,8 @@ class SearchFiltersContainer extends Component {
 
     // store filters in Map
     const booleanFiltersMap = new Map();
-    this.props.filters.forEach((searchFilter) => {
+    filters$
+    .forEach((searchFilter) => {
       if (searchFilter.item.bool) {
         booleanFiltersMap.set(searchFilter.item.description, searchFilter);
       }
@@ -98,7 +107,7 @@ class SearchFiltersContainer extends Component {
     });
 
     // get our normal multi-select filters
-    const multiSelectFilterNames = ['skill', 'grade', 'region', 'tod', 'language',
+    const multiSelectFilterNames = ['bidSeason', 'bidCycle', 'skill', 'grade', 'region', 'tod', 'language',
       'postDiff', 'dangerPay'];
     const blackList = []; // don't create accordions for these
 
@@ -115,7 +124,7 @@ class SearchFiltersContainer extends Component {
 
     // store filters in Map
     const toggleFiltersMap = new Map();
-    this.props.filters.forEach((searchFilter) => {
+    filters$.forEach((searchFilter) => {
       if (searchFilter.item.isToggle) {
         toggleFiltersMap.set(searchFilter.item.description, searchFilter);
       }
@@ -134,11 +143,6 @@ class SearchFiltersContainer extends Component {
     const projectedVacancyFilter = sortedToggleNames.length ?
       get(toggleFiltersMap.get('projectedVacancy'), 'data') : null;
 
-    if (isProjectedVacancy) {
-      multiSelectFilterNames.unshift('bidSeason');
-    } else {
-      multiSelectFilterNames.unshift('bidCycle');
-    }
     // post should come before TOD
     multiSelectFilterNames.splice(indexOf(multiSelectFilterNames, 'tod'), 0, 'post');
     // END TOGGLE FILTERS
@@ -147,7 +151,7 @@ class SearchFiltersContainer extends Component {
     const multiSelectFilterMap = new Map();
 
     // pull filters from props and add to Map
-    this.props.filters.slice().forEach((f) => {
+    filters$.slice().forEach((f) => {
       if (multiSelectFilterNames.indexOf(f.item.description) > -1) {
         // extra handling for skill
         if (f.item.description === 'skill' && f.data) {
@@ -167,20 +171,22 @@ class SearchFiltersContainer extends Component {
     });
 
     // special handling for functional bureau
-    const functionalBureaus = this.props.filters.slice().find(f => f.item.description === 'functionalRegion');
+    const functionalBureaus = filters$.slice().find(f => f.item.description === 'functionalRegion');
 
     // special handling for is_domestic filter
-    const domesticFilter = (this.props.filters || []).find(f => f.item.description === 'domestic');
+    const domesticFilter = (filters$ || []).find(f => f.item.description === 'domestic');
     const overseasFilterData = propOrDefault(domesticFilter, 'data', []).find(d => d.code === 'false');
     const domesticFilterData = propOrDefault(domesticFilter, 'data', []).find(d => d.code === 'true');
     const overseasIsSelected = propOrDefault(overseasFilterData, 'isSelected', false);
     const domesticIsSelected = propOrDefault(domesticFilterData, 'isSelected', false);
 
     // get skill cones
-    const skillCones = (this.props.filters || []).find(f => f.item.description === 'skillCone');
+    const skillCones = (filters$ || []).find(f => f.item.description === 'skillCone');
 
     // get language groups
-    const languageGroups = (this.props.filters || []).find(f => f.item.description === 'languageGroup');
+    const languageGroups = (filters$ || []).find(f => f.item.description === 'languageGroup');
+
+    console.log(multiSelectFilterNames);
 
     // adding filters based on multiSelectFilterNames
     const sortedFilters = [];

--- a/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
+++ b/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
@@ -186,8 +186,6 @@ class SearchFiltersContainer extends Component {
     // get language groups
     const languageGroups = (filters$ || []).find(f => f.item.description === 'languageGroup');
 
-    console.log(multiSelectFilterNames);
-
     // adding filters based on multiSelectFilterNames
     const sortedFilters = [];
     multiSelectFilterNames.forEach((n) => {

--- a/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.test.jsx
+++ b/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.test.jsx
@@ -125,9 +125,7 @@ describe('SearchFiltersContainerComponent', () => {
     expect(toggleValue.value).toEqual({
       is_available_in_bidcycle: null,
       is_available_in_current_bidcycle: null,
-      is_domestic: null,
       ordering: 'ted',
-      position__post__in: null,
       projectedVacancy: 'pv',
     });
   });

--- a/src/actions/filters/filters.js
+++ b/src/actions/filters/filters.js
@@ -3,8 +3,11 @@ import Q from 'q';
 import api from '../../api';
 import { ASYNC_PARAMS, ENDPOINT_PARAMS } from '../../Constants/EndpointParams';
 import { mapDuplicates, removeDuplicates } from '../../utilities';
+import { checkFlag } from '../../flags';
 import { getFilterCustomDescription, getPillDescription, getPostOrMissionDescription,
   doesCodeOrIdMatch, isBooleanFilter, isPercentageFilter } from './helpers';
+
+const getUsePV = () => checkFlag('flags.projected_vacancy');
 
 export function filtersHasErrored(bool) {
   return {
@@ -236,7 +239,10 @@ export function filtersFetchData(items = { filters: [] }, queryParams = {}, save
       responses.filters.push(...staticFilters);
 
       // our dynamic filters
-      const dynamicFilters = items.filters.slice().filter(item => (item.item.endpoint));
+      let dynamicFilters = items.filters.slice().filter(item => (item.item.endpoint));
+      if (!getUsePV()) {
+        dynamicFilters = dynamicFilters.filter(f => !get(f, 'item.onlyProjectedVacancy'));
+      }
       const queryProms = dynamicFilters.map(item => (
         api().get(`/${item.item.endpoint}`)
           .then((response) => {

--- a/src/reducers/filters/filters.js
+++ b/src/reducers/filters/filters.js
@@ -27,6 +27,7 @@ const items =
           description: 'bidCycle',
           endpoint: 'bidcycle/?active=true&ordering=name',
           selectionRef: ENDPOINT_PARAMS.bidCycle,
+          onlyAvailablePositions: true,
           text: 'Choose Bid Cycles',
         },
         data: [
@@ -40,6 +41,7 @@ const items =
           endpoint: 'fsbid/bid_seasons/',
           selectionRef: ENDPOINT_PARAMS.bidSeason,
           text: 'Choose Bid Seasons',
+          onlyProjectedVacancy: true,
         },
         data: [
         ],
@@ -75,6 +77,29 @@ const items =
           endpoint: 'language/?is_available=true',
           selectionRef: ENDPOINT_PARAMS.language,
           text: 'Choose languages',
+          onlyAvailablePositions: true,
+        },
+        data: [
+        ],
+        // Allow users to include languages with no code. This option is not supplied from
+        // the endpoint, so we define it here.
+        initialData: [
+          {
+            code: COMMON_PROPERTIES.NULL_LANGUAGE,
+            short_description: 'No language requirement',
+            custom_description: 'No language requirement',
+          },
+        ],
+      },
+      {
+        item: {
+          title: 'Language',
+          sort: 500,
+          description: 'language',
+          endpoint: 'language/',
+          selectionRef: ENDPOINT_PARAMS.language,
+          text: 'Choose languages',
+          onlyProjectedVacancy: true,
         },
         data: [
         ],
@@ -110,6 +135,20 @@ const items =
           endpoint: 'grade/?is_available=true',
           selectionRef: ENDPOINT_PARAMS.grade,
           text: 'Choose grades',
+          onlyAvailablePositions: true,
+        },
+        data: [
+        ],
+      },
+      {
+        item: {
+          title: 'Grade',
+          sort: 300,
+          description: 'grade',
+          endpoint: 'grade/',
+          selectionRef: ENDPOINT_PARAMS.grade,
+          text: 'Choose grades',
+          onlyProjectedVacancy: true,
         },
         data: [
         ],
@@ -122,6 +161,22 @@ const items =
           endpoint: 'tour_of_duty/?is_available=true&ordering=months',
           selectionRef: ENDPOINT_PARAMS.tod,
           text: 'Choose Tour of Duty length',
+          onlyAvailablePositions: true,
+          choices: [
+          ],
+        },
+        data: [
+        ],
+      },
+      {
+        item: {
+          title: 'Tour of Duty',
+          sort: 400,
+          description: 'tod',
+          endpoint: 'tour_of_duty/?ordering=months',
+          selectionRef: ENDPOINT_PARAMS.tod,
+          text: 'Choose Tour of Duty length',
+          onlyProjectedVacancy: true,
           choices: [
           ],
         },
@@ -267,6 +322,23 @@ const items =
           description: 'post',
           endpoint: 'orgpost/?limit=500&is_available=true',
           selectionRef: ENDPOINT_PARAMS.post,
+          onlyAvailablePositions: true,
+          choices: [
+          ],
+        },
+        data: [
+        ],
+      },
+      {
+        item: {
+          title: 'Post',
+          altTitle: 'Location',
+          sort: 1100,
+          bool: false,
+          description: 'post',
+          endpoint: 'orgpost/?limit=500',
+          selectionRef: ENDPOINT_PARAMS.post,
+          onlyProjectedVacancy: true,
           choices: [
           ],
         },


### PR DESCRIPTION
Don't limit PV search filters to `is_available=true`, as this filter is only relevant for positions in our database. 