### PR TITLE
Some functionality for CDOs to bid on behalf of a client

### DIFF
--- a/src/Components/BidListButton/BidListButton.jsx
+++ b/src/Components/BidListButton/BidListButton.jsx
@@ -41,7 +41,9 @@ class BidListButton extends Component {
     // is the bid currently saved?
     // save value and avoid interrogating the array more than once
     const { isSaved, canDelete } = this.getBidData();
-    const text = isSaved ? 'Remove from Bid List' : 'Add to Bid List';
+    const { isClient } = this.context;
+    const isClientText = isClient ? ' Client' : '';
+    const text = isSaved ? `Remove from${isClientText} Bid List` : `Add to${isClientText} Bid List`;
     const iconClass = isSaved ? 'minus-circle' : 'plus-circle';
     const { className, disabled, isLoading } = this.props;
 
@@ -59,6 +61,10 @@ class BidListButton extends Component {
     );
   }
 }
+
+BidListButton.contextTypes = {
+  isClient: PropTypes.bool,
+};
 
 BidListButton.propTypes = {
   id: PropTypes.number.isRequired,

--- a/src/Components/BidListButton/BidListButton.test.jsx
+++ b/src/Components/BidListButton/BidListButton.test.jsx
@@ -122,4 +122,16 @@ describe('BidListButtonComponent', () => {
     );
     expect(toJSON(wrapper)).toMatchSnapshot();
   });
