### PR TITLE
Fix "Remove from Bid Tracker" spacing

### DIFF
--- a/src/sass/_bidTracker.scss
+++ b/src/sass/_bidTracker.scss
@@ -198,7 +198,7 @@ $draft-icon-offset: 120px;
   }
 
   .bid-tracker-title-content-container {
-    flex-grow: 1;
+    flex: 5;
   }
 
   .bid-tracker-card-title-container-right {
@@ -708,6 +708,8 @@ $draft-icon-offset: 120px;
   }
 
   .bid-tracker-card-title-outer-container-right {
+    flex: 3;
+
     .bid-tracker-question-text-container {
       display: none;
     }


### PR DESCRIPTION
Allow room for "Remove from Bid Tracker" to sit on one line in condensed bid tracker.