### PR TITLE
Use the correct variable to reference the client's ID

### DIFF
--- a/src/actions/bidList.js
+++ b/src/actions/bidList.js
@@ -310,19 +310,20 @@ export function toggleBidPosition(id, remove, isClient, clientId, fromTracker) {
       url: `/fsbid/bidlist/position/${idString}/`,
     };
 
-    let client;
+    const { client: client$ } = getState().clientView;
+    const client = client$;
+
+    // Allow function param to override client in state, if it exists
+    const clientToUse = clientId || client.perdet_seq_number;
 
     // using the client context
     if (isClient) {
-      const { client: client$ } = getState().clientView;
-      client = client$;
-
-      config.url = `/fsbid/cdo/position/${idString}/client/${client.perdet_seq_number}/`;
+      config.url = `/fsbid/cdo/position/${idString}/client/${clientToUse}/`;
     }
 
     // explicitly using a clientId
     if (clientId) {
-      config.url = `/fsbid/cdo/position/${idString}/client/${clientId}/`;
+      config.url = `/fsbid/cdo/position/${idString}/client/${clientToUse}/`;
     }
 
     api()(config)
@@ -334,9 +335,9 @@ export function toggleBidPosition(id, remove, isClient, clientId, fromTracker) {
         dispatch(toastSuccess(message));
         dispatch(bidListToggleIsLoading(false, id));
         dispatch(bidListToggleHasErrored(false));
-        if (isClient || clientId) { // could be optimized to reduce duplicate calls
+        if (clientToUse) { // could be optimized to reduce duplicate calls
           dispatch(clientBidListFetchData());
-          dispatch(userProfilePublicFetchData(clientId));
+          dispatch(userProfilePublicFetchData(clientToUse));
         } else {
           dispatch(bidListFetchData());
         }

--- a/src/actions/bidList.test.js
+++ b/src/actions/bidList.test.js
@@ -4,6 +4,8 @@ import * as actions from './bidList';
 const { mockStore, mockAdapter } = setupAsyncMocks();
 
 describe('async actions', () => {
+  let store;
+
   const bidList = {
     count: 2,
     next: null,
@@ -31,11 +33,11 @@ describe('async actions', () => {
   // reset the mockAdapter since we repeat specific requests
   beforeEach(() => {
     mockAdapter.reset();
+
+    store = mockStore({ profile: {}, clientView: { client: { perdet_seq_number: 1 } } });
   });
 
   it('can fetch a bid list', (done) => {
-    const store = mockStore({ });
-
     mockAdapter.onGet('http://localhost:8000/api/v1/fsbid/bidlist/?ordering=draft_date').reply(200,
       bidList,
     );
@@ -50,8 +52,6 @@ describe('async actions', () => {
   });
 
   it('can handle errors when fetching a bid list', (done) => {
-    const store = mockStore({ });
-
     mockAdapter.onGet('http://localhost:8000/api/v1/fsbid/bidlist/?ordering=draft_date').reply(404,
       null,
     );
@@ -66,8 +66,6 @@ describe('async actions', () => {
   });
 
   it('can remove a position from the bid list', (done) => {
-    const store = mockStore({ profile: {} });
-
     mockAdapter.onDelete('http://localhost:8000/api/v1/fsbid/bidlist/position/1/').reply(204,
       null,
     );
@@ -82,8 +80,6 @@ describe('async actions', () => {
   });
 
   it('can add a position to the bid list', (done) => {
-    const store = mockStore({ profile: {} });
-
     mockAdapter.onPut('http://localhost:8000/api/v1/fsbid/bidlist/position/1/').reply(204,
       null,
     );
@@ -98,8 +94,6 @@ describe('async actions', () => {
   });
 
   it('can submit a bid', (done) => {
-    const store = mockStore({ profile: {} });
-
     mockAdapter.onPut('http://localhost:8000/api/v1/fsbid/bidlist/position/1/submit/').reply(204,
       null,
     );
@@ -114,8 +108,6 @@ describe('async actions', () => {
   });
 
   it('can handle errors when submitting a bid', (done) => {
-    const store = mockStore({ profile: {} });
-
     mockAdapter.onPut('http://localhost:8000/api/v1/fsbid/bidlist/position/1/submit/').reply(404,
       null,
     );
@@ -130,8 +122,6 @@ describe('async actions', () => {
   });
 
   it('can handle errors when adding a position to the bid list', (done) => {
-    const store = mockStore({ profile: {} });
-
     mockAdapter.onPut('http://localhost:8000/api/v1/fsbid/bidlist/position/1/').reply(404,
       null,
     );
@@ -146,8 +136,6 @@ describe('async actions', () => {
   });
 
   it('can accept a bid', (done) => {
-    const store = mockStore({});
-
     mockAdapter.onGet('http://localhost:8000/api/v1/bid/1/accept_handshake/').reply(204,
       null,
     );
@@ -162,8 +150,6 @@ describe('async actions', () => {
   });
 
   it('can handle errors when accepting a bid', (done) => {
-    const store = mockStore({});
-
     mockAdapter.onGet('http://localhost:8000/api/v1/bid/1/accept_handshake/').reply(404,
       null,
     );
@@ -178,8 +164,6 @@ describe('async actions', () => {
   });
 
   it('can decline a bid', (done) => {
-    const store = mockStore({});
-
     mockAdapter.onGet('http://localhost:8000/api/v1/bid/1/decline_handshake/').reply(204,
       null,
     );
@@ -194,8 +178,6 @@ describe('async actions', () => {
   });
 
   it('can handle errors when declining a bid', (done) => {
-    const store = mockStore({});
-
     mockAdapter.onGet('http://localhost:8000/api/v1/bid/1/decline_handshake/').reply(404,
       null,
     );

--- a/src/actions/userProfilePublic.js
+++ b/src/actions/userProfilePublic.js
@@ -44,7 +44,7 @@ export function userProfilePublicFetchData(id, bypass) {
     const getUserAccount = () => api().get(`/fsbid/client/${id}/`);
 
     // bids
-    const getUserBids = () => api().get(`/fsbid/cdo/client/${id}/`); // TODO use fsbid
+    const getUserBids = () => api().get(`/fsbid/cdo/client/${id}/`);
 
     // use api' Promise.all to fetch the profile, assignments and any other requests we
     // might add in the future


### PR DESCRIPTION
Previously, this was checking for either a function parameter or a state value to get the client's ID. However, only one of those values was being checked when being passed into `userProfilePublicFetchData`. This change fixes it so that it will look for either, with priority given to client ID that is passed via function parameter.