### PR TITLE
Confetti fixes

### DIFF
--- a/src/Components/BidTracker/BidStep/BidSteps.jsx
+++ b/src/Components/BidTracker/BidStep/BidSteps.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import Steps, { Step } from 'rc-steps';
 import shortId from 'shortid';
+import PropTypes from 'prop-types';
 import { APPROVED } from 'Constants/BidStatuses';
 import { checkFlag } from 'flags';
 import ConfettiIcon from './ConfettiIcon';
@@ -22,24 +23,9 @@ const getUseConfetti = () => checkFlag('flags.confetti');
 // by bidClassesFromCurrentStatus.
 // These classes determine colors, whether to use an icon or a number, the title text, etc.
 class BidSteps extends Component {
-  constructor(props) {
-    super(props);
-    this.celebrate = this.celebrate.bind(this);
-    this.state = {
-      confettiActive: false,
-    };
-  }
-  celebrate() {
-    this.setState({
-      confettiActive: true,
-    }, () => {
-      setTimeout(() => {
-        this.setState({ confettiActive: false });
-      }, 0);
-    });
-  }
   render() {
     const { bid } = this.props;
+    const { condensedView } = this.context;
     const bidData = bidClassesFromCurrentStatus(bid).stages || {};
     const getIcon = (status) => {
       const icon = (
@@ -52,7 +38,7 @@ class BidSteps extends Component {
         />
       );
       if (bidData[status.prop].isCurrent && bidData[status.prop].title === APPROVED.text
-      && getUseConfetti()) {
+      && getUseConfetti() && !condensedView) {
         return (
           <ConfettiIcon>
             {icon}
@@ -90,6 +76,10 @@ class BidSteps extends Component {
     );
   }
 }
+
+BidSteps.contextTypes = {
+  condensedView: PropTypes.bool,
+};
 
 BidSteps.propTypes = {
   bid: BID_OBJECT.isRequired,

--- a/src/Components/BidTracker/BidStep/BidSteps.test.jsx
+++ b/src/Components/BidTracker/BidStep/BidSteps.test.jsx
@@ -10,13 +10,24 @@ describe('BidStepsComponent', () => {
   it('is defined', () => {
     const wrapper = shallow(
       <BidSteps bid={bid} />,
+      { context: { condensedView: false } },
     );
     expect(wrapper).toBeDefined();
   });
 
+  it('is defined when context.condensedView === true', () => {
+    const wrapper = shallow(
+      <BidSteps bid={bid} />,
+      { context: { condensedView: true } },
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+
   it('matches snapshot', () => {
     const wrapper = shallow(
       <BidSteps bid={bid} />,
+      { context: { condensedView: false } },
     );
     expect(toJSON(wrapper)).toMatchSnapshot();
   });

--- a/src/Components/BidTracker/BidStep/ConfettiIcon.jsx
+++ b/src/Components/BidTracker/BidStep/ConfettiIcon.jsx
@@ -4,15 +4,15 @@ import Confetti from 'react-dom-confetti';
 import { throttle } from 'lodash';
 import InteractiveElement from 'Components/InteractiveElement';
 
-const DURATION = 4000;
-const DURATION_CLICK_OFFSET = -800;
+const THROTTLE_DURATION = 3000;
+const ANIMATION_DURATION = 3000;
 
 class ConfettiIcon extends Component {
   constructor(props) {
     super(props);
     this.celebrate = throttle(
       this.celebrate.bind(this),
-      DURATION + DURATION_CLICK_OFFSET,
+      THROTTLE_DURATION,
       { trailing: true, leading: true },
     );
     this.state = {
@@ -37,7 +37,7 @@ class ConfettiIcon extends Component {
       startVelocity: '30',
       elementCount: 50,
       dragFriction: 0.1,
-      duration: `${DURATION}`,
+      duration: `${ANIMATION_DURATION}`,
       stagger: 2,
       width: '10px',
       height: '10px',

--- a/src/Components/BidTracker/BidStep/__snapshots__/ConfettiIcon.test.jsx.snap
+++ b/src/Components/BidTracker/BidStep/__snapshots__/ConfettiIcon.test.jsx.snap
@@ -22,7 +22,7 @@ exports[`ConfettiIconComponent matches snapshot 1`] = `
             "#E31C3D",
           ],
           "dragFriction": 0.1,
-          "duration": "4000",
+          "duration": "3000",
           "elementCount": 50,
           "height": "10px",
           "spread": 45,


### PR DESCRIPTION
:confetti_ball: :wrench:

- Remove confetti functions from parent component
- Update `onMouseOver` timing
- Use `context` to disable if `condensedView` is active