### PR TITLE
Call /perdet_seq_num then /permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "date-fns": "^1.29.0",
     "draft-js": "^0.10.4",
     "draft-js-plugins-editor": "^2.1.1",
+    "enum": "^2.5.0",
     "express": "^4.17.1",
     "flag": "^3.0.0-1",
     "flat": "^4.1.0",

--- a/src/actions/userProfile.js
+++ b/src/actions/userProfile.js
@@ -231,6 +231,7 @@ export function updateSavedSearches() {
   api().put('/searches/listcount/');
 }
 
+// IMPORTANT: return the function instead of calling it, since this is used in the interceptor
 export function setUserEmpId() {
   return api().put('/fsbid/employee/perdet_seq_num/');
 }

--- a/src/actions/userProfile.js
+++ b/src/actions/userProfile.js
@@ -4,7 +4,7 @@ import Q from 'q';
 import imagediff from 'imagediff';
 
 import { loadImg } from 'utilities';
-import api from '../api';
+import api, { INTERCEPTORS } from '../api';
 import { favoritePositionsFetchData } from './favoritePositions';
 import { toastSuccess, toastError } from './toast';
 import * as SystemMessages from '../Constants/SystemMessages';
@@ -70,7 +70,7 @@ export function userProfileFetchData(bypass, cb) {
     // profile
     const getUserAccount = () => api().get('/profile/');
     // permissions
-    const getUserPermissions = () => api().get('/permission/user/');
+    const getUserPermissions = () => api().get('/permission/user/', { headers: { [INTERCEPTORS.PUT_PERDET.value]: true } });
     // AP favorites
     const getAPFavorites = () => api().get('/available_position/favorites/?limit=500');
 
@@ -232,5 +232,5 @@ export function updateSavedSearches() {
 }
 
 export function setUserEmpId() {
-  api().put('/fsbid/employee/perdet_seq_num/');
+  return api().put('/fsbid/employee/perdet_seq_num/');
 }

--- a/src/api.js
+++ b/src/api.js
@@ -29,7 +29,7 @@ export const config = () => ({
 });
 
 // Called as a function so that sessionStorage can be set first
-const api = (useInterceptor = true) => {
+const api = () => {
   const api$ = axios.create(config());
 
   api$.interceptors.request.use((request) => {
@@ -77,32 +77,30 @@ const api = (useInterceptor = true) => {
     return request;
   });
 
-  if (useInterceptor) {
-    api$.interceptors.response.use(response => response, (error) => {
-      switch (propOrDefault(error, 'response.status')) {
-        case 401: {
-          // Due to timing of import store before history is created, importing store here causes
-          // exports of api to be undefined. So this causes an error for `userProfile.js` when
-          // attempting to login. Went with the eslint quick re-enable to get around this.
-          debouncedLogout();
-          break;
-        }
-
-        default: {
-          // We don't want to stop the pipeline even if there's a problem with the dispatch
-          // and if there is, that should be resolved. This is just a placeholder until we
-          // actually need a default case to satisfy eslint.
-          const serverMessage = propOrDefault(error, 'response.data.detail');
-
-          if (serverMessage === 'Invalid token') {
-            redirectToLoginRedirect();
-          }
-        }
+  api$.interceptors.response.use(response => response, (error) => {
+    switch (propOrDefault(error, 'response.status')) {
+      case 401: {
+        // Due to timing of import store before history is created, importing store here causes
+        // exports of api to be undefined. So this causes an error for `userProfile.js` when
+        // attempting to login. Went with the eslint quick re-enable to get around this.
+        debouncedLogout();
+        break;
       }
 
-      return Promise.reject(error);
-    });
-  }
+      default: {
+        // We don't want to stop the pipeline even if there's a problem with the dispatch
+        // and if there is, that should be resolved. This is just a placeholder until we
+        // actually need a default case to satisfy eslint.
+        const serverMessage = propOrDefault(error, 'response.data.detail');
+
+        if (serverMessage === 'Invalid token') {
+          redirectToLoginRedirect();
+        }
+      }
+    }
+
+    return Promise.reject(error);
+  });
 
   return api$;
 };

--- a/src/login/sagas.js
+++ b/src/login/sagas.js
@@ -3,7 +3,7 @@ import { take, call, put, cancelled, race } from 'redux-saga/effects';
 import { push } from 'react-router-redux';
 import api from '../api';
 import { unsetNotificationsCount } from '../actions/notifications';
-import { userProfileFetchData, unsetUserProfile, trackLogin, updateSavedSearches, setUserEmpId } from '../actions/userProfile';
+import { userProfileFetchData, unsetUserProfile, trackLogin, updateSavedSearches } from '../actions/userProfile';
 import { setClient, unsetClient } from '../client/actions';
 import isCurrentPath from '../Components/ProfileMenu/navigation';
 import { redirectToLogout, redirectToLogin } from '../utilities';
@@ -41,7 +41,6 @@ export const auth = {
       // Track login. Don't attempt without a token, or endless redirect will occur.
       if (!loginHasBeenTracked && token) {
         trackLogin();
-        setUserEmpId();
         updateSavedSearches();
         loginHasBeenTracked = true;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3329,6 +3329,12 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
+enum@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/enum/-/enum-2.5.0.tgz#f205b8c65a335a8ace8081105df971b18568b984"
+  dependencies:
+    is-buffer "^1.1.0"
+
 enzyme-to-json@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-1.6.0.tgz#9d9bba706e8b500c673b7a4fa9ff7ce57b8b9254"


### PR DESCRIPTION
Ensure that a request made against `/permissions` is preceded by a request to `/perdet_seq_num`. This way, there is time for the permissions to be updated before we send them to the user. Previously, a refresh was required to get the updated permissions. We'll only perform this extra request once per session.