### PR TITLE
Include bidStatistics in details prop

### DIFF
--- a/src/Components/PositionDetailsItem/PositionDetailsItem.jsx
+++ b/src/Components/PositionDetailsItem/PositionDetailsItem.jsx
@@ -126,7 +126,10 @@ const PositionDetailsItem = (props) => {
         </div>
         <div className="usa-width-one-third position-details-contact-container">
           <PositionDetailsContact
-            details={position}
+            details={{
+              ...position,
+              bidStatistics: get(details, 'bid_statistics', [{}]),
+            }}
             editWebsiteContent={editWebsiteContent}
             editPocContent={editPocContent}
             resetDescriptionEditMessages={resetDescriptionEditMessages}

--- a/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
+++ b/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
@@ -173,6 +173,9 @@ exports[`PositionDetailsItem matches snapshot 1`] = `
         bidListToggleIsLoading={false}
         details={
           Object {
+            "bidStatistics": Array [
+              Object {},
+            ],
             "bid_statistics": Array [
               Object {
                 "at_skill": 0,
@@ -529,6 +532,9 @@ exports[`PositionDetailsItem matches snapshot when there is an obc id 1`] = `
         bidListToggleIsLoading={false}
         details={
           Object {
+            "bidStatistics": Array [
+              Object {},
+            ],
             "bid_statistics": Array [
               Object {
                 "at_skill": 0,
@@ -887,6 +893,9 @@ exports[`PositionDetailsItem matches snapshot when various data is missing from 
         bidListToggleIsLoading={false}
         details={
           Object {
+            "bidStatistics": Array [
+              Object {},
+            ],
             "bid_statistics": Array [
               Object {
                 "at_skill": 0,


### PR DESCRIPTION
Fixes an issue where bid statistics were not displaying on the Position Details screen.