+
+  it('matches snapshot when context.client === true', () => {
+    const wrapper = shallow(
+      <BidListButton
+        id={1}
+        toggleBidPosition={() => {}}
+        compareArray={bidList}
+        isLoading={false}
+      />, { context: { isClient: true } },
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
 });

--- a/src/Components/BidListButton/__snapshots__/BidListButton.test.jsx.snap
+++ b/src/Components/BidListButton/__snapshots__/BidListButton.test.jsx.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`BidListButtonComponent matches snapshot when context.client === true 1`] = `
+<button
+  className=" bid-list-button"
+  disabled={false}
+  onClick={[Function]}
+  style={
+    Object {
+      "pointerEvents": "inherit",
+    }
+  }
+>
+  <span
+    className="button-icon"
+  >
+    <FontAwesome
+      name="minus-circle"
+    />
+  </span>
+  <span>
+    Remove from Client Bid List
+  </span>
+</button>
+`;
+
 exports[`BidListButtonComponent matches snapshot when the user can add the position 1`] = `
 <button
   className=" bid-list-button"

--- a/src/Components/BidListMessages/Success.jsx
+++ b/src/Components/BidListMessages/Success.jsx
@@ -1,8 +1,21 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
 
-const Success = () => (
-  <span>Bid successfully added. <Link to="/profile/bidtracker/">Go to Bid Tracker</Link>.</span>
+const Success = ({ client }) => (
+  !!client && !!client.id && !!client.display_name ?
+    <span>Bid successfully added. <Link to={`/profile/public/${client.id}/`}>Go to {`${client.display_name}'s'`} Bid Tracker</Link>.</span>
+    :
+    <span>Bid successfully added. <Link to="/profile/bidtracker/">Go to Bid Tracker</Link>.</span>
 );
+
+Success.propTypes = {
+  client: PropTypes.shape({}),
+};
+
+Success.defaultProps = {
+  client: {},
+};
+
 
 export default Success;

--- a/src/Components/PositionDetails/PositionDetails.jsx
+++ b/src/Components/PositionDetails/PositionDetails.jsx
@@ -27,6 +27,10 @@ class PositionDetails extends Component {
     };
   }
 
+  getChildContext() {
+    return { isClient: this.props.isClient };
+  }
+
   // The additional details section should match after edits are made,
   // so we set the content to a value in local state when ever any edits are made.
   editDescriptionContent(content) {
@@ -112,6 +116,10 @@ class PositionDetails extends Component {
   }
 }
 
+PositionDetails.childContextTypes = {
+  isClient: PropTypes.bool,
+};
+
 PositionDetails.propTypes = {
   details: POSITION_DETAILS,
   isLoading: PropTypes.bool,
@@ -127,6 +135,7 @@ PositionDetails.propTypes = {
   highlightPosition: HIGHLIGHT_POSITION,
   onHighlight: PropTypes.func.isRequired,
   isProjectedVacancy: PropTypes.bool,
+  isClient: PropTypes.bool,
 };
 
 PositionDetails.defaultProps = {
@@ -141,6 +150,7 @@ PositionDetails.defaultProps = {
   highlightPosition: DEFAULT_HIGHLIGHT_POSITION,
   onHighlight: EMPTY_FUNCTION,
   isProjectedVacancy: false,
+  isClient: false,
 };
 
 export default PositionDetails;

--- a/src/Components/PositionTitle/PositionTitle.jsx
+++ b/src/Components/PositionTitle/PositionTitle.jsx
@@ -26,8 +26,9 @@ class PositionTitle extends Component {
 
   renderBidListButton() {
     const { details, bidList } = this.props;
+    const { isClient } = this.context;
     return (
-      <PermissionsWrapper permissions="bidder">
+      <PermissionsWrapper permissions={isClient ? [] : 'bidder'}>
         <BidListButton
           compareArray={bidList.results}
           id={details.cpId}
@@ -47,6 +48,7 @@ class PositionTitle extends Component {
 
   render() {
     const { details, isProjectedVacancy, userProfile } = this.props;
+    const { isClient } = this.context;
     const OBCUrl$ = propOrDefault(details, 'post.post_overview_url');
     const availablilityText = get(details, 'availability.reason') ?
       `${details.availability.reason}${CANNOT_BID_SUFFIX}` : CANNOT_BID_DEFAULT;
@@ -73,14 +75,17 @@ class PositionTitle extends Component {
                   </div>
                 </div>
                 <div className="usa-width-one-half title-actions-section">
-                  <Favorite
-                    refKey={details.cpId}
-                    compareArray={userProfile[isProjectedVacancy ? 'favorite_positions_pv' : 'favorite_positions']}
-                    useLongText
-                    useSpinnerWhite
-                    useButtonClass
-                    isPV={isProjectedVacancy}
-                  />
+                  {
+                  !isClient &&
+                    <Favorite
+                      refKey={details.cpId}
+                      compareArray={userProfile[isProjectedVacancy ? 'favorite_positions_pv' : 'favorite_positions']}
+                      useLongText
+                      useSpinnerWhite
+                      useButtonClass
+                      isPV={isProjectedVacancy}
+                    />
+                }
                 </div>
               </div>
             </div>
@@ -126,6 +131,10 @@ class PositionTitle extends Component {
     );
   }
 }
+
+PositionTitle.contextTypes = {
+  isClient: PropTypes.bool,
+};
 
 PositionTitle.propTypes = {
   details: POSITION_DETAILS,

--- a/src/Components/PositionTitle/PositionTitle.test.jsx
+++ b/src/Components/PositionTitle/PositionTitle.test.jsx
@@ -65,6 +65,16 @@ describe('PositionTitleComponent', () => {
     expect(toJSON(wrapper)).toMatchSnapshot();
   });
 
+  it('matches snapshot when context.client === true', () => {
+    const wrapper = shallow(
+      <PositionTitle
+        {...props}
+        details={detailsObject}
+      />, { context: { isClient: true } },
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
   // will include once new Go Back button is added
   xit('handles go back link click', () => {
     const stub = sinon.stub(window.history, 'back');

--- a/src/Components/PositionTitle/__snapshots__/PositionTitle.test.jsx.snap
+++ b/src/Components/PositionTitle/__snapshots__/PositionTitle.test.jsx.snap
@@ -86,3 +86,83 @@ exports[`PositionTitleComponent matches snapshot 1`] = `
   </div>
 </div>
 `;
+
+exports[`PositionTitleComponent matches snapshot when context.client === true 1`] = `
+<div
+  className="position-details-header-container"
+>
+  <HelmetWrapper
+    defer={true}
+    encodeSpecialCharacters={true}
+  >
+    <title>
+      Test Position
+    </title>
+    <meta
+      content="Test Position 00003027"
+      property="og:title"
+    />
+    <meta
+      content="a description"
+      property="og:description"
+    />
+    <meta
+      content="http://localhost/"
+      property="og:url"
+    />
+  </HelmetWrapper>
+  <div
+    className="position-details-header"
+  >
+    <div
+      className="usa-grid-full positions-details-header-grid padded-main-content"
+    >
+      <div
+        className="usa-width-two-thirds"
+      >
+        <div
+          className="usa-grid-full"
+        >
+          <div
+            className="usa-width-one-half header-title-container"
+          >
+            <div
+              className="position-details-header-title"
+            >
+              <h1>
+                Test Position
+              </h1>
+            </div>
+            <div
+              className="post-title"
+            >
+              Location: 
+              Freetown, Sierra Leone
+            </div>
+          </div>
+          <div
+            className="usa-width-one-half title-actions-section"
+          />
+        </div>
+      </div>
+    </div>
+    <img
+      alt="United States flag background"
+      className="position-details-header-image"
+      src="/assets/img/us-flag.jpg"
+    />
+  </div>
+  <div
+    className="offset-bid-button-container"
+  >
+    <Flag
+      name="flags.bidding"
+      render={[Function]}
+    />
+    <Flag
+      name="flags.bidding"
+      render={[Function]}
+    />
+  </div>
+</div>
+`;

--- a/src/Components/PositionTitle/__snapshots__/PositionTitle.test.jsx.snap
+++ b/src/Components/PositionTitle/__snapshots__/PositionTitle.test.jsx.snap
@@ -156,9 +156,10 @@ exports[`PositionTitleComponent matches snapshot when context.client === true 1`
   <div
     className="offset-bid-button-container"
   >
-    <Flag
-      name="flags.bidding"
-      render={[Function]}
+    <BidCountFeatureFlagWrapper
+      altStyle={true}
+      hideLabel={true}
+      isCondensed={true}
     />
     <Flag
       name="flags.bidding"

--- a/src/Components/ResultsCard/ResultsCard.jsx
+++ b/src/Components/ResultsCard/ResultsCard.jsx
@@ -15,6 +15,7 @@ import BoxShadow from '../BoxShadow';
 import { Featured, Handshake } from '../Ribbon';
 import HoverDescription from './HoverDescription';
 import OBCUrl from '../OBCUrl';
+import BidListButton from '../../Containers/BidListButton';
 
 import { formatDate, propOrDefault, getPostName, getBidStatisticsObject, shortenString,
 getDifferentialPercentage } from '../../utilities';
@@ -95,7 +96,7 @@ class ResultsCard extends Component {
       favorites,
       favoritesPV,
     } = this.props;
-    const { isProjectedVacancy } = this.context;
+    const { isProjectedVacancy, isClient } = this.context;
 
     const pos = result.position || result;
 
@@ -159,6 +160,13 @@ class ResultsCard extends Component {
     };
 
     const detailsLink = <Link to={`/${isProjectedVacancy ? 'vacancy' : 'details'}/${result.id}`}>View position</Link>;
+
+    const renderBidListButton = () => (
+      <BidListButton
+        id={result.id}
+        disabled={!get(result, 'availability.availability', true)}
+      />
+    );
 
     return (
       <MediaQueryWrapper breakpoint="screenSmMax" widthType="max">
@@ -244,10 +252,17 @@ class ResultsCard extends Component {
               <Row className="footer results-card-padded-section" fluid>
                 <Column columns={matches ? 8 : 6} as="section">
                   {
-                    !!favorites &&
+                    !!favorites && !isClient &&
                       <Favorite {...options.favorite} />
                   }
-                  {!isProjectedVacancy && <CompareCheck {...options.compare} />}
+                  {
+                    isClient && !isProjectedVacancy &&
+                      <Flag
+                        name="flags.bidding"
+                        render={renderBidListButton}
+                      />
+                  }
+                  {!isProjectedVacancy && !isClient && <CompareCheck {...options.compare} />}
                 </Column>
                 <Column columns={matches ? 4 : 6} as="section">
                   <div>
@@ -271,6 +286,7 @@ class ResultsCard extends Component {
 
 ResultsCard.contextTypes = {
   isProjectedVacancy: PropTypes.bool,
+  isClient: PropTypes.bool,
 };
 
 ResultsCard.propTypes = {

--- a/src/Components/ResultsCard/ResultsCard.test.jsx
+++ b/src/Components/ResultsCard/ResultsCard.test.jsx
@@ -71,6 +71,17 @@ describe('ResultsCardComponent', () => {
     expect(toJSON(wrapper)).toMatchSnapshot();
   });
 
+  it('matches snapshot when context.isClient === true', () => {
+    wrapper = shallow(
+      <ResultsCard
+        id={1}
+        result={resultsObject.results[0]}
+        onToggle={() => {}}
+        bidList={[]}
+      />, { context: { isClient: true } });
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
   it('matches snapshot with empty result', () => {
     wrapper = shallow(
       <ResultsCard

--- a/src/Components/ResultsCard/__snapshots__/ResultsCard.test.jsx.snap
+++ b/src/Components/ResultsCard/__snapshots__/ResultsCard.test.jsx.snap
@@ -7,6 +7,13 @@ exports[`ResultsCardComponent matches snapshot 1`] = `
 />
 `;
 
+exports[`ResultsCardComponent matches snapshot when context.isClient === true 1`] = `
+<MediaQueryWrapper
+  breakpoint="screenSmMax"
+  widthType="max"
+/>
+`;
+
 exports[`ResultsCardComponent matches snapshot with empty result 1`] = `
 <MediaQueryWrapper
   breakpoint="screenSmMax"

