### PR TITLE
Generate colors for client avatars

### DIFF
--- a/src/Components/AccountDropdown/__snapshots__/AccountDropdown.test.jsx.snap
+++ b/src/Components/AccountDropdown/__snapshots__/AccountDropdown.test.jsx.snap
@@ -13,6 +13,7 @@ exports[`AccountDropdown matches snapshot 1`] = `
   >
     <Avatar
       className="account-dropdown--avatar"
+      colorString=""
       displayName="John Doe"
       externalSource={Object {}}
       externalSourceToUse="s"
@@ -83,6 +84,7 @@ exports[`AccountDropdown matches snapshot when shouldDisplayName is true 1`] = `
   >
     <Avatar
       className="account-dropdown--avatar"
+      colorString=""
       displayName="John Doe"
       externalSource={Object {}}
       externalSourceToUse="s"

--- a/src/Components/Avatar/Avatar.jsx
+++ b/src/Components/Avatar/Avatar.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import FA from 'react-fontawesome';
 import { get } from 'lodash';
 import ImageFallback from 'react-image-fallback';
+import { getAvatarColor } from 'utilities';
 import { EMPTY_FUNCTION } from '../../Constants/PropTypes';
 
 const propTypes = {
@@ -20,6 +21,7 @@ const propTypes = {
     compare: PropTypes.arrayOf(PropTypes.string),
   }),
   externalSourceToUse: PropTypes.oneOf(['s', 'm', 'l', null]),
