### PR TITLE
Feature/register toast notification

### DIFF
--- a/src/Components/BidListMessages/RegisterSuccess.jsx
+++ b/src/Components/BidListMessages/RegisterSuccess.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import InteractiveElement from '../InteractiveElement';
+
+const RegisterSuccess = ({ undo }) => (
+  <span>
+    Handshake successfully registered.&nbsp;
+    <InteractiveElement
+      type="a"
+      onClick={undo}
+    >
+        Undo
+    </InteractiveElement>.
+  </span>
+);
+
+RegisterSuccess.propTypes = {
+  undo: PropTypes.func.isRequired,
+};
+
+export default RegisterSuccess;

--- a/src/Components/BidListMessages/RegisterSuccess.test.jsx
+++ b/src/Components/BidListMessages/RegisterSuccess.test.jsx
@@ -1,0 +1,10 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import RegisterSuccess from './RegisterSuccess';
+
+describe('RegisterSuccess', () => {
+  it('is defined', () => {
+    const wrapper = shallow(<RegisterSuccess undo={() => {}} />);
+    expect(wrapper).toBeDefined();
+  });
+});

--- a/src/Constants/SystemMessages.js
+++ b/src/Constants/SystemMessages.js
@@ -1,8 +1,9 @@
-import FavoriteSuccess from '../Components/FavoriteMessages/Success';
-import RemoveSuccess from '../Components/FavoriteMessages/RemoveSuccess';
-import BidAddSuccess from '../Components/BidListMessages/Success';
-import BidRemoveSuccess from '../Components/BidListMessages/RemoveSuccess';
-import SavedSearchSuccess from '../Components/SavedSearchMessages/Success';
+import RegisterHandshakeSuccess from 'Components/BidListMessages/RegisterSuccess';
+import FavoriteSuccess from 'Components/FavoriteMessages/Success';
+import RemoveSuccess from 'Components/FavoriteMessages/RemoveSuccess';
+import BidAddSuccess from 'Components/BidListMessages/Success';
+import BidRemoveSuccess from 'Components/BidListMessages/RemoveSuccess';
+import SavedSearchSuccess from 'Components/SavedSearchMessages/Success';
 
 export const DEFAULT_TEXT = 'None listed';
 
@@ -59,7 +60,7 @@ export const DECLINE_BID_ERROR = 'Error trying to decline this bid.';
 export const SUBMIT_BID_SUCCESS = 'Bid successfully submitted.';
 export const SUBMIT_BID_ERROR = 'Error trying to submit this bid.';
 
-export const REGISTER_HANDSHAKE_SUCCESS = 'Handshake successfully registered.';
+export const REGISTER_HANDSHAKE_SUCCESS = undo => RegisterHandshakeSuccess({ undo });
 export const REGISTER_HANDSHAKE_ERROR = 'Error trying to register handshake.';
 export const UNREGISTER_HANDSHAKE_SUCCESS = 'Handshake successfully unregistered.';
 export const UNREGISTER_HANDSHAKE_ERROR = 'Error trying to unregister handshake.';

--- a/src/actions/bidList.js
+++ b/src/actions/bidList.js
@@ -207,6 +207,9 @@ export function routeChangeResetState() {
       dispatch(declineBidSuccess(false));
       dispatch(declineBidHasErrored(false));
       dispatch(declineBidSuccess(false));
+      dispatch(registerHandshakeSuccess(false));
+      dispatch(registerHandshakeHasErrored(false));
+      dispatch(registerHandshakeSuccess(false));
     });
   };
 }
@@ -408,16 +411,20 @@ export function registerHandshake(id, clientId) {
     api().put(url)
       .then(response => response.data)
       .then(() => {
+        const message = SystemMessages.REGISTER_HANDSHAKE_SUCCESS;
         batch(() => {
+          dispatch(toastSuccess(message));
           dispatch(registerHandshakeHasErrored(false));
           dispatch(registerHandshakeIsLoading(false));
-          dispatch(registerHandshakeSuccess(SystemMessages.REGISTER_HANDSHAKE_SUCCESS));
+          dispatch(registerHandshakeSuccess(message));
         });
         dispatch(userProfilePublicFetchData(clientId));
       })
       .catch(() => {
+        const message = SystemMessages.REGISTER_HANDSHAKE_ERROR;
         batch(() => {
-          dispatch(registerHandshakeHasErrored(SystemMessages.REGISTER_HANDSHAKE_ERROR));
+          dispatch(toastError(message));
+          dispatch(registerHandshakeHasErrored(message));
           dispatch(registerHandshakeIsLoading(false));
         });
       });

--- a/src/actions/bidList.js
+++ b/src/actions/bidList.js
@@ -396,41 +396,6 @@ export function declineBid(id, clientId) {
   };
 }
 
