### PR TITLE
skill param updated. query fallbacks implemented

### DIFF
--- a/src/actions/homePagePositions.js
+++ b/src/actions/homePagePositions.js
@@ -75,9 +75,11 @@ export function homePagePositionsFetchData(skills = [], grade) {
       .then((results) => {
         // ...and because of that, we can be sure results[x] aligns with queryTypes[x]
         // and set the relevant resultsType property accordingly
+        let shouldSkip = false;
         results.forEach((result, i) => {
           // if our query returned no results, we will want to fall to the next arrangement
           if (!result.data.results.length) {
+            shouldSkip = true;
             if (queryTypes[i].name === 'userSkillAndGradePositions') {
               dispatch(homePagePositionsFetchData([], grade));
             } else if (queryTypes[i].name === 'userGradePositions') {
@@ -86,9 +88,11 @@ export function homePagePositionsFetchData(skills = [], grade) {
           }
           resultsTypes[queryTypes[i].name] = result.data.results;
         });
-        dispatch(homePagePositionsFetchDataSuccess(resultsTypes));
-        dispatch(homePagePositionsHasErrored(false));
-        dispatch(homePagePositionsIsLoading(false));
+        if (!shouldSkip) {
+          dispatch(homePagePositionsFetchDataSuccess(resultsTypes));
+          dispatch(homePagePositionsHasErrored(false));
+          dispatch(homePagePositionsIsLoading(false));
+        }
       })
       .catch(() => {
         dispatch(homePagePositionsHasErrored(true));


### PR DESCRIPTION
skill param was using old format, so skills weren't being passed in.

Fallbacks updated------------------
Fallbacks that were already in place:
Positions that match users’ grade and skill (if user has at least one skill and a grade in userProfile)
Positions that match users’ grade (if user has grade in userProfile)
Users’ favorite positions (grab users’ Favorites, regardless of if they have any)

But the fallbacks weren’t accounting for if the user **did** have skill and grade but the query matched no positions.