--- a/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.jsx
+++ b/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.jsx
@@ -46,6 +46,7 @@ class ResultsCondensedCardBottom extends Component {
         showCompareButton,
         isProjectedVacancy,
       } = this.props;
+    const { isClient } = this.context;
     const pos = position.position || position;
     return (
       <div className="condensed-card-bottom-container">
@@ -56,17 +57,20 @@ class ResultsCondensedCardBottom extends Component {
           />
           <CondensedCardData position={position} />
           <div className="usa-grid-full condensed-card-buttons-section">
-            <Favorite
-              useLongText
-              hideText={useShortFavButton}
-              hasBorder
-              refKey={position.id}
-              isPV={pos.isPV || position.isPV}
-              compareArray={pos.isPV || position.isPV ? favoritesPV : favorites}
-              useButtonClass={!useShortFavButton}
-              useButtonClassSecondary={useShortFavButton}
-              refresh={refreshFavorites}
-            />
+            {
+              !isClient &&
+              <Favorite
+                useLongText
+                hideText={useShortFavButton}
+                hasBorder
+                refKey={position.id}
+                isPV={pos.isPV || position.isPV}
+                compareArray={pos.isPV || position.isPV ? favoritesPV : favorites}
+                useButtonClass={!useShortFavButton}
+                useButtonClassSecondary={useShortFavButton}
+                refresh={refreshFavorites}
+              />
+            }
             <Flag
               name="flags.bidding"
               render={this.renderBidListButton}
@@ -81,6 +85,10 @@ class ResultsCondensedCardBottom extends Component {
     );
   }
 }
