### PR TITLE
Code splitting for less commonly used functionality

### DIFF
--- a/src/Components/AdministratorPage/AdministratorPageLoadable.jsx
+++ b/src/Components/AdministratorPage/AdministratorPageLoadable.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import createLoader from '../Loadable';
+
+export const path = () => import('./AdministratorPage');
+
+const AdministratorPage = createLoader({ path, shouldPreload: false });
+
+const AdministratorPageLoadable = ({ ...rest }) => (
+  <AdministratorPage {...rest} />
+);
+
+export default AdministratorPageLoadable;

--- a/src/Components/AdministratorPage/index.js
+++ b/src/Components/AdministratorPage/index.js
@@ -1,1 +1,1 @@
-export { default } from './AdministratorPage';
+export { default } from './AdministratorPageLoadable';

--- a/src/Components/BidTracker/BidTrackerLoadable.jsx
+++ b/src/Components/BidTracker/BidTrackerLoadable.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import createLoader from '../Loadable';
+
+export const path = () => import('./BidTracker');
+
+const BidTracker = createLoader({ path, shouldPreload: false });
+
+const BidTrackerLoadable = ({ ...rest }) => (
+  <BidTracker {...rest} />
+);
+
+export default BidTrackerLoadable;

--- a/src/Components/BidTracker/index.js
+++ b/src/Components/BidTracker/index.js
@@ -1,1 +1,1 @@
-export { default } from './BidTracker';
+export { default } from './BidTrackerLoadable';

--- a/src/Components/BidderPortfolio/BidderPortfolioPage/BidderPortfolioLoader.jsx
+++ b/src/Components/BidderPortfolio/BidderPortfolioPage/BidderPortfolioLoader.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import createLoader from '../../Loadable';
+
+export const path = () => import('./BidderPortfolioPage');
+
+const BidderPortfolio = createLoader({ path, shouldPreload: false });
+
+const BidderPortfolioLoadable = ({ ...rest }) => (
+  <BidderPortfolio {...rest} />
+);
+
+export default BidderPortfolioLoadable;

--- a/src/Components/BidderPortfolio/BidderPortfolioPage/index.js
+++ b/src/Components/BidderPortfolio/BidderPortfolioPage/index.js
@@ -1,1 +1,1 @@
-export { default } from './BidderPortfolioPage';
+export { default } from './BidderPortfolioLoader';

--- a/src/Components/GlossaryEditor/GlossaryEditorPage/GlossaryEditorLoadable.jsx
+++ b/src/Components/GlossaryEditor/GlossaryEditorPage/GlossaryEditorLoadable.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import createLoader from '../../Loadable';
+
+export const path = () => import('./GlossaryEditorPage');
+
+const GlossaryEditorPage = createLoader({ path, shouldPreload: false });
+
+const GlossaryEditorPageLoadable = ({ ...rest }) => (
+  <GlossaryEditorPage {...rest} />
+);
+
+export default GlossaryEditorPageLoadable;

--- a/src/Components/GlossaryEditor/GlossaryEditorPage/index.js
+++ b/src/Components/GlossaryEditor/GlossaryEditorPage/index.js
@@ -1,1 +1,1 @@
-export { default } from './GlossaryEditorPage';
+export { default } from './GlossaryEditorLoadable';


### PR DESCRIPTION
Reduces our `main.js` bundle size by about 7% by configuring code splitting for screens that are less commonly used (Bid Tracker, Bidder Portfolio, Glossary Editor, Admin).