### PR TITLE
Remove available_positions feature flag usage

### DIFF
--- a/src/Components/PositionDetailsItem/PositionDetailsItem.jsx
+++ b/src/Components/PositionDetailsItem/PositionDetailsItem.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
-import { Flag } from 'flag';
 import Differentials from 'Components/Differentials';
 import { COMMON_PROPERTIES } from '../../Constants/EndpointParams';
 import LanguageList from '../../Components/LanguageList/LanguageList';
@@ -85,10 +84,7 @@ const PositionDetailsItem = (props) => {
   return (
     <div className="usa-grid-full padded-main-content position-details-outer-container">
       <div className="handshake-offset-container">
-        <Flag
-          name="flags.available_positions"
-          render={() => renderHandshake(stats, position)}
-        />
+        {renderHandshake(stats, position)}
         {
           isHighlighted && <Featured cutSide="both" className="ribbon-position-details" />
         }

--- a/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
+++ b/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
@@ -6,12 +6,7 @@ exports[`PositionDetailsItem matches snapshot 1`] = `
 >
   <div
     className="handshake-offset-container"
-  >
-    <Flag
-      name="flags.available_positions"
-      render={[Function]}
-    />
-  </div>
+  />
   <div
     className="usa-grid-full position-details-description-container positions-details-about-position"
   >
@@ -367,12 +362,7 @@ exports[`PositionDetailsItem matches snapshot when there is an obc id 1`] = `
 >
   <div
     className="handshake-offset-container"
-  >
-    <Flag
-      name="flags.available_positions"
-      render={[Function]}
-    />
-  </div>
+  />
   <div
     className="usa-grid-full position-details-description-container positions-details-about-position"
   >
@@ -730,12 +720,7 @@ exports[`PositionDetailsItem matches snapshot when various data is missing from 
 >
   <div
     className="handshake-offset-container"
-  >
-    <Flag
-      name="flags.available_positions"
-      render={[Function]}
-    />
-  </div>
+  />
   <div
     className="usa-grid-full position-details-description-container positions-details-about-position"
   >

--- a/src/Components/ResultsCard/ResultsCard.jsx
+++ b/src/Components/ResultsCard/ResultsCard.jsx
@@ -230,46 +230,31 @@ class ResultsCard extends Component {
                     }
                   </Row>
               }
-              <Flag
-                name="flags.available_positions"
-                render={() =>
-                (<Row id={innerId} fluid>
-                  <Column columns="6">
-                    <DefinitionList items={sections[0]} />
-                  </Column>
-                  {
-                    !matches &&
-                    <Column columns="4">
-                      <DefinitionList items={sections[1]} />
-                    </Column>
-                  }
-                  <Column columns="2">
-                    <div className="ribbon-container">
-                      {
-                        get(stats, 'has_handshake_offered', false) && <Handshake isWide className="ribbon-results-card" />
-                      }
-                      {
-                        get(result, 'position.is_highlighted') && <Featured isWide className="ribbon-results-card" />
-                      }
-                      {
-                        // conditional rendering occurs inside the container
-                        <InBidListContainer id={result.id} isWide className="ribbon-results-card" />
-                      }
-                    </div>
-                  </Column>
-                </Row>)
-              }
-                fallbackRender={() =>
-                (<Row id={`${id}-inner`} fluid>
-                  <Column columns="6">
-                    <DefinitionList items={sections[0]} />
-                  </Column>
-                  <Column columns="6">
+              <Row id={innerId} fluid>
+                <Column columns="5">
+                  <DefinitionList items={sections[0]} />
+                </Column>
+                {
+                  !matches &&
+                  <Column columns="5">
                     <DefinitionList items={sections[1]} />
                   </Column>
-                </Row>)
-              }
-              />
+                }
+                <Column columns="2">
+                  <div className="ribbon-container">
+                    {
+                      get(stats, 'has_handshake_offered', false) && <Handshake isWide className="ribbon-results-card" />
+                    }
+                    {
+                      get(result, 'position.is_highlighted') && <Featured isWide className="ribbon-results-card" />
+                    }
+                    {
+                      // conditional rendering occurs inside the container
+                      <InBidListContainer id={result.id} isWide className="ribbon-results-card" />
+                    }
+                  </div>
+                </Column>
+              </Row>
               <Row className="footer results-card-padded-section" fluid>
                 <Column columns={matches ? 8 : 6} as="section">
                   {

--- a/src/Components/ResultsCondensedCardTop/ResultsCondensedCardTop.jsx
+++ b/src/Components/ResultsCondensedCardTop/ResultsCondensedCardTop.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
-import { Flag } from 'flag';
 import { Link } from 'react-router-dom';
 import { Featured, Handshake } from '../Ribbon';
 import { POSITION_DETAILS, HOME_PAGE_CARD_TYPE } from '../../Constants/PropTypes';
@@ -61,12 +60,9 @@ const ResultsCondensedCardTop = ({ position, isProjectedVacancy, isRecentlyAvail
           </span></span>
         </div>
         <div className="ribbon-container">
-          <Flag
-            name="flags.available_positions"
-            render={() => (
-              hasHandshake && <Handshake className="ribbon-condensed-card" />
-            )}
-          />
+          {
+            hasHandshake && <Handshake className="ribbon-condensed-card" />
+          }
           {
             get(position, 'position.is_highlighted') && <Featured className="ribbon-results-card" />
           }

--- a/src/Components/ResultsCondensedCardTop/__snapshots__/ResultsCondensedCardTop.test.jsx.snap
+++ b/src/Components/ResultsCondensedCardTop/__snapshots__/ResultsCondensedCardTop.test.jsx.snap
@@ -41,12 +41,7 @@ exports[`ResultsCondensedCardTopComponent matches snapshot 1`] = `
       </div>
       <div
         className="ribbon-container"
-      >
-        <Flag
-          name="flags.available_positions"
-          render={[Function]}
-        />
-      </div>
+      />
     </div>
   </div>
 </Link>
@@ -93,12 +88,7 @@ exports[`ResultsCondensedCardTopComponent matches snapshot when type is serviceN
       </div>
       <div
         className="ribbon-container"
-      >
-        <Flag
-          name="flags.available_positions"
-          render={[Function]}
-        />
-      </div>
+      />
     </div>
   </div>
 </Link>


### PR DESCRIPTION
The deprecated `available_positions` flag was still being checked in a few spots, causing the Handshake indicator to not display on the cards or the details page. It also resulted in a visual bug on the results card when the feature flag was true.