### PR TITLE
Fix/bid count card details

### DIFF
--- a/src/Components/ResultsCard/ResultsCard.jsx
+++ b/src/Components/ResultsCard/ResultsCard.jsx
@@ -97,7 +97,7 @@ class ResultsCard extends Component {
     } = this.props;
     const { isProjectedVacancy } = this.context;
 
-    const pos = result.position || result;
+    const pos = result;
 
     const title = propOrDefault(pos, 'title');
     const position = getResult(pos, 'position_number', NO_POSITION_NUMBER);

--- a/src/Components/ResultsCard/ResultsCard.jsx
+++ b/src/Components/ResultsCard/ResultsCard.jsx
@@ -16,7 +16,7 @@ import { Featured, Handshake } from '../Ribbon';
 import HoverDescription from './HoverDescription';
 import OBCUrl from '../OBCUrl';
 
-import { formatDate, propOrDefault, getPostName, getBidStatisticsObject, shortenString,
+import { formatDate, propOrDefault, getPostName, shortenString,
 getDifferentialPercentage } from '../../utilities';
 
 import { POSITION_DETAILS, FAVORITE_POSITIONS_ARRAY } from '../../Constants/PropTypes';
@@ -107,7 +107,7 @@ class ResultsCard extends Component {
 
     const post = `${getPostName(pos.post, NO_POST)}${pos.organization ? `: ${pos.organization}` : ''}`;
 
-    const stats = getBidStatisticsObject(pos.bid_statistics);
+    const stats = pos.bid_statistics;
 
     const description = shortenString(get(pos, 'description.content') || 'No description.', 750);
     const descriptionMobile = shortenString(get(pos, 'description.content') || 'No description.', 500);

--- a/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.jsx
+++ b/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.jsx
@@ -18,9 +18,8 @@ class ResultsCondensedCardBottom extends Component {
   }
   renderStats() {
     const { showBidCount, position } = this.props;
-    const pos = position.position || position;
     return showBidCount ?
-      <ResultsCondensedCardStats bidStatisticsArray={pos.bid_statistics} />
+      <ResultsCondensedCardStats bidStatistics={position.bid_statistics} />
     :
     null;
   }

--- a/src/Components/ResultsCondensedCardStats/ResultsCondensedCardStats.jsx
+++ b/src/Components/ResultsCondensedCardStats/ResultsCondensedCardStats.jsx
@@ -1,25 +1,21 @@
 import React from 'react';
-import { BID_STATISTICS_ARRAY } from '../../Constants/PropTypes';
 import BidCount from '../BidCount';
-import { getBidStatisticsObject } from '../../utilities';
+import { BID_STATISTICS_OBJECT } from '../../Constants/PropTypes';
 
-const ResultsCondensedCardStats = ({ bidStatisticsArray }) => {
-  const bidStatistics = getBidStatisticsObject(bidStatisticsArray);
-  return (
-    <div className="condensed-card-footer condensed-card-statistics">
-      <div className="usa-grid-full condensed-card-statistics-inner">
-        <BidCount bidStatistics={bidStatistics} />
-      </div>
+const ResultsCondensedCardStats = ({ bidStatistics }) => (
+  <div className="condensed-card-footer condensed-card-statistics">
+    <div className="usa-grid-full condensed-card-statistics-inner">
+      <BidCount bidStatistics={bidStatistics} />
     </div>
-  );
-};
+  </div>
+);
 
 ResultsCondensedCardStats.propTypes = {
-  bidStatisticsArray: BID_STATISTICS_ARRAY,
+  bidStatistics: BID_STATISTICS_OBJECT,
 };
 
 ResultsCondensedCardStats.defaultProps = {
-  bidStatisticsArray: [],
+  bidStatistics: {},
 };
 
 export default ResultsCondensedCardStats;

--- a/src/Components/ResultsCondensedCardStats/__snapshots__/ResultsCondensedCardStats.test.jsx.snap
+++ b/src/Components/ResultsCondensedCardStats/__snapshots__/ResultsCondensedCardStats.test.jsx.snap
@@ -9,14 +9,7 @@ exports[`ResultsCondensedCardStatsComponent matches snapshot 1`] = `
   >
     <BidCount
       altStyle={false}
-      bidStatistics={
-        Object {
-          "at_skill": 5,
-          "in_grade": 5,
-          "in_grade_at_skill": 5,
-          "total_bids": 5,
-        }
-      }
+      bidStatistics={Object {}}
       hideLabel={false}
       isCondensed={false}
       label="Bid count:"

--- a/src/Components/ResultsCondensedCardTop/ResultsCondensedCardTop.jsx
+++ b/src/Components/ResultsCondensedCardTop/ResultsCondensedCardTop.jsx
@@ -6,7 +6,7 @@ import { Link } from 'react-router-dom';
 import { Featured, Handshake } from '../Ribbon';
 import { POSITION_DETAILS, HOME_PAGE_CARD_TYPE } from '../../Constants/PropTypes';
 import { NO_POST } from '../../Constants/SystemMessages';
-import { getPostName, getBidStatisticsObject } from '../../utilities';
+import { getPostName } from '../../utilities';
 import { checkFlag } from '../../flags';
 
 const useProjectedVacancy = () => checkFlag('flags.projected_vacancy');
@@ -25,7 +25,7 @@ const ResultsCondensedCardTop = ({ position, isProjectedVacancy, isRecentlyAvail
     vacancyText = 'Now available';
   }
   const p = position.position || position;
-  const stats = getBidStatisticsObject(p.bid_statistics);
+  const stats = p.bid_statistics;
   const hasHandshake = get(stats, 'has_handshake_offered', false);
 
   const title = get(position, 'position.title', '');

--- a/src/Constants/PropTypes.js
+++ b/src/Constants/PropTypes.js
@@ -516,8 +516,6 @@ export const BID_STATISTICS_OBJECT = PropTypes.shape({
   bidding_days_remaining: PropTypes.number,
 });
 
-export const BID_STATISTICS_ARRAY = PropTypes.arrayOf(BID_STATISTICS_OBJECT);
-
 export const CLIENT_BY_ID = PropTypes.shape({
   id: PropTypes.number,
   current_assignment: ASSIGNMENT_OBJECT,


### PR DESCRIPTION
This PR is only looking at the condensed cards usually shown at the bottom of the home page and position details page as teasers for other positions. The bid count wasn't updating after adding it to the user's list. It appears to be an issue with the getBidStatisticsObject method defaulting to an empty object. There are already validations for the BID_STATS_OBJ, but some of these components  were using a validation for an array instead. After deleting the code for the getBidStatsObj, and referencing the position details being passed down as props (including the bid_statistics), everything started working. 

Would like some feedback if I overlooked something by deleting that method etc.? 