### PR TITLE
Use compatible jest-junit version in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          keys: 
+          keys:
           - dependency-cache-{{ .Branch }}-{{ checksum "yarn.lock" }}
           # fallback to using the latest cache if no exact match is found
           - dependency-cache-
@@ -56,7 +56,7 @@ jobs:
       - run: yarn install --pure-lockfile
       - run:
           name: Install JUnit coverage reporter
-          command: yarn add --dev jest-junit
+          command: yarn add --dev jest-junit@8.0.0
       - run:
           name: Jest Test Coverage
           command: yarn test -- --ci --reporters=default --reporters=jest-junit


### PR DESCRIPTION
Tests were failing because the newest version of jest-junit is only compatible with node >=8