### PR TITLE
perpetual loading of bidder portfolio fixed

### DIFF
--- a/src/actions/bidderPortfolio.js
+++ b/src/actions/bidderPortfolio.js
@@ -228,8 +228,8 @@ export function bidderPortfolioFetchData(query = {}) {
         })
         .catch((m) => {
           if (get(m, 'message') === 'cancel') {
-            dispatch(bidderPortfolioIsLoading(true));
             dispatch(bidderPortfolioHasErrored(false));
+            dispatch(bidderPortfolioIsLoading(false));
           } else {
             dispatch(bidderPortfolioHasErrored(true));
             dispatch(bidderPortfolioIsLoading(false));


### PR DESCRIPTION
when Select All was double clicked, it would send the bidder portfolio stuff into perpetual loading.