### PR TITLE
Fix and clean up the position export urls

### DIFF
--- a/src/actions/results.js
+++ b/src/actions/results.js
@@ -74,9 +74,10 @@ export function resultsFetchSimilarPositions(id) {
 }
 
 export function downloadPositionData(query, isPV) {
-  const prefix = `fsbid/${!isPV ? '/fsbid/available_positions' : '/fsbid/projected_vacancies'}/export`;
+  const prefix = `/fsbid${isPV ? '/projected_vacancies' : '/available_positions'}/export/`;
+  console.log(prefix, query);
   return api()
-  .get(`${prefix}/?${query}`, {
+  .get(`${prefix}?${query}`, {
     cancelToken: new CancelToken((c) => { cancel = c; }),
     responseType: 'stream',
   })

--- a/src/actions/results.js
+++ b/src/actions/results.js
@@ -75,7 +75,6 @@ export function resultsFetchSimilarPositions(id) {
 
 export function downloadPositionData(query, isPV) {
   const prefix = `/fsbid${isPV ? '/projected_vacancies' : '/available_positions'}/export/`;
-  console.log(prefix, query);
   return api()
   .get(`${prefix}?${query}`, {
     cancelToken: new CancelToken((c) => { cancel = c; }),


### PR DESCRIPTION
There was an extra `fsbid/` prefix in the URL, causing the position export to fail.