### PR TITLE
Fix PV saved search not storing keyword search term

### DIFF
--- a/src/Components/SaveNewSearch/SaveNewSearchDialog/SaveNewSearchDialog.jsx
+++ b/src/Components/SaveNewSearch/SaveNewSearchDialog/SaveNewSearchDialog.jsx
@@ -38,7 +38,10 @@ export class SaveNewSearchDialog extends Component {
     const hasPV = get(currentSearch, 'projectedVacancy') === 'projected';
     const endpoint = hasPV ? '/api/v1/fsbid/projected_vacancies/' : '/api/v1/cycleposition/';
     let filters = omit(currentSearch, ['projectedVacancy']);
-    if (hasPV) { filters = omit(filters, ['q']); } // q does not exist on PV
+
+    // any filters we want to omit for PV. currently none.
+    if (hasPV) { filters = omit(filters, []); }
+
     this.props.saveSearch({
       name: this.state.newSearchName,
       endpoint,


### PR DESCRIPTION
We used to not be able to search by keyword for projected vacancies, but that functionality has since been added. The saved search object now accepts that parameter.