### PR TITLE
Add conditional for isLoading TM-1683

### DIFF
--- a/src/Containers/BidderPortfolio/BidderPortfolio.jsx
+++ b/src/Containers/BidderPortfolio/BidderPortfolio.jsx
@@ -126,7 +126,7 @@ class BidderPortfolio extends Component {
     bidderPortfolioCountsHasErrored, cdos, bidderPortfolioCDOsIsLoading,
     classifications, classificationsIsLoading, classificationsHasErrored } = this.props;
     const { defaultPageSize, defaultPageNumber, hasHandshake, ordering } = this.state;
-    const isLoading = bidderPortfolioCDOsIsLoading || bidderPortfolioIsLoading;
+    const isLoading = (bidderPortfolioCDOsIsLoading || bidderPortfolioIsLoading) && cdos.length;
     return (
       <BidderPortfolioPage
         bidderPortfolio={bidderPortfolio}

--- a/src/actions/bidderPortfolio.js
+++ b/src/actions/bidderPortfolio.js
@@ -229,14 +229,12 @@ export function bidderPortfolioFetchData(query = {}) {
         .catch((m) => {
           if (get(m, 'message') === 'cancel') {
             dispatch(bidderPortfolioHasErrored(false));
-            dispatch(bidderPortfolioIsLoading(false));
+            dispatch(bidderPortfolioIsLoading(true));
           } else {
             dispatch(bidderPortfolioHasErrored(true));
             dispatch(bidderPortfolioIsLoading(false));
           }
         });
-    } else {
-      dispatch(bidderPortfolioIsLoading(false));
     }
   };
 }


### PR DESCRIPTION
@elizabeth-jimenez The bug you found was universal for any fast clicking through the list that ended in a query with no cdos selected (so deselecting 'select all' or just fast deselecting cdos until there are no clients). 

@mjoyce91 fixed this by adding the cdos.length condition to the isLoading state

Thanks to both of you who literally did all the work for this PR 🚀 💯 👍 