### PR TITLE
Include capsule description in client-side export

### DIFF
--- a/src/Components/SearchResultsExportLink/SearchResultsExportLink.jsx
+++ b/src/Components/SearchResultsExportLink/SearchResultsExportLink.jsx
@@ -32,6 +32,7 @@ const HEADERS = [
   { label: 'Bid Cycle/Season', key: 'bidcycle__name' },
   { label: 'Posted date', key: 'posted_date' },
   { label: 'Status code', key: 'status_code' },
+  { label: 'Capsule Description', key: 'position__description__content' },
 ];
 
 // Processes results before sending to the download component to allow for custom formatting.

--- a/src/Components/SearchResultsExportLink/__snapshots__/SearchResultsExportLink.test.jsx.snap
+++ b/src/Components/SearchResultsExportLink/__snapshots__/SearchResultsExportLink.test.jsx.snap
@@ -85,6 +85,10 @@ exports[`SearchResultsExportLink matches snapshot 1`] = `
           "key": "status_code",
           "label": "Status code",
         },
+        Object {
+          "key": "position__description__content",
+          "label": "Capsule Description",
+        },
       ]
     }
     separator=","


### PR DESCRIPTION
Only relevant when `available_positions` feature flag is `false`.

Also, see related bug TM-1403 which I will be working on.