### PR TITLE
Respect line breaks in the source content for the banner

### DIFF
--- a/src/sass/_betaHeader.scss
+++ b/src/sass/_betaHeader.scss
@@ -11,11 +11,18 @@
 
     > div {
       display: inline;
+      line-height: 1em;
+      white-space: pre-wrap;
     }
+  }
+
+  .DraftEditor-editorContainer > div {
+    overflow-y: scroll;
   }
 
   .editor {
     height: 80px;
+    padding: 8px;
   }
 
   .public-DraftEditor-content {


### PR DESCRIPTION
In the gold banner, any line breaks added by the author were not being displayed. This fix resolves that issue.