### PR TITLE
Explicitly require certain browsers to allow dark mode

### DIFF
--- a/src/Components/AccountDropdown/AccountDropdown.jsx
+++ b/src/Components/AccountDropdown/AccountDropdown.jsx
@@ -15,11 +15,14 @@ const browserHandler = () => {
   switch (getBrowserName()) {
     // Dark mode breaks in IE11.
     // Attempt to disable dark mode if for some reason it is set to true.
-    case 'Internet Explorer': {
-      return null;
+    // Also set in src/Containers/DarkMode/DarkMode.jsx
+    case 'Chrome':
+    case 'Firefox':
+    case 'Safari': {
+      return <DarkModeToggle className="unstyled-button account-dropdown--identity account-dropdown--segment account-dropdown-link account-dropdown-link--button" />;
     }
     default: {
-      return <DarkModeToggle className="unstyled-button account-dropdown--identity account-dropdown--segment account-dropdown-link account-dropdown-link--button" />;
+      return null;
     }
   }
 };

--- a/src/Components/AccountDropdown/__snapshots__/AccountDropdown.test.jsx.snap
+++ b/src/Components/AccountDropdown/__snapshots__/AccountDropdown.test.jsx.snap
@@ -46,9 +46,6 @@ exports[`AccountDropdown matches snapshot 1`] = `
       >
         Dashboard
       </Link>
-      <Connect(DarkModeToggle)
-        className="unstyled-button account-dropdown--identity account-dropdown--segment account-dropdown-link account-dropdown-link--button"
-      />
       <Link
         className="account-dropdown--identity account-dropdown--segment account-dropdown-link"
         onClick={[Function]}
@@ -114,9 +111,6 @@ exports[`AccountDropdown matches snapshot when shouldDisplayName is true 1`] = `
       >
         Dashboard
       </Link>
-      <Connect(DarkModeToggle)
-        className="unstyled-button account-dropdown--identity account-dropdown--segment account-dropdown-link account-dropdown-link--button"
-      />
       <Link
         className="account-dropdown--identity account-dropdown--segment account-dropdown-link"
         onClick={[Function]}

--- a/src/Containers/DarkMode/DarkMode.jsx
+++ b/src/Containers/DarkMode/DarkMode.jsx
@@ -38,11 +38,14 @@ class DarkMode extends Component {
     switch (getBrowserName()) {
       // Dark mode breaks in IE11.
       // Attempt to disable dark mode if for some reason it is set to true.
-      case 'Internet Explorer': {
-        return <div>{this.props.isDarkMode && setMode(false)}</div>;
+      // Also set in src/Components/AccountDropdown/AccountDropdown.jsx
+      case 'Chrome':
+      case 'Firefox':
+      case 'Safari': {
+        return <div />;
       }
       default: {
-        return <div />;
+        return <div>{this.props.isDarkMode && setMode(false)}</div>;
       }
     }
   }

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -661,4 +661,4 @@ export const scrollToGlossaryTerm = (term) => {
 
 export const shouldUseAPFilters = () => checkFlag('flags.available_positions');
 
-export const getBrowserName = () => Bowser.getParser(window.navigator.userAgent).getBrowserName();
+export const getBrowserName = () => Bowser.getParser(window.navigator.userAgent).getBrowserName;


### PR DESCRIPTION
Because Dark Mode doesn't work in some browsers (Edge and IE11, and maybe others).