+  colorString: PropTypes.string,
 };
 
 const defaultProps = {
@@ -33,19 +35,27 @@ const defaultProps = {
   useExternalImg: false,
   externalSource: {},
   externalSourceToUse: null,
+  colorString: '',
 };
 
 const Avatar = ({ initials, firstName, lastName, className, small, onClick, fallback,
-  externalSource, externalSourceToUse }) => {
+  externalSource, externalSourceToUse, colorString }) => {
   const avatar = <span>{initials || fallback}</span>;
   /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
   /* eslint-disable jsx-a11y/no-static-element-interactions */
   const style = {
     borderRadius: 50,
   };
+  let containerStyle = {};
+  if (colorString) {
+    const output = getAvatarColor((colorString));
+    containerStyle = {
+      ...containerStyle, ...output,
+    };
+  }
   if (small) { style.borderRadius = 30; }
   return (
-    <div className={`tm-avatar ${small ? 'tm-avatar--small' : ''} ${className}`} onClick={onClick} role="img" aria-label={`${firstName} ${lastName}`}>
+    <div style={containerStyle} className={`tm-avatar ${small ? 'tm-avatar--small' : ''} ${className}`} onClick={onClick} role="img" aria-label={`${firstName} ${lastName}`}>
       {
         get(externalSource, externalSourceToUse) ?
           <ImageFallback

--- a/src/Components/Avatar/__snapshots__/Avatar.test.jsx.snap
+++ b/src/Components/Avatar/__snapshots__/Avatar.test.jsx.snap
@@ -6,6 +6,7 @@ exports[`Avatar matches snapshot 1`] = `
   className="tm-avatar  special-class"
   onClick={[Function]}
   role="img"
+  style={Object {}}
 >
   <span>
     JD

--- a/src/Components/BidderPortfolio/BidderPortfolioCard/__snapshots__/BidderPortfolioCard.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidderPortfolioCard/__snapshots__/BidderPortfolioCard.test.jsx.snap
@@ -13,8 +13,10 @@ exports[`BidderPortfolioCardComponent matches snapshot 1`] = `
   style={Object {}}
 >
   <UserProfileGeneralInformation
+    colorProp="displayName"
     isPublic={false}
     showEditLink={false}
+    useColor={false}
     useGroup={true}
     userProfile={
       Object {

--- a/src/Components/BidderPortfolio/BidderPortfolioGridItem/__snapshots__/BidderPortfolioGridItem.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidderPortfolioGridItem/__snapshots__/BidderPortfolioGridItem.test.jsx.snap
@@ -32,8 +32,10 @@ exports[`BidderPortfolioGridItemComponent matches snapshot 1`] = `
         className="general-information-container"
       >
         <UserProfileGeneralInformation
+          colorProp="displayName"
           isPublic={false}
           showEditLink={false}
+          useColor={false}
           useGroup={true}
           userProfile={
             Object {

--- a/src/Components/ProfileDashboard/ExternalUserStatus/__snapshots__/ExternalUserStatus.test.jsx.snap
+++ b/src/Components/ProfileDashboard/ExternalUserStatus/__snapshots__/ExternalUserStatus.test.jsx.snap
@@ -12,6 +12,7 @@ exports[`ExternalUserStatusComponent matches snapshot 1`] = `
     >
       <Avatar
         className=""
+        colorString=""
         externalSource={Object {}}
         externalSourceToUse={null}
         fallback={
@@ -65,6 +66,7 @@ exports[`ExternalUserStatusComponent matches snapshot when showMail is true 1`] 
     >
       <Avatar
         className=""
+        colorString=""
         externalSource={Object {}}
         externalSourceToUse={null}
         fallback={

--- a/src/Components/ProfileDashboard/UserProfile/UserProfile.jsx
+++ b/src/Components/ProfileDashboard/UserProfile/UserProfile.jsx
@@ -19,6 +19,8 @@ const UserProfile = ({ userProfile, showEditLink, showGeneralInformation,
           showEditLink={showEditLink}
           useGroup={useGroup}
           isPublic={isPublic}
+          colorProp="firstName"
+          useColor={isPublic}
         />
       }
       {

--- a/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/UserProfileGeneralInformation.jsx
+++ b/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/UserProfileGeneralInformation.jsx
@@ -66,7 +66,7 @@ UserProfileGeneralInformation.propTypes = {
   useGroup: PropTypes.bool,
   isPublic: PropTypes.bool,
   useColor: PropTypes.bool,
-  colorProp: PropTypes.bool,
+  colorProp: PropTypes.string,
 };
 
 UserProfileGeneralInformation.defaultProps = {

--- a/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/UserProfileGeneralInformation.jsx
+++ b/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/UserProfileGeneralInformation.jsx
@@ -10,7 +10,8 @@ import Avatar from '../../../Avatar';
 import StaticDevContent from '../../../StaticDevContent';
 import SkillCodeList from '../../../SkillCodeList';
 
-const UserProfileGeneralInformation = ({ userProfile, showEditLink, useGroup, isPublic }) => {
+const UserProfileGeneralInformation = ({ userProfile, showEditLink, useGroup, isPublic,
+  colorProp, useColor }) => {
   const avatar = {
     firstName: get(userProfile, 'user.first_name'),
     lastName: get(userProfile, 'user.last_name'),
@@ -19,6 +20,7 @@ const UserProfileGeneralInformation = ({ userProfile, showEditLink, useGroup, is
     externalSource: get(userProfile, 'avatar'),
     externalSourceToUse: 'm',
   };
+  avatar.colorString = useColor ? avatar[colorProp] : undefined;
   const infoDataPointClassName = 'skill-code-data-point-container skill-code-data-point-container-gen-spec';
   const conditionalStaticDevContent = isPublic ?
     (<InformationDataPoint
@@ -63,12 +65,16 @@ UserProfileGeneralInformation.propTypes = {
   showEditLink: PropTypes.bool,
   useGroup: PropTypes.bool,
   isPublic: PropTypes.bool,
+  useColor: PropTypes.bool,
+  colorProp: PropTypes.bool,
 };
 
 UserProfileGeneralInformation.defaultProps = {
   showEditLink: true,
   useGroup: false,
   isPublic: false,
+  useColor: false,
+  colorProp: 'displayName',
 };
 
 export default UserProfileGeneralInformation;

--- a/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/__snapshots__/UserProfileGeneralInformation.test.jsx.snap
+++ b/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/__snapshots__/UserProfileGeneralInformation.test.jsx.snap
@@ -12,6 +12,7 @@ exports[`UserProfileGeneralInformationComponent matches snapshot 1`] = `
     >
       <Avatar
         className="dashboard-user-profile-picture"
+        colorString=""
         displayName="John"
         externalSource={Object {}}
         externalSourceToUse="m"
@@ -92,6 +93,7 @@ exports[`UserProfileGeneralInformationComponent matches snapshot when showEditLi
     >
       <Avatar
         className="dashboard-user-profile-picture"
+        colorString=""
         displayName="John"
         externalSource={Object {}}
         externalSourceToUse="m"
@@ -172,6 +174,7 @@ exports[`UserProfileGeneralInformationComponent matches snapshot when useGroup i
     >
       <Avatar
         className="dashboard-user-profile-picture"
+        colorString=""
         displayName="John"
         externalSource={Object {}}
         externalSourceToUse="m"

--- a/src/Components/ProfileDashboard/UserProfile/__snapshots__/UserProfile.test.jsx.snap
+++ b/src/Components/ProfileDashboard/UserProfile/__snapshots__/UserProfile.test.jsx.snap
@@ -5,8 +5,10 @@ exports[`UserProfileComponent matches snapshot 1`] = `
   className="usa-grid-full current-user"
 >
   <UserProfileGeneralInformation
+    colorProp="firstName"
     isPublic={false}
     showEditLink={true}
+    useColor={false}
     useGroup={false}
     userProfile={
       Object {

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -757,3 +757,37 @@ export const stopProp = (event) => {
     e.stopPropagation();
   }
 };
+
+export const getContrastYIQ = hexcolor => {
+  const r = parseInt(hexcolor.substr(0, 2), 16);
+  const g = parseInt(hexcolor.substr(2, 2), 16);
+  const b = parseInt(hexcolor.substr(4, 2), 16);
+  const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
+  return (yiq >= 128) ? 'black' : 'white';
+};
+
+// Supply a user's full name
+// Returns background color and text color
+export const getAvatarColor = str => {
+  if (str) {
+    let hash = 0;
+    [...str].forEach((s, i) => {
+      if (i) {
+        hash = str.charCodeAt(i) + ((hash << 5) - hash); // eslint-disable-line
+      }
+    });
+
+    const c = (hash & 0x00FFFFFF) // eslint-disable-line
+      .toString(16)
+      .toUpperCase();
+
+    const backgroundColor = '00000'.substring(0, 6 - c.length) + c;
+    const color = getContrastYIQ(backgroundColor);
+
+    const backgroundColorWithHash = `#${backgroundColor}`;
+
+    return { backgroundColor: backgroundColorWithHash, color };
+  }
+
+  return null;
+};


### PR DESCRIPTION
Use with https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/327

Generates a repeatable color scheme for the avatar in the client's public profile.