### PR TITLE
Do not show bidding text if the position is a projected vacancy

### DIFF
--- a/src/Components/PositionTitle/PositionTitle.jsx
+++ b/src/Components/PositionTitle/PositionTitle.jsx
@@ -99,7 +99,7 @@ class PositionTitle extends Component {
         </div>
         <div className={useBidding() ? 'offset-bid-button-container' : 'offset-bid-button-container-no-button'}>
           {
-            !availableToBid &&
+            !availableToBid && !isProjectedVacancy &&
             <Flag
               name="flags.bidding"
               render={() => (


### PR DESCRIPTION
This text was white so it wasn't noticeable, but the "why can't I add this position text" should never display for a projected vacancy.