### PR TITLE
Fix similar positions loading

### DIFF
--- a/src/Containers/PositionSimilarPositions/PositionSimilarPositions.jsx
+++ b/src/Containers/PositionSimilarPositions/PositionSimilarPositions.jsx
@@ -9,8 +9,8 @@ import HomePagePositionsSection from '../../Components/HomePagePositionsSection'
 class Position extends Component {
 
   componentWillMount() {
-    const { fetchSimilarPositions, id } = this.props;
-    fetchSimilarPositions(id);
+    const { fetchSimilarPositions, id, positionDetailsIsLoading } = this.props;
+    if (!positionDetailsIsLoading) { fetchSimilarPositions(id); }
   }
 
   render() {
@@ -40,6 +40,7 @@ Position.propTypes = {
   userProfile: USER_PROFILE,
   bidList: BID_LIST,
   fetchSimilarPositions: PropTypes.func.isRequired,
+  positionDetailsIsLoading: PropTypes.bool,
 };
 
 Position.defaultProps = {
@@ -50,6 +51,7 @@ Position.defaultProps = {
   userProfile: { favorite_positions: [] },
   bidList: { results: [] },
   fetchSimilarPositions: EMPTY_FUNCTION,
+  positionDetailsIsLoading: false,
 };
 
 const mapStateToProps = state => ({
@@ -63,6 +65,7 @@ const mapStateToProps = state => ({
   similarPositions: state.similarPositions,
   similarPositionsIsLoading: state.similarPositionsIsLoading,
   similarPositionsHasErrored: state.similarPositionsHasErrored,
+  positionDetailsIsLoading: state.positionDetailsIsLoading,
 });
 
 export const mapDispatchToProps = dispatch => ({

--- a/src/actions/results.js
+++ b/src/actions/results.js
@@ -7,6 +7,7 @@ import { checkFlag } from '../flags';
 const getUseAP = () => checkFlag('flags.available_positions');
 
 let cancel;
+let cancelSimilar;
 
 export function resultsHasErrored(bool) {
   return {
@@ -48,21 +49,26 @@ export function resultsSimilarPositionsFetchDataSuccess(results) {
 
 export function resultsFetchSimilarPositions(id) {
   return (dispatch) => {
-    if (cancel) { cancel(); }
+    if (cancelSimilar) { cancelSimilar(); }
     const useAP = getUseAP();
     const prefix = useAP ? '/fsbid/available_positions' : '/cycleposition';
 
     dispatch(resultsSimilarPositionsIsLoading(true));
-    api().get(`${prefix}/${id}/similar/?limit=3`)
+    api().get(`${prefix}/${id}/similar/?limit=3`, {
+      cancelToken: new CancelToken((c) => {
+        cancelSimilar = c;
+      }),
+    })
       .then(response => response.data)
       .then((results) => {
         dispatch(resultsSimilarPositionsFetchDataSuccess(results));
-        dispatch(resultsSimilarPositionsIsLoading(false));
         dispatch(resultsSimilarPositionsHasErrored(false));
+        dispatch(resultsSimilarPositionsIsLoading(false));
       })
       .catch(() => {
-        dispatch(resultsSimilarPositionsIsLoading(false));
+        dispatch(resultsSimilarPositionsFetchDataSuccess({}));
         dispatch(resultsSimilarPositionsHasErrored(true));
+        dispatch(resultsSimilarPositionsIsLoading(false));
       });
   };
 }


### PR DESCRIPTION
If the user navigated from position to position, the Similar Positions component used the position ID from the previous route to make an initial request, and then made another request using the new ID. This updates the Similar Positions component to wait for the details to finish loading to resolve this, which also gives the added benefit of delaying the `/similar` request, since that data is not immediately needed.

Also defaults the similar positions state to an empty object if the request fails, as there was a bug where if the request failed, the user would see any old similar positions state alongside an error message. 

~~Merge #474 first~~