### PR TITLE
Default bidStatistics to empty object if not truthy

### DIFF
--- a/src/Components/BidCount/BidCount.jsx
+++ b/src/Components/BidCount/BidCount.jsx
@@ -6,15 +6,16 @@ import { BID_STATISTICS_OBJECT } from '../../Constants/PropTypes';
 const BidCount = ({ bidStatistics, hideLabel, label, altStyle, isCondensed }) => {
   let labelClass = 'bid-count-label';
   if (hideLabel) { labelClass = `${labelClass} usa-sr-only`; }
+  const bidStatistics$ = bidStatistics || {};
   return (
     <div className={`usa-grid-full bid-count-container ${altStyle ? 'bid-count-secondary' : ''} ${isCondensed ? 'bid-count-condensed' : ''}`}>
       <div className={labelClass} id="bid-counts">{label}</div>
       {/* set an aria-labelledby so that screen readers understand the purpose of the list */}
       <ul className="bid-count-list" aria-labelledby="bid-counts">
-        <BidCountNumber type="totalBids" number={bidStatistics.total_bids || 0} />
-        <BidCountNumber type="inGradeBids" number={bidStatistics.in_grade || 0} />
-        <BidCountNumber type="atSkillBids" number={bidStatistics.at_skill || 0} />
-        <BidCountNumber type="inGradeAtSkillBids" number={bidStatistics.in_grade_at_skill || 0} />
+        <BidCountNumber type="totalBids" number={bidStatistics$.total_bids || 0} />
+        <BidCountNumber type="inGradeBids" number={bidStatistics$.in_grade || 0} />
+        <BidCountNumber type="atSkillBids" number={bidStatistics$.at_skill || 0} />
+        <BidCountNumber type="inGradeAtSkillBids" number={bidStatistics$.in_grade_at_skill || 0} />
       </ul>
     </div>
   );


### PR DESCRIPTION
Caused an error if bidStatistics object was `null`, which is sometimes the case.