+
+ResultsCondensedCardBottom.contextTypes = {
+  isClient: PropTypes.bool,
+};
 
 ResultsCondensedCardBottom.propTypes = {
   position: PropTypes.shape({

--- a/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.test.jsx
+++ b/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.test.jsx
@@ -85,6 +85,18 @@ describe('ResultsCondensedCardBottomComponent', () => {
     expect(toJSON(wrapper)).toMatchSnapshot();
   });
 
+  it('matches snapshot when context.isClient === true', () => {
+    const wrapper = shallow(
+      <ResultsCondensedCardBottom
+        position={resultsObject.results[0]}
+        bidList={bidListObject.results}
+        favorites={favorites}
+        favoritesPV={favoritesPV}
+      />, { context: { isClient: true } },
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
   it('matches snapshot with bidlist button', () => {
     const wrapper = shallow(
       <ResultsCondensedCardBottom

--- a/src/Components/ResultsCondensedCardBottom/__snapshots__/ResultsCondensedCardBottom.test.jsx.snap
+++ b/src/Components/ResultsCondensedCardBottom/__snapshots__/ResultsCondensedCardBottom.test.jsx.snap
@@ -131,6 +131,116 @@ exports[`ResultsCondensedCardBottomComponent matches snapshot 1`] = `
 </div>
 `;
 
+exports[`ResultsCondensedCardBottomComponent matches snapshot when context.isClient === true 1`] = `
+<div
+  className="condensed-card-bottom-container"
+>
+  <div
+    className="usa-grid-full condensed-card-bottom"
+  >
+    <Flag
+      name="flags.bidding"
+      render={[Function]}
+    />
+    <CondensedCardData
+      position={
+        Object {
+          "bidcycle": Object {
+            "name": "Bid Cycle 1",
+          },
+          "id": 1,
+          "position": Object {
+            "bid_statistics": Array [
+              Object {
+                "at_skill": 0,
+                "bidcycle": "Demo BidCycle 2018-03-13 15:51:10.980576+00:00",
+                "id": 6,
+                "in_grade": 0,
+                "in_grade_at_skill": 0,
+                "total_bids": 2,
+              },
+            ],
+            "bureau": "(AF) BUREAU OF AFRICAN AFFAIRS",
+            "classifications": Array [],
+            "create_date": "2006-09-20T00:00:00Z",
+            "current_assignment": Object {
+              "estimated_end_date": "2020-03-13T15:51:11.478084Z",
+              "start_date": "2018-03-13T15:51:11.478084Z",
+              "status": "active",
+              "tour_of_duty": "2 YRS (2 R & R)",
+              "user": "John Doe",
+            },
+            "description": Object {
+              "content": "The Office Management Specialist (OMS) for the Deputy Chief of Mission (DCM) provides office management services in this Mission of six agencies, 387 American and Locally Employed Staff (LES) positions, and 279 guard force contractors.  The OMS manages Executive Office operations and positionstains the DCM’s calendar in support of overall Mission goals and objectives.  The OMS (DCM) drafts routine correspondence, memoranda and cables as appropriate and ensures documents are cleared and delivered in a timely fashion. The OMS serves as back up to the Ambassador’s OMS.  POCs areSandra McInturff, DCM OMS, McInturffSL@state.gov, 231-77-677-7000, ext. 7452; Samue Watson, DCM, WatsonSR@state.gov, 231-77-677-7000, ext. 7452. Please submit lobbying documents to the 360 Community Lobbying Center http://appcenter.state.sbu/CLC. (Revised 1/2017)
+
+",
+              "date_created": "2018-03-08T18:00:33.241370Z",
+              "date_updated": "2018-03-13T15:55:00.018644Z",
+              "id": 90,
+              "is_editable_by_user": false,
+              "last_editing_user": null,
+              "point_of_contact": null,
+              "website": null,
+            },
+            "effective_date": "2012-10-22T00:00:00Z",
+            "grade": "06",
+            "id": 6,
+            "is_highlighted": false,
+            "is_overseas": true,
+            "languages": Array [],
+            "latest_bidcycle": Object {
+              "active": true,
+              "cycle_deadline_date": "2018-04-13T15:51:10.980554Z",
+              "cycle_end_date": "2018-06-13T15:51:10.980554Z",
+              "cycle_start_date": "2017-12-13T15:51:10.980554Z",
+              "id": 1,
+              "name": "Demo BidCycle 2018-03-13 15:51:10.980576+00:00",
+            },
+            "organization": "(MONROVIA) MONROVIA LIBERIA",
+            "position_number": "10034001",
+            "post": Object {
+              "code": "LI6000000",
+              "cost_of_living_adjustment": 30,
+              "danger_pay": 0,
+              "differential_rate": 30,
+              "has_consumable_allowance": true,
+              "has_service_needs_differential": true,
+              "id": 160,
+              "location": Object {
+                "city": "Freetown",
+                "code": "00A",
+                "country": "Sierra Leone",
+                "id": 103,
+                "state": "",
+              },
+              "obc_id": 1,
+              "rest_relaxation_point": "Paris",
+              "tour_of_duty": "2 YRS (2 R & R)",
+            },
+            "posted_date": "2012-10-22T00:00:00Z",
+            "representation": "[10034001] OMS (DCM) (Monrovia, Liberia)",
+            "skill": "OFFICE MANAGEMENT (9017)",
+            "status": null,
+            "status_code": null,
+            "title": "OMS (DCM)",
+            "tour_of_duty": null,
+            "update_date": "2017-06-08T00:00:00Z",
+          },
+        }
+      }
+    />
+    <div
+      className="usa-grid-full condensed-card-buttons-section"
+    >
+      <Flag
+        name="flags.bidding"
+        render={[Function]}
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`ResultsCondensedCardBottomComponent matches snapshot with bidlist button 1`] = `
 <div
   className="condensed-card-bottom-container"

--- a/src/Components/ResultsControls/ResultsControls.jsx
+++ b/src/Components/ResultsControls/ResultsControls.jsx
@@ -28,7 +28,7 @@ class ResultsControls extends Component {
   render() {
     const { results, hasLoaded, defaultSort, pageSizes,
             defaultPageSize, defaultPageNumber, sortBy } = this.props;
-    const { isProjectedVacancy } = this.context;
+    const { isProjectedVacancy, isClient } = this.context;
     return (
       <div className="usa-grid-full results-controls">
         <div className="usa-width-one-fifth total-results">
@@ -90,9 +90,12 @@ class ResultsControls extends Component {
                         <SearchResultsExportLink count={results.count} />
                       </PermissionsWrapper>
                     </div>
-                    <Trigger isPrimary>
-                      <button className="usa-button">Save Search</button>
-                    </Trigger>
+                    {
+                      !isClient &&
+                      <Trigger isPrimary>
+                        <button className="usa-button">Save Search</button>
+                      </Trigger>
+                    }
                   </div>
                 </div>
               )
@@ -106,6 +109,7 @@ class ResultsControls extends Component {
 
 ResultsControls.contextTypes = {
   isProjectedVacancy: PropTypes.bool,
+  isClient: PropTypes.bool,
 };
 
 ResultsControls.propTypes = {

--- a/src/Components/ResultsControls/ResultsControls.test.jsx
+++ b/src/Components/ResultsControls/ResultsControls.test.jsx
@@ -112,4 +112,18 @@ describe('ResultsControlsComponent', () => {
     />);
     expect(toJSON(wrapper)).toMatchSnapshot();
   });
+
+  it('matches snapshot when context.isClient === true', () => {
+    wrapper = shallow(<ResultsControls
+      results={resultsObject}
+      isLoading={isLoading}
+      queryParamUpdate={onQueryParamUpdate}
+      sortBy={sortBy}
+      pageSizes={pageSizes}
+      pageCount={pageCount}
+      hasLoaded={hasLoaded}
+      onToggle={onToggle}
+    />, { context: { isClient: true } });
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
 });

--- a/src/Components/ResultsControls/__snapshots__/ResultsControls.test.jsx.snap
+++ b/src/Components/ResultsControls/__snapshots__/ResultsControls.test.jsx.snap
@@ -20,3 +20,24 @@ exports[`ResultsControlsComponent matches snapshot 1`] = `
   />
 </div>
 `;
+
+exports[`ResultsControlsComponent matches snapshot when context.isClient === true 1`] = `
+<div
+  className="usa-grid-full results-controls"
+>
+  <div
+    className="usa-width-one-fifth total-results"
+  >
+    <TotalResults
+      pageNumber={0}
+      pageSize={10}
+      suffix="Results"
+      total={2}
+    />
+  </div>
+  <MediaQueryWrapper
+    breakpoint="screenMdMin"
+    widthType="min"
+  />
+</div>
+`;

--- a/src/Components/ResultsPage/ResultsPage.jsx
+++ b/src/Components/ResultsPage/ResultsPage.jsx
@@ -21,7 +21,10 @@ class Results extends Component {
   }
 
   getChildContext() {
-    return { isProjectedVacancy: this.props.isProjectedVacancy };
+    return {
+      isProjectedVacancy: this.props.isProjectedVacancy,
+      isClient: this.props.isClient,
+    };
   }
 
   shouldComponentUpdate(nextProps) {
@@ -145,6 +148,7 @@ Results.propTypes = {
   isProjectedVacancy: PropTypes.bool,
   showClear: PropTypes.bool,
   shouldShowMobileFilter: PropTypes.bool,
+  isClient: PropTypes.bool,
 };
 
 Results.defaultProps = {
@@ -166,6 +170,7 @@ Results.defaultProps = {
   isProjectedVacancy: false,
   showClear: false,
   shouldShowMobileFilter: false,
+  isClient: false,
 };
 
 Results.contextTypes = {
@@ -174,6 +179,7 @@ Results.contextTypes = {
 
 Results.childContextTypes = {
   isProjectedVacancy: PropTypes.bool,
+  isClient: PropTypes.bool,
 };
 
 export const mapStateToProps = state => ({

--- a/src/Constants/SystemMessages.js
+++ b/src/Constants/SystemMessages.js
@@ -38,7 +38,7 @@ export const GENERAL_SAVED_SEARCH_ERROR = 'An error occurred trying to save this
 
 export const DELETE_BID_ITEM_SUCCESS = 'Bid successfully removed.';
 export const DELETE_BID_ITEM_ERROR = 'Error trying to delete this bid.';
-export const ADD_BID_ITEM_SUCCESS = BidAddSuccess();
+export const ADD_BID_ITEM_SUCCESS = (props = {}) => BidAddSuccess(props);
 export const ADD_BID_ITEM_ERROR = 'Error trying to add this bid.';
 
 export const ADD_FAVORITE_TITLE = 'Favorite Added';

--- a/src/Constants/SystemMessages.test.js
+++ b/src/Constants/SystemMessages.test.js
@@ -1,3 +1,4 @@
+import { isArray } from 'lodash';
 import * as SystemMessages from './SystemMessages';
 
 const expectedMessages = [
@@ -33,7 +34,7 @@ const expectedMessages = [
 
   'DELETE_BID_ITEM_SUCCESS',
   'DELETE_BID_ITEM_ERROR',
-  'ADD_BID_ITEM_SUCCESS',
+  ['ADD_BID_ITEM_SUCCESS'], // array denotes that it is a function
   'ADD_BID_ITEM_ERROR',
 
   'ACCEPT_BID_SUCCESS',
@@ -48,7 +49,7 @@ const expectedMessages = [
 describe('SystemMessages', () => {
   it('should have all expected messages defined', () => {
     expectedMessages.forEach((msg) => {
-      expect(SystemMessages[msg]).toBeDefined();
+      expect(isArray(msg) ? SystemMessages[msg]() : SystemMessages[msg]).toBeDefined();
     });
   });
 

--- a/src/Containers/BidListButton/BidListButton.jsx
+++ b/src/Containers/BidListButton/BidListButton.jsx
@@ -1,39 +1,55 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { SetType, BID_LIST } from '../../Constants/PropTypes';
-import { toggleBidPosition } from '../../actions/bidList';
+import { SetType, BID_LIST, EMPTY_FUNCTION } from '../../Constants/PropTypes';
+import { toggleBidPosition, toggleClientBidPosition } from '../../actions/bidList';
 import BidListButton from '../../Components/BidListButton';
 
-const BidListButtonContainer = ({ toggleBid, isLoading, id, compareArray, ...rest }) => (
-  <BidListButton
-    toggleBidPosition={toggleBid}
-    id={id}
-    isLoading={isLoading.has(id)}
-    compareArray={compareArray.results}
-    {...rest}
-  />
+const BidListButtonContainer = (
+  { toggleBid, toggleClientBid, isLoading, id, compareArray, clientCompareArray, ...rest },
+  { isClient },
+  ) => (
+    <BidListButton
+      toggleBidPosition={(id$, remove) => // eslint-disable-line no-confusing-arrow
+        isClient ?
+          toggleClientBid(id$, remove) :
+          toggleBid(id$, remove)}
+      id={id}
+      isLoading={isLoading.has(id)}
+      compareArray={[isClient ? clientCompareArray : compareArray].results}
+      {...rest}
+    />
 );
+
+BidListButtonContainer.contextTypes = {
+  isClient: PropTypes.bool,
+};
 
 BidListButtonContainer.propTypes = {
   toggleBid: PropTypes.func.isRequired,
+  toggleClientBid: PropTypes.func,
   isLoading: SetType,
   id: PropTypes.number.isRequired,
-  compareArray: BID_LIST.isRequired,
+  compareArray: BID_LIST,
+  clientCompareArray: BID_LIST,
 };
 
 BidListButtonContainer.defaultProps = {
+  toggleClientBid: EMPTY_FUNCTION,
   isLoading: new Set(),
   compareArray: { results: [] },
+  clientCompareArray: { results: [] },
 };
 
 export const mapStateToProps = state => ({
   isLoading: state.bidListToggleIsLoading,
   compareArray: state.bidListFetchDataSuccess,
+  clientCompareArray: state.clientBidListFetchDataSuccess,
 });
 
 export const mapDispatchToProps = dispatch => ({
   toggleBid: (id, remove) => dispatch(toggleBidPosition(id, remove)),
+  toggleClientBid: (id, remove) => dispatch(toggleClientBidPosition(id, remove)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(BidListButtonContainer);

--- a/src/Containers/Position/Position.jsx
+++ b/src/Containers/Position/Position.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 import { withRouter } from 'react-router';
+import { get } from 'lodash';
 import PositionDetails from '../../Components/PositionDetails/PositionDetails';
 // Actions
 import { positionDetailsFetchData } from '../../actions/positionDetails';
@@ -28,6 +29,7 @@ import {
   DESCRIPTION_EDIT_HAS_ERRORED,
   EMPTY_FUNCTION,
   HIGHLIGHT_POSITION,
+  BIDDER_OBJECT,
 } from '../../Constants/PropTypes';
 
 class Position extends Component {
@@ -90,7 +92,12 @@ class Position extends Component {
       highlightPosition,
       onHighlight,
       isProjectedVacancy,
+      client,
+      clientIsLoading,
+      clientHasErrored,
     } = this.props;
+
+    const isClient = client && !!client.id && !clientIsLoading && !clientHasErrored;
 
     return (
       <PositionDetails
@@ -115,6 +122,7 @@ class Position extends Component {
         highlightPosition={highlightPosition}
         onHighlight={onHighlight}
         isProjectedVacancy={isProjectedVacancy}
+        isClient={isClient}
       />
     );
   }
@@ -156,6 +164,9 @@ Position.propTypes = {
   highlightPosition: HIGHLIGHT_POSITION,
   onHighlight: PropTypes.func.isRequired,
   isProjectedVacancy: PropTypes.bool,
+  client: BIDDER_OBJECT,
+  clientIsLoading: PropTypes.bool,
+  clientHasErrored: PropTypes.bool,
 };
 
 Position.defaultProps = {
@@ -182,6 +193,9 @@ Position.defaultProps = {
   highlightPosition: DEFAULT_HIGHLIGHT_POSITION,
   onHighlight: EMPTY_FUNCTION,
   isProjectedVacancy: false,
+  client: {},
+  clientIsLoading: false,
+  clientHasErrored: false,
 };
 
 const mapStateToProps = (state, ownProps) => ({
@@ -201,6 +215,9 @@ const mapStateToProps = (state, ownProps) => ({
   descriptionEditIsLoading: state.descriptionEditIsLoading,
   descriptionEditSuccess: state.descriptionEditSuccess,
   highlightPosition: state.highlightPosition,
+  client: get(state, 'clientView.client'),
+  clientIsLoading: get(state, 'clientView.isLoading'),
+  clientHasErrored: get(state, 'clientView.hasErrored'),
 });
 
 export const mapDispatchToProps = dispatch => ({

--- a/src/Containers/Results/Results.jsx
+++ b/src/Containers/Results/Results.jsx
@@ -19,7 +19,7 @@ import ResultsPage from '../../Components/ResultsPage/ResultsPage';
 import CompareDrawer from '../../Components/CompareDrawer';
 import { POSITION_SEARCH_RESULTS, FILTERS_PARENT, ACCORDION_SELECTION_OBJECT,
 USER_PROFILE, MISSION_DETAILS_ARRAY, POST_DETAILS_ARRAY,
-EMPTY_FUNCTION, BID_LIST } from '../../Constants/PropTypes';
+EMPTY_FUNCTION, BID_LIST, BIDDER_OBJECT } from '../../Constants/PropTypes';
 import { ACCORDION_SELECTION } from '../../Constants/DefaultProps';
 import { LOGIN_REDIRECT } from '../../login/routes';
 import { POSITION_SEARCH_SORTS, POSITION_PAGE_SIZES, POSITION_PAGE_SIZES_TYPE,
@@ -250,10 +250,12 @@ class Results extends Component {
             selectedAccordion, setAccordion, userProfile, fetchMissionAutocomplete,
             missionSearchResults, missionSearchIsLoading, missionSearchHasErrored,
             fetchPostAutocomplete, postSearchResults, postSearchIsLoading,
-            postSearchHasErrored, shouldShowSearchBar, bidList } = this.props;
+            postSearchHasErrored, shouldShowSearchBar, bidList,
+            client, clientIsLoading, clientHasErrored } = this.props;
     const { filtersIsLoading } = this.state;
     const filters$ = shouldUseAPFilters() ? filtersAP : filters;
     const showClear = this.getQueryExists();
+    const isClient = client && !!client.id && !clientIsLoading && !clientHasErrored;
     return (
       <div>
         <ResultsPage
@@ -289,6 +291,7 @@ class Results extends Component {
           bidList={bidList.results}
           isProjectedVacancy={results.isProjectedVacancy}
           showClear={showClear}
+          isClient={isClient}
         />
         <CompareDrawer />
       </div>
@@ -328,6 +331,9 @@ Results.propTypes = {
   bidListFetchData: PropTypes.func.isRequired,
   defaultPageSize: PropTypes.number.isRequired,
   storeSearch: PropTypes.func,
+  client: BIDDER_OBJECT,
+  clientIsLoading: PropTypes.bool,
+  clientHasErrored: PropTypes.bool,
 };
 
 Results.defaultProps = {
@@ -352,6 +358,9 @@ Results.defaultProps = {
   debounceTimeInMs: 50,
   bidList: { results: [] },
   storeSearch: EMPTY_FUNCTION,
+  client: {},
+  clientIsLoading: false,
+  clientHasErrored: false,
 };
 
 const mapStateToProps = state => ({
@@ -374,6 +383,9 @@ const mapStateToProps = state => ({
   shouldShowSearchBar: state.shouldShowSearchBar,
   bidList: state.bidListFetchDataSuccess,
   defaultPageSize: get(state, `sortPreferences.${POSITION_PAGE_SIZES_TYPE}.defaultSort`, POSITION_PAGE_SIZES.defaultSort),
+  client: get(state, 'clientView.client'),
+  clientIsLoading: get(state, 'clientView.isLoading'),
+  clientHasErrored: get(state, 'clientView.hasErrored'),
 });
 
 export const mapDispatchToProps = dispatch => ({

--- a/src/actions/clientView.js
+++ b/src/actions/clientView.js
@@ -1,5 +1,6 @@
 import api from '../api';
 import { toastSuccess, toastError } from './toast';
+import { clientBidListFetchData } from './bidList';
 import { SET_CLIENT_SUCCESS, GET_CLIENT_SUCCESS_MESSAGE, SET_CLIENT_ERROR,
   UNSET_CLIENT_SUCCESS, UNSET_CLIENT_SUCCESS_MESSAGE } from '../Constants/SystemMessages';
 
@@ -27,6 +28,7 @@ export function setClient(id) {
     api().get(`/client/${id}/`)
       .then(({ data }) => {
         dispatch(setClientViewAs({ client: data, isLoading: false, hasErrored: false }));
+        dispatch(clientBidListFetchData());
         dispatch(toastSuccess(GET_CLIENT_SUCCESS_MESSAGE(data.user), SET_CLIENT_SUCCESS));
       })
       .catch(() => {

--- a/src/reducers/bidList/bidList.js
+++ b/src/reducers/bidList/bidList.js
@@ -22,6 +22,30 @@ export function bidListFetchDataSuccess(state = { results: [] }, action) {
       return state;
   }
 }
+export function clientBidListHasErrored(state = false, action) {
+  switch (action.type) {
+    case 'CLIENT_BID_LIST_HAS_ERRORED':
+      return action.hasErrored;
+    default:
+      return state;
+  }
+}
+export function clientBidListIsLoading(state = false, action) {
+  switch (action.type) {
+    case 'CLIENT_BID_LIST_IS_LOADING':
+      return action.isLoading;
+    default:
+      return state;
+  }
+}
+export function clientBidListFetchDataSuccess(state = { results: [] }, action) {
+  switch (action.type) {
+    case 'CLIENT_BID_LIST_FETCH_DATA_SUCCESS':
+      return action.results;
+    default:
+      return state;
+  }
+}
 export function bidListToggleHasErrored(state = false, action) {
   switch (action.type) {
     case 'BID_LIST_TOGGLE_HAS_ERRORED':

--- a/src/reducers/bidList/index.js
+++ b/src/reducers/bidList/index.js
@@ -1,12 +1,17 @@
 import { bidListHasErrored, bidListIsLoading, bidListFetchDataSuccess,
+  clientBidListHasErrored, clientBidListIsLoading, clientBidListFetchDataSuccess,
   bidListToggleHasErrored, bidListToggleIsLoading, bidListToggleSuccess,
   submitBidHasErrored, submitBidIsLoading, submitBidSuccess,
   acceptBidHasErrored, acceptBidIsLoading, acceptBidSuccess,
   declineBidHasErrored, declineBidIsLoading, declineBidSuccess } from './bidList';
 
-export default { bidListHasErrored,
+export default {
+  bidListHasErrored,
   bidListIsLoading,
   bidListFetchDataSuccess,
+  clientBidListHasErrored,
+  clientBidListIsLoading,
+  clientBidListFetchDataSuccess,
   bidListToggleHasErrored,
   bidListToggleIsLoading,
   bidListToggleSuccess,
@@ -18,4 +23,5 @@ export default { bidListHasErrored,
   acceptBidSuccess,
   declineBidHasErrored,
   declineBidIsLoading,
-  declineBidSuccess };
+  declineBidSuccess,
+};

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,6 +1,6 @@
 import Scroll from 'react-scroll';
 import { distanceInWords, format } from 'date-fns';
-import { cloneDeep, get, intersection, isEqual, isNumber, isObject, keys, lowerCase,
+import { cloneDeep, get, intersection, isArray, isEqual, isNumber, isObject, keys, lowerCase,
   merge as merge$, orderBy, toString, transform } from 'lodash';
 import numeral from 'numeral';
 import queryString from 'query-string';
@@ -258,8 +258,9 @@ export const existsInArray = (ref, array) => {
 
 // for checking if a position is in the user's bid list
 export const existsInNestedObject = (ref, array, prop = 'position', nestedProp = 'id') => {
+  const array$ = isArray(array) ? array : [];
   let found = false;
-  array.some((i) => {
+  array$.some((i) => {
     if (i[prop] && i[prop][nestedProp] === ref) {
       found = i;
       return true;


### PR DESCRIPTION
This doesn't add full functionality (waiting on endpoints for CDO to bid on behalf of a client), but builds on the ability for a CDO to work through that process.

When a client is selected from the CDO portfolio:
- Search results cards lose the "Add to Favorites" and "Compare" and display "Add to Client's Bid List"
- Same thing for Position details as above