### PR TITLE
Include client's skills and grade in "Search as Client" results

### DIFF
--- a/src/Components/BidderPortfolio/BidderPortfolioStatCard/BidderPortfolioStatCard.jsx
+++ b/src/Components/BidderPortfolio/BidderPortfolioStatCard/BidderPortfolioStatCard.jsx
@@ -45,7 +45,7 @@ const BidderPortfolioStatCard = ({ userProfile }) => {
           </StaticDevContent>
         </div>
         <div className="button-container" style={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between' }}>
-          <SearchAsClientButton id={userProfile.perdet_seq_number} />
+          <SearchAsClientButton user={userProfile} />
         </div>
       </div>
     </BoxShadow>

--- a/src/Components/BidderPortfolio/BidderPortfolioStatCard/__snapshots__/BidderPortfolioStatCard.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidderPortfolioStatCard/__snapshots__/BidderPortfolioStatCard.test.jsx.snap
@@ -100,7 +100,116 @@ exports[`BidderPortfolioStatCard matches snapshot 1`] = `
         }
       }
     >
-      <Connect(withRouter(SearchAsClientButton)) />
+      <Connect(withRouter(SearchAsClientButton))
+        user={
+          Object {
+            "assignments": Array [
+              Object {
+                "arrival_date": null,
+                "bid_approval_date": "1975-01-01T00:00:00Z",
+                "combined_differential": 0,
+                "create_date": "2018-01-12T15:11:37.521934Z",
+                "curtailment_reason": null,
+                "end_date": null,
+                "estimated_end_date": "2019-01-12T00:00:00Z",
+                "id": 5,
+                "is_domestic": false,
+                "position": Object {
+                  "bureau": "(WHA) BUREAU OF WESTERN HEMISPHERIC AFFAIRS",
+                  "position_number": "58312265",
+                  "post": Object {
+                    "location": Object {
+                      "city": "Freetown",
+                      "code": "00A",
+                      "country": "Sierra Leone",
+                      "id": 103,
+                      "state": "",
+                    },
+                  },
+                  "skill": "CONSTRUCTION ENGINEERING (6218)",
+                  "title": "PROJECT DIRECTOR",
+                },
+                "service_duration": null,
+                "standard_tod_months": 0,
+                "start_date": "2018-01-12T00:00:00Z",
+                "status": "active",
+                "tour_of_duty": "1 YR (3 R & R)",
+                "update_date": "2018-01-12T15:12:01.013500Z",
+                "user": "Kara Batisak",
+              },
+            ],
+            "bid_statistics": Array [
+              Object {
+                "approved": 0,
+                "bidcycle": "Demo BidCycle 2018-01-12 15:11:38.004793",
+                "closed": 0,
+                "declined": 0,
+                "draft": 5,
+                "handshake_accepted": 0,
+                "handshake_declined": 0,
+                "handshake_offered": 3,
+                "id": 1,
+                "in_panel": 0,
+                "submitted": 2,
+                "user": "Kara Batisak",
+              },
+            ],
+            "current_assignment": Object {
+              "arrival_date": null,
+              "bid_approval_date": "1975-01-01T00:00:00Z",
+              "combined_differential": 0,
+              "create_date": "2018-01-12T15:11:37.521934Z",
+              "curtailment_reason": null,
+              "end_date": null,
+              "estimated_end_date": "2019-01-12T00:00:00Z",
+              "id": 5,
+              "is_domestic": false,
+              "position": Object {
+                "bureau": "(WHA) BUREAU OF WESTERN HEMISPHERIC AFFAIRS",
+                "position_number": "58312265",
+                "post": Object {
+                  "location": Object {
+                    "city": "Freetown",
+                    "code": "00A",
+                    "country": "Sierra Leone",
+                    "id": 103,
+                    "state": "",
+                  },
+                },
+                "skill": "CONSTRUCTION ENGINEERING (6218)",
+                "title": "PROJECT DIRECTOR",
+              },
+              "service_duration": null,
+              "standard_tod_months": 0,
+              "start_date": "2018-01-12T00:00:00Z",
+              "status": "active",
+              "tour_of_duty": "1 YR (3 R & R)",
+              "update_date": "2018-01-12T15:12:01.013500Z",
+              "user": "Kara Batisak",
+            },
+            "grade": "01",
+            "id": 5,
+            "is_cdo": false,
+            "language_qualifications": Array [],
+            "primary_nationality": "United States",
+            "secondary_nationality": null,
+            "skills": Array [
+              Object {
+                "code": "6218",
+                "cone": null,
+                "description": "CONSTRUCTION ENGINEERING",
+                "id": 63,
+              },
+            ],
+            "user": Object {
+              "email": "batisak@state.gov",
+              "first_name": "Kara",
+              "last_name": "Batisak",
+              "username": "batisak",
+            },
+          }
+        }
+      />
     </div>
   </div>
 </BoxShadow>

--- a/src/Components/BidderPortfolio/BidderPortfolioStatRow/BidderPortfolioStatRow.jsx
+++ b/src/Components/BidderPortfolio/BidderPortfolioStatRow/BidderPortfolioStatRow.jsx
@@ -56,7 +56,7 @@ const BidderPortfolioStatRow = ({ userProfile, showEdit }) => {
       {
         !showEdit &&
         <div className="button-container">
-          <SearchAsClientButton id={userProfile.perdet_seq_number} />
+          <SearchAsClientButton user={userProfile} />
         </div>
       }
       {

--- a/src/Components/BidderPortfolio/BidderPortfolioStatRow/__snapshots__/BidderPortfolioStatRow.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidderPortfolioStatRow/__snapshots__/BidderPortfolioStatRow.test.jsx.snap
@@ -92,7 +92,116 @@ exports[`BidderPortfolioStatRow matches snapshot 1`] = `
   <div
     className="button-container"
   >
-    <Connect(withRouter(SearchAsClientButton)) />
+    <Connect(withRouter(SearchAsClientButton))
+      user={
+        Object {
+          "assignments": Array [
+            Object {
+              "arrival_date": null,
+              "bid_approval_date": "1975-01-01T00:00:00Z",
+              "combined_differential": 0,
+              "create_date": "2018-01-12T15:11:37.521934Z",
+              "curtailment_reason": null,
+              "end_date": null,
+              "estimated_end_date": "2019-01-12T00:00:00Z",
+              "id": 5,
+              "is_domestic": false,
+              "position": Object {
+                "bureau": "(WHA) BUREAU OF WESTERN HEMISPHERIC AFFAIRS",
+                "position_number": "58312265",
+                "post": Object {
+                  "location": Object {
+                    "city": "Freetown",
+                    "code": "00A",
+                    "country": "Sierra Leone",
+                    "id": 103,
+                    "state": "",
+                  },
+                },
+                "skill": "CONSTRUCTION ENGINEERING (6218)",
+                "title": "PROJECT DIRECTOR",
+              },
+              "service_duration": null,
+              "standard_tod_months": 0,
+              "start_date": "2018-01-12T00:00:00Z",
+              "status": "active",
+              "tour_of_duty": "1 YR (3 R & R)",
+              "update_date": "2018-01-12T15:12:01.013500Z",
+              "user": "Kara Batisak",
+            },
+          ],
+          "bid_statistics": Array [
+            Object {
+              "approved": 0,
+              "bidcycle": "Demo BidCycle 2018-01-12 15:11:38.004793",
+              "closed": 0,
+              "declined": 0,
+              "draft": 5,
+              "handshake_accepted": 0,
+              "handshake_declined": 0,
+              "handshake_offered": 3,
+              "id": 1,
+              "in_panel": 0,
+              "submitted": 2,
+              "user": "Kara Batisak",
+            },
+          ],
+          "current_assignment": Object {
+            "arrival_date": null,
+            "bid_approval_date": "1975-01-01T00:00:00Z",
+            "combined_differential": 0,
+            "create_date": "2018-01-12T15:11:37.521934Z",
+            "curtailment_reason": null,
+            "end_date": null,
+            "estimated_end_date": "2019-01-12T00:00:00Z",
+            "id": 5,
+            "is_domestic": false,
+            "position": Object {
+              "bureau": "(WHA) BUREAU OF WESTERN HEMISPHERIC AFFAIRS",
+              "position_number": "58312265",
+              "post": Object {
+                "location": Object {
+                  "city": "Freetown",
+                  "code": "00A",
+                  "country": "Sierra Leone",
+                  "id": 103,
+                  "state": "",
+                },
+              },
+              "skill": "CONSTRUCTION ENGINEERING (6218)",
+              "title": "PROJECT DIRECTOR",
+            },
+            "service_duration": null,
+            "standard_tod_months": 0,
+            "start_date": "2018-01-12T00:00:00Z",
+            "status": "active",
+            "tour_of_duty": "1 YR (3 R & R)",
+            "update_date": "2018-01-12T15:12:01.013500Z",
+            "user": "Kara Batisak",
+          },
+          "grade": "01",
+          "id": 5,
+          "is_cdo": false,
+          "language_qualifications": Array [],
+          "primary_nationality": "United States",
+          "secondary_nationality": null,
+          "skills": Array [
+            Object {
+              "code": "6218",
+              "cone": null,
+              "description": "CONSTRUCTION ENGINEERING",
+              "id": 63,
+            },
+          ],
+          "user": Object {
+            "email": "batisak@state.gov",
+            "first_name": "Kara",
+            "last_name": "Batisak",
+            "username": "batisak",
+          },
+        }
+      }
+    />
   </div>
 </div>
 `;

--- a/src/Components/BidderPortfolio/SearchAsClientButton/SearchAsClientButton.test.jsx
+++ b/src/Components/BidderPortfolio/SearchAsClientButton/SearchAsClientButton.test.jsx
@@ -7,7 +7,7 @@ import { MemoryRouter } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import sinon from 'sinon';
-import SearchAsClientButtonContainer, { SearchAsClientButton, mapDispatchToProps } from './SearchAsClientButton';
+import SearchAsClientButtonContainer, { SearchAsClientButton, genSearchParams, mapDispatchToProps } from './SearchAsClientButton';
 import { testDispatchFunctions } from '../../../testUtilities/testUtilities';
 
 const middlewares = [thunk];
@@ -15,7 +15,7 @@ const mockStore = configureStore(middlewares);
 
 describe('SearchAsClientButton', () => {
   const props = {
-    id: 1,
+    user: { perdet_seq_number: 1 },
     set: () => {},
     history: { push: () => {} },
   };
@@ -31,7 +31,7 @@ describe('SearchAsClientButton', () => {
     const wrapper = shallow(<SearchAsClientButton {...props} />);
     wrapper.setProps({
       ...props,
-      id: 1,
+      client: { perdet_seq_number: 1 },
       history: { push: spy },
       client: { perdet_seq_number: 1 },
       isLoading: false,
@@ -49,6 +49,22 @@ describe('SearchAsClientButton', () => {
     const wrapper = shallow(<SearchAsClientButton {...props} set={spy} />);
     wrapper.find('button').simulate('click');
     sinon.assert.calledOnce(spy);
+  });
+
+  it('generates a query string on genSearchParams()', () => {
+    const user = {
+      perdet_seq_number: 2,
+      skills: [{ code: 1 }, { code: '5A' }],
+      grade: '03',
+    };
+    const result = () => genSearchParams(user);
+    expect(result()).toBe('position__grade__code__in=03&position__skill__code__in=1%2C5A');
+
+    user.grade = null;
+    expect(result()).toBe('position__skill__code__in=1%2C5A');
+
+    user.skills = null;
+    expect(result()).toBe('');
   });
 
   it('it mounts', () => {


### PR DESCRIPTION
Now when a CDO clicks "Search as Client", the client's skills and grade will be populated as default search filters.