### PR TITLE
Remove assignments endpoint since it no longer exists

### DIFF
--- a/src/actions/userProfilePublic.js
+++ b/src/actions/userProfilePublic.js
@@ -43,16 +43,13 @@ export function userProfilePublicFetchData(id, bypass) {
     // profile
     const getUserAccount = () => api().get(`/client/${id}/`);
 
-    // assignments
-    const getUserAssignments = () => api().get(`/client/${id}/assignments/`);
-
     // bids
     const getUserBids = () => api().get(`/client/${id}/bids/`);
 
     // use api' Promise.all to fetch the profile, assignments and any other requests we
     // might add in the future
-    axios.all([getUserAccount(), getUserAssignments(), getUserBids()])
-      .then(axios.spread((acct, assignments, bids) => {
+    axios.all([getUserAccount(), getUserBids()])
+      .then(axios.spread((acct, bids) => {
         // form the userProfile object
         if (!get(acct, 'data.id')) {
           dispatch(userProfilePublicHasErrored(true));
@@ -61,7 +58,7 @@ export function userProfilePublicFetchData(id, bypass) {
           const account = acct.data;
           const newProfileObject = {
             ...account,
-            assignments: get(assignments, 'data.results', []),
+            assignments: [],
             bidList: get(bids, 'data.results', []),
             // any other profile info we want to add in the future
           };

--- a/src/actions/userProfilePublic.test.js
+++ b/src/actions/userProfilePublic.test.js
@@ -1,6 +1,5 @@
 import { setupAsyncMocks } from '../testUtilities/testUtilities';
 import * as actions from './userProfilePublic';
-import assignmentObject from '../__mocks__/assignmentObject';
 import bidListObject from '../__mocks__/bidListObject';
 
 const { mockStore, mockAdapter } = setupAsyncMocks();
@@ -19,8 +18,6 @@ describe('async actions', () => {
     received_shares: [],
   };
 
-  const assignments = [assignmentObject];
-
   const bids = bidListObject;
 
   // reset the mockAdapter since we repeat specific requests
@@ -33,10 +30,6 @@ describe('async actions', () => {
 
     mockAdapter.onGet('http://localhost:8000/api/v1/client/1/').reply(200,
       profile,
-    );
-
-    mockAdapter.onGet('http://localhost:8000/api/v1/client/1/assignments/').reply(200,
-      { results: assignments },
     );
 
     mockAdapter.onGet('http://localhost:8000/api/v1/client/1/bids/').reply(200,
@@ -59,10 +52,6 @@ describe('async actions', () => {
       { ...profile, id: null },
     );
 
-    mockAdapter.onGet('http://localhost:8000/api/v1/client/1/assignments/').reply(200,
-      { results: assignments },
-    );
-
     mockAdapter.onGet('http://localhost:8000/api/v1/client/1/bids/').reply(200,
       { results: bids },
     );
@@ -82,10 +71,6 @@ describe('async actions', () => {
     mockAdapter.reset();
 
     mockAdapter.onGet('http://localhost:8000/api/v1/client/1/').reply(404,
-      {},
-    );
-
-    mockAdapter.onGet('http://localhost:8000/api/v1/client/1/assignments/').reply(404,
       {},
     );
 


### PR DESCRIPTION
And default assignments to `[]` in case we want to show the Assignments widget for demo'ing.