### PR TITLE
Update/remove edit classifications TM-1413

### DIFF
--- a/src/Components/BidTracker/BidStep/__snapshots__/BidSteps.test.jsx.snap
+++ b/src/Components/BidTracker/BidStep/__snapshots__/BidSteps.test.jsx.snap
@@ -5,6 +5,7 @@ exports[`BidStepsComponent matches snapshot 1`] = `
   current={0}
   direction="horizontal"
   iconPrefix="rc"
+  initial={0}
   labelPlacement="vertical"
   prefixCls="rc-steps"
   progressDot={false}

--- a/src/Components/BidTracker/BidStep/__snapshots__/BidSteps.test.jsx.snap
+++ b/src/Components/BidTracker/BidStep/__snapshots__/BidSteps.test.jsx.snap
@@ -5,7 +5,6 @@ exports[`BidStepsComponent matches snapshot 1`] = `
   current={0}
   direction="horizontal"
   iconPrefix="rc"
-  initial={0}
   labelPlacement="vertical"
   prefixCls="rc-steps"
   progressDot={false}

--- a/src/Components/ProfileDashboard/Updates/Updates.jsx
+++ b/src/Components/ProfileDashboard/Updates/Updates.jsx
@@ -11,6 +11,7 @@ class Updates extends Component {
     this.disableEdit = this.disableEdit.bind(this);
     this.state = {
       isEditable: false,
+      hideEditButton: true,
     };
   }
   enableEdit() {
@@ -20,7 +21,7 @@ class Updates extends Component {
     this.setState({ isEditable: false });
   }
   render() {
-    const { isEditable } = this.state;
+    const { isEditable, hideEditButton } = this.state;
     return (
       <div className="usa-grid-full profile-section-container updates-container">
         <div className="usa-grid-full section-padded-inner-container">
@@ -31,10 +32,13 @@ class Updates extends Component {
             <CheckboxList isDisabled={!isEditable} id="updates" />
           </div>
         </div>
-        <div className="section-padded-inner-container small-link-container view-more-link-centered">
-          { !isEditable && <button className="unstyled-button" onClick={this.enableEdit}><FA name="pencil" /> Edit Updates</button> }
-          { isEditable && <EditButtons initialShowSave onChange={this.disableEdit} /> }
-        </div>
+        {
+          !hideEditButton &&
+          <div className="section-padded-inner-container small-link-container view-more-link-centered">
+            { !isEditable && <button className="unstyled-button" onClick={this.enableEdit}><FA name="pencil" /> Edit Updates</button> }
+            { isEditable && <EditButtons initialShowSave onChange={this.disableEdit} /> }
+          </div>
+        }
       </div>
     );
   }

--- a/src/Components/ProfileDashboard/Updates/Updates.jsx
+++ b/src/Components/ProfileDashboard/Updates/Updates.jsx
@@ -11,7 +11,7 @@ class Updates extends Component {
     this.disableEdit = this.disableEdit.bind(this);
     this.state = {
       isEditable: false,
-      hideEditButton: true,
+      showEditButton: false,
     };
   }
   enableEdit() {
@@ -21,7 +21,7 @@ class Updates extends Component {
     this.setState({ isEditable: false });
   }
   render() {
-    const { isEditable, hideEditButton } = this.state;
+    const { isEditable, showEditButton } = this.state;
     return (
       <div className="usa-grid-full profile-section-container updates-container">
         <div className="usa-grid-full section-padded-inner-container">
@@ -33,7 +33,7 @@ class Updates extends Component {
           </div>
         </div>
         {
-          !hideEditButton &&
+          !!showEditButton &&
           <div className="section-padded-inner-container small-link-container view-more-link-centered">
             { !isEditable && <button className="unstyled-button" onClick={this.enableEdit}><FA name="pencil" /> Edit Updates</button> }
             { isEditable && <EditButtons initialShowSave onChange={this.disableEdit} /> }

--- a/src/Components/ProfileDashboard/Updates/Updates.test.jsx
+++ b/src/Components/ProfileDashboard/Updates/Updates.test.jsx
@@ -14,6 +14,8 @@ describe('UpdatesComponent', () => {
     expect(wrapper.find('button').length).toBe(0);
   });
 
+  // TESTS FOR EDIT FUNCTIONALITY OF UPDATES (CLASSIFICATIONS) -FUTURE FEATURE-
+  //
   // it('renders one button on mount when showEditButton is true ', () => {
   //   const wrapper = shallow(<Updates />);
   //   expect(wrapper.find('button').length).toBe(1);

--- a/src/Components/ProfileDashboard/Updates/Updates.test.jsx
+++ b/src/Components/ProfileDashboard/Updates/Updates.test.jsx
@@ -9,27 +9,33 @@ describe('UpdatesComponent', () => {
     expect(wrapper).toBeDefined();
   });
 
-  it('renders one button on mount', () => {
+  it('renders no button on mount when showEditButton is false', () => {
     const wrapper = shallow(<Updates />);
-    expect(wrapper.find('button').length).toBe(1);
-    expect(wrapper.find('EditButtons').exists()).toBe(false);
+    expect(wrapper.find('button').length).toBe(0);
   });
 
-  it('renders two buttons when the Edit button is clicked', () => {
-    const wrapper = shallow(<Updates />);
-    wrapper.find('button').simulate('click');
-    expect(wrapper.find('button').exists()).toBe(false);
-    expect(wrapper.find('EditButtons').exists()).toBe(true);
-  });
+  // it('renders one button on mount when showEditButton is true ', () => {
+  //   const wrapper = shallow(<Updates />);
+  //   expect(wrapper.find('button').length).toBe(1);
+  //   expect(wrapper.find('EditButtons').exists()).toBe(false);
+  // });
 
-  it('renders one button when enableEdit() is called and then disableEdit() is called', () => {
-    const wrapper = shallow(<Updates />);
-    const instance = wrapper.instance();
-    instance.enableEdit();
-    instance.disableEdit();
-    expect(wrapper.find('button').length).toBe(1);
-    expect(wrapper.find('EditButtons').exists()).toBe(false);
-  });
+  // it('renders two buttons when the Edit button is clicked', () => {
+  //   const wrapper = shallow(<Updates />);
+  //   wrapper.find('button').simulate('click');
+  //   expect(wrapper.find('button').exists()).toBe(false);
+  //   expect(wrapper.find('EditButtons').exists()).toBe(true);
+  // });
+
+  // it('renders one button when enableEdit() is called and then disableEdit() is called', () => {
+  //   const wrapper = shallow(<Updates />);
+  //   const instance = wrapper.instance();
+  //   instance.enableEdit();
+  //   instance.disableEdit();
+  //   expect(wrapper.find('button').length).toBe(1);
+  //   expect(wrapper.find('EditButtons').exists()).toBe(false);
+  // });
+
 
   it('matches snapshot', () => {
     const wrapper = shallow(<Updates />);

--- a/src/Components/ProfileDashboard/Updates/__snapshots__/Updates.test.jsx.snap
+++ b/src/Components/ProfileDashboard/Updates/__snapshots__/Updates.test.jsx.snap
@@ -26,18 +26,5 @@ exports[`UpdatesComponent matches snapshot 1`] = `
       />
     </div>
   </div>
-  <div
-    className="section-padded-inner-container small-link-container view-more-link-centered"
-  >
-    <button
-      className="unstyled-button"
-      onClick={[Function]}
-    >
-      <FontAwesome
-        name="pencil"
-      />
-       Edit Updates
-    </button>
-  </div>
 </div>
 `;


### PR DESCRIPTION
Removed the ability to select/see the edit buttons. Still need to setup how we will receive and use the classifications from FSBid. Should that be a separate BE/FE PR/jira ticket, or just do it in this PR?