### PR TITLE
Fallback for bidlist results when it is not defined on load

### DIFF
--- a/src/Components/BidTracker/BidTracker.jsx
+++ b/src/Components/BidTracker/BidTracker.jsx
@@ -40,7 +40,7 @@ class BidTracker extends Component {
 
   getSortedBids() {
     const { sortValue } = this.state;
-    const { bidList: { results } } = this.props;
+    const results = get(this.props, 'bidList.results', []);
     let results$ = [...results];
     switch (sortValue) {
       case UPDATED:


### PR DESCRIPTION
Fixes an issue where the public bid list page wouldn't load if accessed directly