### PR TITLE
Improve performance of favorites button

### DIFF
--- a/src/reducers/userProfile/userProfile.js
+++ b/src/reducers/userProfile/userProfile.js
@@ -19,7 +19,7 @@ export function userProfileIsLoading(state = false, action) {
 export function userProfile(state = DEFAULT_USER_PROFILE, action) {
   switch (action.type) {
     case 'USER_PROFILE_FETCH_DATA_SUCCESS':
-      return action.userProfile;
+      return { ...state, ...action.userProfile };
     default:
       return state;
   }

--- a/src/reducers/userProfile/userProfile.test.js
+++ b/src/reducers/userProfile/userProfile.test.js
@@ -9,8 +9,11 @@ describe('reducers', () => {
     expect(reducers.userProfileIsLoading(false, { type: 'USER_PROFILE_IS_LOADING', isLoading: true })).toBe(true);
   });
 
-  it('can set reducer USER_PROFILE_FETCH_DATA_SUCCESS', () => {
-    expect(reducers.userProfile({}, { type: 'USER_PROFILE_FETCH_DATA_SUCCESS', userProfile: true })).toBe(true);
+  it('can spread new props on the reducer USER_PROFILE_FETCH_DATA_SUCCESS', () => {
+    const original = { a: 1, b: 2 };
+    const updated = { a: 'one', c: 'two' };
+    const expected = { ...original, ...updated };
+    expect(reducers.userProfile(original, { type: 'USER_PROFILE_FETCH_DATA_SUCCESS', userProfile: updated })).toEqual(expected);
   });
 
   it('can set reducer USER_PROFILE_FAVORITE_POSITION_HAS_ERRORED', () => {

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -252,7 +252,7 @@ export const shortenString = (string, shortenTo = 250, suffix = '...') => {
 export const existsInArray = (ref, array) => {
   let found = false;
   array.forEach((i) => {
-    if (i.id === ref) {
+    if (get(i, 'id') && ref && `${i.id}` === `${ref}`) {
       found = true;
     }
   });


### PR DESCRIPTION
Use with https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/319

Reduces the time it takes for the add/remove Favorite spinner to finish, as we were unnecessarily fetching data, such as the entire favorites list (with position data), and other user data.