### PR TITLE
Consistent naming for main bundles, force no-cache on those files

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -34,7 +34,7 @@ if (env.stringified['process.env'].NODE_ENV !== '"production"') {
 }
 
 // Note: defined here because it will be used more than once.
-const cssFilename = 'static/css/[name].[contenthash:8].css';
+const cssFilename = 'static/css/[name].css';
 
 // ExtractTextPlugin expects the build output to be flat.
 // (See https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/27)
@@ -62,7 +62,7 @@ module.exports = {
     // Generated JS file names (with nested folders).
     // There will be one main bundle, and one file per asynchronous chunk.
     // We don't currently advertise code splitting but Webpack supports it.
-    filename: 'static/js/[name].[chunkhash:8].js',
+    filename: 'static/js/[name].js',
     chunkFilename: 'static/js/[name].[chunkhash:8].chunk.js',
     // We inferred the "public path" (such as / or /my-project) from homepage.
     publicPath: publicPath,

--- a/src/server.js
+++ b/src/server.js
@@ -18,6 +18,16 @@ const removeCacheControl = (req, res, next) => {
   next();
 };
 
+// middleware to force cache control
+const forceCacheControl = (req, res, next) => {
+  res.set({
+    'Cache-Control': 'no-cache, no-store, must-revalidate',
+    Pragma: 'no-cache',
+    Expires: 0,
+  });
+  next();
+};
+
 // define full path to static build
 const STATIC_PATH = process.env.STATIC_PATH || path.join(__dirname, '../build');
 
@@ -93,9 +103,12 @@ app.use(helmet.noCache());
 // cache certain extensions (images and fonts)
 app.use(PUBLIC_URL, (req, res, next) => {
   const urlObj = url.parse(req.originalUrl);
-  const matches = urlObj.pathname.match(/\.(jpe?g|png|gif|svg|woff2)$/i);
-  if (matches) {
+  const cacheMatches = urlObj.pathname.match(/\.(jpe?g|png|gif|svg|woff2|ico)$/i);
+  const noCacheMatches = urlObj.pathname.match(/\.(js|css)$/i);
+  if (cacheMatches) {
     removeCacheControl(req, res, next);
+  } else if (noCacheMatches) {
+    forceCacheControl(req, res, next);
   } else {
     next();
   }


### PR DESCRIPTION
- Don't use generated hash in js and css bundle names (allows us to standardize our deployment)
- Because we no longer hash the bundles, don't let the browser cache them 