-export function registerHandshake(id, clientId) {
-  return (dispatch) => {
-    const idString = id.toString();
-    // reset the states to ensure only one message can be shown
-    batch(() => {
-      dispatch(routeChangeResetState());
-      dispatch(registerHandshakeIsLoading(true));
-      dispatch(registerHandshakeHasErrored(false));
-    });
-
-    const url = `/fsbid/cdo/position/${idString}/client/${clientId}/register/`;
-
-    api().put(url)
-      .then(response => response.data)
-      .then(() => {
-        const message = SystemMessages.REGISTER_HANDSHAKE_SUCCESS;
-        batch(() => {
-          dispatch(toastSuccess(message));
-          dispatch(registerHandshakeHasErrored(false));
-          dispatch(registerHandshakeIsLoading(false));
-          dispatch(registerHandshakeSuccess(message));
-        });
-        dispatch(userProfilePublicFetchData(clientId));
-      })
-      .catch(() => {
-        const message = SystemMessages.REGISTER_HANDSHAKE_ERROR;
-        batch(() => {
-          dispatch(toastError(message));
-          dispatch(registerHandshakeHasErrored(message));
-          dispatch(registerHandshakeIsLoading(false));
-        });
-      });
-  };
-}
-
 export function unregisterHandshake(id, clientId) {
   return (dispatch) => {
     const idString = id.toString();
@@ -446,17 +411,57 @@ export function unregisterHandshake(id, clientId) {
     api().delete(url)
       .then(response => response.data)
       .then(() => {
+        const message = SystemMessages.UNREGISTER_HANDSHAKE_SUCCESS;
         batch(() => {
+          dispatch(toastSuccess(message));
           dispatch(unregisterHandshakeHasErrored(false));
           dispatch(unregisterHandshakeIsLoading(false));
-          dispatch(unregisterHandshakeSuccess(SystemMessages.UNREGISTER_HANDSHAKE_SUCCESS));
+          dispatch(unregisterHandshakeSuccess(message));
         });
         dispatch(userProfilePublicFetchData(clientId));
       })
       .catch(() => {
+        const message = SystemMessages.UNREGISTER_HANDSHAKE_ERROR;
         batch(() => {
-          dispatch(unregisterHandshakeHasErrored(SystemMessages.UNREGISTER_HANDSHAKE_ERROR));
+          dispatch(toastError(message));
+          dispatch(unregisterHandshakeHasErrored(message));
           dispatch(unregisterHandshakeIsLoading(false));
+        });
+      });
+  };
+}
+
+export function registerHandshake(id, clientId) {
+  return (dispatch) => {
+    const idString = id.toString();
+    // reset the states to ensure only one message can be shown
+    batch(() => {
+      dispatch(routeChangeResetState());
+      dispatch(registerHandshakeIsLoading(true));
+      dispatch(registerHandshakeHasErrored(false));
+    });
+
+    const url = `/fsbid/cdo/position/${idString}/client/${clientId}/register/`;
+
+    api().put(url)
+      .then(response => response.data)
+      .then(() => {
+        const undo = () => dispatch(unregisterHandshake(id, clientId));
+        const message = SystemMessages.REGISTER_HANDSHAKE_SUCCESS(undo);
+        batch(() => {
+          dispatch(toastSuccess(message));
+          dispatch(registerHandshakeHasErrored(false));
+          dispatch(registerHandshakeIsLoading(false));
+          dispatch(registerHandshakeSuccess(message));
+        });
+        dispatch(userProfilePublicFetchData(clientId));
+      })
+      .catch(() => {
+        const message = SystemMessages.REGISTER_HANDSHAKE_ERROR;
+        batch(() => {
+          dispatch(toastError(message));
+          dispatch(registerHandshakeHasErrored(message));
+          dispatch(registerHandshakeIsLoading(false));
         });
       });
   };

--- a/src/actions/bidList.js
+++ b/src/actions/bidList.js
@@ -197,19 +197,19 @@ export function routeChangeResetState() {
     batch(() => {
       dispatch(bidListToggleSuccess(false));
       dispatch(bidListToggleHasErrored(false));
-      dispatch(bidListToggleSuccess(false));
+      dispatch(bidListToggleIsLoading(false));
       dispatch(submitBidSuccess(false));
       dispatch(submitBidHasErrored(false));
-      dispatch(submitBidSuccess(false));
+      dispatch(submitBidIsLoading(false));
       dispatch(acceptBidSuccess(false));
       dispatch(acceptBidHasErrored(false));
-      dispatch(acceptBidSuccess(false));
+      dispatch(acceptBidIsLoading(false));
       dispatch(declineBidSuccess(false));
       dispatch(declineBidHasErrored(false));
-      dispatch(declineBidSuccess(false));
+      dispatch(declineBidIsLoading(false));
       dispatch(registerHandshakeSuccess(false));
       dispatch(registerHandshakeHasErrored(false));
-      dispatch(registerHandshakeSuccess(false));
+      dispatch(registerHandshakeIsLoading(false));
     });
   };
 }


### PR DESCRIPTION
- Shows success and error notification on register HS
- Success message includes undo link, which will refresh the page with the register handshake option overlay still showing (reverts state so it appears the handshake didn't register)
- When you undo a register handshake, the next toast notification will be a success/error toast for unregistering a HS