### PR TITLE
Fix sort preferences not persisting; fix browser check

### DIFF
--- a/src/Components/AccountDropdown/AccountDropdown.jsx
+++ b/src/Components/AccountDropdown/AccountDropdown.jsx
@@ -3,11 +3,11 @@ import { Link } from 'react-router-dom';
 import Dropdown, { DropdownTrigger, DropdownContent } from 'react-simple-dropdown';
 import PropTypes from 'prop-types';
 import { get, compact, values } from 'lodash';
+import { EMPTY_FUNCTION, USER_PROFILE } from 'Constants/PropTypes';
+import { checkFlag } from 'flags';
+import { getBrowserName } from 'utilities';
 import Avatar from '../Avatar';
 import DarkModeToggle from './DarkModeToggle';
-import { EMPTY_FUNCTION, USER_PROFILE } from '../../Constants/PropTypes';
-import { checkFlag } from '../../flags';
-import { getBrowserName } from '../../utilities';
 
 const getUseDarkMode = () => checkFlag('flags.personalization');
 

--- a/src/Components/AccountDropdown/__snapshots__/AccountDropdown.test.jsx.snap
+++ b/src/Components/AccountDropdown/__snapshots__/AccountDropdown.test.jsx.snap
@@ -51,6 +51,9 @@ exports[`AccountDropdown matches snapshot 1`] = `
       >
         Dashboard
       </Link>
+      <Connect(DarkModeToggle)
+        className="unstyled-button account-dropdown--identity account-dropdown--segment account-dropdown-link account-dropdown-link--button"
+      />
       <Link
         className="account-dropdown--identity account-dropdown--segment account-dropdown-link"
         onClick={[Function]}
@@ -121,6 +124,9 @@ exports[`AccountDropdown matches snapshot when shouldDisplayName is true 1`] = `
       >
         Dashboard
       </Link>
+      <Connect(DarkModeToggle)
+        className="unstyled-button account-dropdown--identity account-dropdown--segment account-dropdown-link account-dropdown-link--button"
+      />
       <Link
         className="account-dropdown--identity account-dropdown--segment account-dropdown-link"
         onClick={[Function]}

--- a/src/reducers/preferences/preferences.js
+++ b/src/reducers/preferences/preferences.js
@@ -1,5 +1,5 @@
 import { findIndex } from 'lodash';
-import SORT_PREFERENCES from '../../Constants/Sort';
+import SORT_PREFERENCES from 'Constants/Sort';
 
 // no need to store options in localStorage
 const SORT_PREFERENCES_WITHOUT_OPTIONS = Object.assign(
@@ -9,6 +9,7 @@ const SORT_PREFERENCES_WITHOUT_OPTIONS = Object.assign(
   )),
 );
 
+// The name of this reducer is important because we whitelist it as a persistent reducer
 export function sortPreferences(state = SORT_PREFERENCES_WITHOUT_OPTIONS, action) {
   switch (action.type) {
     case 'SET_SORT_PREFERENCE': {
@@ -28,6 +29,7 @@ export function sortPreferences(state = SORT_PREFERENCES_WITHOUT_OPTIONS, action
   }
 }
 
+// The name of this reducer is important because we whitelist it as a persistent reducer
 export function darkModePreference(state = false, action) {
   switch (action.type) {
     case 'SET_DARK_MODE_PREFERENCE': {

--- a/src/store.js
+++ b/src/store.js
@@ -17,7 +17,7 @@ import IndexSagas from './index-sagas';
 const persistConfig = {
   key: 'root',
   storage,
-  whitelist: ['preferences', 'darkModePreference'], // only persist some reducers
+  whitelist: ['sortPreferences', 'darkModePreference'], // only persist some reducers
 };
 
 // Setup the middleware to watch between the Reducers and the Actions

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -664,4 +664,4 @@ export const scrollToGlossaryTerm = (term) => {
 
 export const shouldUseAPFilters = () => checkFlag('flags.available_positions');
 
-export const getBrowserName = () => Bowser.getParser(window.navigator.userAgent).getBrowserName;
+export const getBrowserName = () => Bowser.getParser(window.navigator.userAgent).getBrowserName();


### PR DESCRIPTION
- Fix a problem with preferences not persisting to localStorage (whitelisted the wrong reducer name)
  - Now users can persist their selection for results page size across sessions
- Fix an issue with the browser check utility (didn't call a function with `()`)
  - Now Dark mode will display for whitelisted browsers