### PR TITLE
TM-1551: Bid Count: change tool tip verbiage

### DIFF
--- a/src/Components/BidCount/BidCount.jsx
+++ b/src/Components/BidCount/BidCount.jsx
@@ -13,9 +13,9 @@ const BidCount = ({ bidStatistics, hideLabel, label, altStyle, isCondensed }) =>
       {/* set an aria-labelledby so that screen readers understand the purpose of the list */}
       <ul className="bid-count-list" aria-labelledby="bid-counts">
         <BidCountNumber type="totalBids" number={bidStatistics$.total_bids || 0} />
-        <BidCountNumber type="inGradeBids" number={bidStatistics$.in_grade || 0} />
-        <BidCountNumber type="atSkillBids" number={bidStatistics$.at_skill || 0} />
-        <BidCountNumber type="inGradeAtSkillBids" number={bidStatistics$.in_grade_at_skill || 0} />
+        <BidCountNumber type="atGradeBids" number={bidStatistics$.in_grade || 0} />
+        <BidCountNumber type="inSkillBids" number={bidStatistics$.at_skill || 0} />
+        <BidCountNumber type="atGradeInSkillBids" number={bidStatistics$.in_grade_at_skill || 0} />
       </ul>
     </div>
   );

--- a/src/Components/BidCount/BidCountNumber/BidCountNumber.jsx
+++ b/src/Components/BidCount/BidCountNumber/BidCountNumber.jsx
@@ -20,7 +20,7 @@ const BidCountNumber = ({ type, number }) => (
 
 BidCountNumber.propTypes = {
   number: PropTypes.number.isRequired,
-  type: PropTypes.oneOf(['totalBids', 'inGradeBids', 'atSkillBids', 'inGradeAtSkillBids']).isRequired,
+  type: PropTypes.oneOf(['totalBids', 'atGradeBids', 'inSkillBids', 'atGradeInSkillBids']).isRequired,
 };
 
 export default BidCountNumber;

--- a/src/Components/BidCount/BidCountNumber/BidCountNumber.test.jsx
+++ b/src/Components/BidCount/BidCountNumber/BidCountNumber.test.jsx
@@ -4,7 +4,7 @@ import toJSON from 'enzyme-to-json';
 import BidCountNumber from './BidCountNumber';
 
 describe('BidCountNumberComponent', () => {
-  ['totalBids', 'inGradeBids', 'atSkillBids', 'inGradeAtSkillBids'].forEach((type) => {
+  ['totalBids', 'atGradeBids', 'inSkillBids', 'atGradeInSkillBids'].forEach((type) => {
     it(`is defined where type = ${type}`, () => {
       const wrapper = shallow(
         <BidCountNumber type={type} number={10} />,

--- a/src/Components/BidCount/BidCountNumber/__snapshots__/BidCountNumber.test.jsx.snap
+++ b/src/Components/BidCount/BidCountNumber/__snapshots__/BidCountNumber.test.jsx.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BidCountNumberComponent matches snapshot where type = atSkillBids 1`] = `
+exports[`BidCountNumberComponent matches snapshot where type = atGradeBids 1`] = `
 <li
   className="bid-count-list-item"
-  title="At-skill bids"
+  title="At-Grade bids"
 >
   <Tooltip
     animateFill={true}
@@ -38,7 +38,7 @@ exports[`BidCountNumberComponent matches snapshot where type = atSkillBids 1`] =
     style={Object {}}
     tabIndex="0"
     theme="dark"
-    title="Number of bidders who are at Skill."
+    title="Number of bidders who are at-Grade."
     touchHold={false}
     trigger="mouseenter focus"
     unmountHTMLWhenHide={false}
@@ -52,10 +52,10 @@ exports[`BidCountNumberComponent matches snapshot where type = atSkillBids 1`] =
 </li>
 `;
 
-exports[`BidCountNumberComponent matches snapshot where type = inGradeAtSkillBids 1`] = `
+exports[`BidCountNumberComponent matches snapshot where type = atGradeInSkillBids 1`] = `
 <li
   className="bid-count-list-item"
-  title="In-grade and at-skill bids"
+  title="At-Grade and in-Skill bids"
 >
   <Tooltip
     animateFill={true}
@@ -90,7 +90,7 @@ exports[`BidCountNumberComponent matches snapshot where type = inGradeAtSkillBid
     style={Object {}}
     tabIndex="0"
     theme="dark"
-    title="Number of bidders who are at Grade and Skill."
+    title="Number of bidders at-Grade and in-Skill."
     touchHold={false}
     trigger="mouseenter focus"
     unmountHTMLWhenHide={false}
@@ -104,10 +104,10 @@ exports[`BidCountNumberComponent matches snapshot where type = inGradeAtSkillBid
 </li>
 `;
 
-exports[`BidCountNumberComponent matches snapshot where type = inGradeBids 1`] = `
+exports[`BidCountNumberComponent matches snapshot where type = inSkillBids 1`] = `
 <li
   className="bid-count-list-item"
-  title="In-grade bids"
+  title="In-Skill bids"
 >
   <Tooltip
     animateFill={true}
@@ -142,7 +142,7 @@ exports[`BidCountNumberComponent matches snapshot where type = inGradeBids 1`] =
     style={Object {}}
     tabIndex="0"
     theme="dark"
-    title="Number of bidders who are at Grade."
+    title="Number of bidders in-Skill."
     touchHold={false}
     trigger="mouseenter focus"
     unmountHTMLWhenHide={false}
@@ -194,7 +194,7 @@ exports[`BidCountNumberComponent matches snapshot where type = totalBids 1`] = `
     style={Object {}}
     tabIndex="0"
     theme="dark"
-    title="Number of bids on this position."
+    title="Total number of bids on this position."
     touchHold={false}
     trigger="mouseenter focus"
     unmountHTMLWhenHide={false}

--- a/src/Components/BidCount/__snapshots__/BidCount.test.jsx.snap
+++ b/src/Components/BidCount/__snapshots__/BidCount.test.jsx.snap
@@ -20,15 +20,15 @@ exports[`BidCountComponent matches snapshot 1`] = `
     />
     <BidCountNumber
       number={5}
-      type="inGradeBids"
+      type="atGradeBids"
     />
     <BidCountNumber
       number={5}
-      type="atSkillBids"
+      type="inSkillBids"
     />
     <BidCountNumber
       number={5}
-      type="inGradeAtSkillBids"
+      type="atGradeInSkillBids"
     />
   </ul>
 </div>
@@ -54,15 +54,15 @@ exports[`BidCountComponent matches snapshot when hideLabel is true 1`] = `
     />
     <BidCountNumber
       number={5}
-      type="inGradeBids"
+      type="atGradeBids"
     />
     <BidCountNumber
       number={5}
-      type="atSkillBids"
+      type="inSkillBids"
     />
     <BidCountNumber
       number={5}
-      type="inGradeAtSkillBids"
+      type="atGradeInSkillBids"
     />
   </ul>
 </div>

--- a/src/Constants/BidCountDefinitions.js
+++ b/src/Constants/BidCountDefinitions.js
@@ -1,8 +1,8 @@
 const BID_COUNT_DEFINITIONS = {
-  totalBids: { title: 'Total bids', definition: 'Number of bids on this position.' },
-  inGradeBids: { title: 'In-grade bids', definition: 'Number of bidders who are at Grade.' },
-  atSkillBids: { title: 'At-skill bids', definition: 'Number of bidders who are at Skill.' },
-  inGradeAtSkillBids: { title: 'In-grade and at-skill bids', definition: 'Number of bidders who are at Grade and Skill.' },
+  totalBids: { title: 'Total bids', definition: 'Total number of bids on this position.' },
+  atGradeBids: { title: 'At-Grade bids', definition: 'Number of bidders who are at-Grade.' },
+  inSkillBids: { title: 'In-Skill bids', definition: 'Number of bidders in-Skill.' },
+  atGradeInSkillBids: { title: 'At-Grade and in-Skill bids', definition: 'Number of bidders at-Grade and in-Skill.' },
 };
 
 export default BID_COUNT_DEFINITIONS;

--- a/src/Constants/BidCountDefinitions.test.js
+++ b/src/Constants/BidCountDefinitions.test.js
@@ -3,13 +3,13 @@ import BID_COUNT_DEFINITIONS from './BidCountDefinitions';
 describe('BidCountDefinitions', () => {
   it('should return a value for valid bid count property', () => {
     expect(BID_COUNT_DEFINITIONS.totalBids.title).toBeDefined();
-    expect(BID_COUNT_DEFINITIONS.inGradeBids.title).toBeDefined();
-    expect(BID_COUNT_DEFINITIONS.atSkillBids.title).toBeDefined();
-    expect(BID_COUNT_DEFINITIONS.inGradeAtSkillBids.title).toBeDefined();
+    expect(BID_COUNT_DEFINITIONS.atGradeBids.title).toBeDefined();
+    expect(BID_COUNT_DEFINITIONS.inSkillBids.title).toBeDefined();
+    expect(BID_COUNT_DEFINITIONS.atGradeInSkillBids.title).toBeDefined();
 
     expect(BID_COUNT_DEFINITIONS.totalBids.definition).toBeDefined();
-    expect(BID_COUNT_DEFINITIONS.inGradeBids.definition).toBeDefined();
-    expect(BID_COUNT_DEFINITIONS.atSkillBids.definition).toBeDefined();
-    expect(BID_COUNT_DEFINITIONS.inGradeAtSkillBids.definition).toBeDefined();
+    expect(BID_COUNT_DEFINITIONS.atGradeBids.definition).toBeDefined();
+    expect(BID_COUNT_DEFINITIONS.inSkillBids.definition).toBeDefined();
+    expect(BID_COUNT_DEFINITIONS.atGradeInSkillBids.definition).toBeDefined();
   });
 });


### PR DESCRIPTION
"Number of bids on this position" --> "Total number of bids on this position."
"Number of bidders who are at grade” --> "Number of bidders who are at-Grade."
"Number of bidders who are at skill” --> "Number of bidders in-Skill."
"Number of bidders who are at Grade and Skill” --> "Number of bidders at-Grade and in-Skill." 

Wording updates to bid count tooltips.