### PR TITLE
Tandem Search Pills

### DIFF
--- a/src/Components/Pill/Pill.jsx
+++ b/src/Components/Pill/Pill.jsx
@@ -2,18 +2,41 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import FontAwesome from 'react-fontawesome';
 
-const Pill = ({ description, codeRef, selectionRef, onPillClick }, { isProjectedVacancy }) => (
-  <button
-    className={`pill ${isProjectedVacancy ? 'pill--projected-vacancy' : ''}`}
-    title={`Remove ${description} filter`}
-    onClick={() => onPillClick(selectionRef, codeRef, true)}
-  >
-    {description} <FontAwesome name="times" />
-  </button>
-);
+const Pill = ({ description, codeRef, selectionRef, onPillClick,
+  isTandem2, isCommon }, { isProjectedVacancy, isTandemSearch }) => {
+  const classes = ['pill'];
+  const lastIndex = classes.length;
+  let titleSuffix = '';
+  if (isProjectedVacancy) {
+    classes.push('pill--projected-vacancy');
+  }
+  if (isTandemSearch) {
+    classes[lastIndex] = 'pill--tandem-search';
+    titleSuffix = ' from Tandem 1';
+  }
+  if (isTandem2) {
+    classes[lastIndex] = 'pill--tandem2';
+    titleSuffix = ' from Tandem 2';
+  }
+  if (isCommon) {
+    classes[lastIndex] = 'pill--common';
+    titleSuffix = '';
+  }
+  const classes$ = classes.join(' ');
+  return (
+    <button
+      className={classes$}
+      title={`Remove ${description} filter${titleSuffix}`}
+      onClick={() => onPillClick(selectionRef, codeRef, true)}
+    >
+      {description} <FontAwesome name="times" />
+    </button>
+  );
+};
 
 Pill.contextTypes = {
   isProjectedVacancy: PropTypes.bool,
+  isTandemSearch: PropTypes.bool,
 };
 
 Pill.propTypes = {
@@ -21,6 +44,13 @@ Pill.propTypes = {
   codeRef: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   selectionRef: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   onPillClick: PropTypes.func.isRequired,
+  isTandem2: PropTypes.bool,
+  isCommon: PropTypes.bool,
+};
+
+Pill.defaultProps = {
+  isTandem2: false,
+  isCommon: false,
 };
 
 export default Pill;

--- a/src/Components/Pill/__snapshots__/Pill.test.jsx.snap
+++ b/src/Components/Pill/__snapshots__/Pill.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`PillComponent matches snapshot 1`] = `
 <button
-  className="pill "
+  className="pill"
   onClick={[Function]}
   title="Remove test filter"
 >

--- a/src/Components/PillList/PillList.jsx
+++ b/src/Components/PillList/PillList.jsx
@@ -6,12 +6,16 @@ import Pill from '../Pill/Pill';
 
 const PillList = ({ items, onPillClick }, { isTandemSearch }) => {
   const ordering = ['description', 'code'];
-  if (isTandemSearch) ordering.splice(0, 0, 'isCommon', 'isTandem');
+  const orders = [];
+  if (isTandemSearch) {
+    ordering.splice(0, 0, 'isCommon', 'isTandem');
+    orders.splice(0, 0, 'asc', 'desc');
+  }
   return (
     <div className="pill-list-container">
       {
         // order items in their correct context
-        (orderBy(items.slice(), ordering))
+        (orderBy(items.slice(), ordering, orders))
           // do not display toggles as pills
           .filter(f => !f.isToggle)
           // display pills in their correct context

--- a/src/Components/PillList/PillList.jsx
+++ b/src/Components/PillList/PillList.jsx
@@ -1,25 +1,39 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { orderBy } from 'lodash';
 import { PILL_ITEM_ARRAY } from '../../Constants/PropTypes';
 import Pill from '../Pill/Pill';
-import { pillSort } from '../../utilities';
 
-const PillList = ({ items, onPillClick }) => (
-  <div className="pill-list-container">
-    {
-      (items.slice().sort(pillSort))
-        .map(item =>
-          (<Pill
-            key={`${item.codeRef}-${item.description}`}
+const PillList = ({ items, onPillClick }, { isTandemSearch }) => {
+  const ordering = ['description', 'code'];
+  if (isTandemSearch) ordering.splice(0, 0, 'isCommon', 'isTandem');
+  return (
+    <div className="pill-list-container">
+      {
+        // order items in their correct context
+        (orderBy(items.slice(), ordering))
+          // do not display toggles as pills
+          .filter(f => !f.isToggle)
+          // display pills in their correct context
+          .filter(f => !isTandemSearch ? !f.isTandem : true)
+          // map items
+          .map(item => (<Pill
+            key={`${item.codeRef}-${item.description}-${item.isTandem}`}
             description={item.description}
             codeRef={item.codeRef}
             selectionRef={item.selectionRef}
             onPillClick={onPillClick}
-          />),
-        )
-    }
-  </div>
-);
+            isTandem2={isTandemSearch && item.isTandem}
+            isCommon={isTandemSearch && item.isCommon}
+          />))
+      }
+    </div>
+  );
+};
+
+PillList.contextTypes = {
+  isTandemSearch: PropTypes.bool,
+};
 
 PillList.propTypes = {
   items: PILL_ITEM_ARRAY,

--- a/src/Components/PillList/__snapshots__/PillList.test.jsx.snap
+++ b/src/Components/PillList/__snapshots__/PillList.test.jsx.snap
@@ -7,35 +7,45 @@ exports[`PillListComponent matches snapshot 1`] = `
   <Pill
     codeRef="code"
     description="a"
-    key="code-a"
+    isCommon={false}
+    isTandem2={false}
+    key="code-a-undefined"
     onPillClick={[Function]}
     selectionRef="selection"
   />
   <Pill
     codeRef="code2"
     description="b"
-    key="code2-b"
+    isCommon={false}
+    isTandem2={false}
+    key="code2-b-undefined"
     onPillClick={[Function]}
     selectionRef="selection2"
   />
   <Pill
     codeRef="code2"
     description="c"
-    key="code2-c"
+    isCommon={false}
+    isTandem2={false}
+    key="code2-c-undefined"
     onPillClick={[Function]}
     selectionRef="selection2"
   />
   <Pill
     codeRef="code3"
     description="c"
-    key="code3-c"
+    isCommon={false}
+    isTandem2={false}
+    key="code3-c-undefined"
     onPillClick={[Function]}
     selectionRef="selection3"
   />
   <Pill
     codeRef="code4"
     description="d"
-    key="code4-d"
+    isCommon={false}
+    isTandem2={false}
+    key="code4-d-undefined"
     onPillClick={[Function]}
     selectionRef="selection3"
   />

--- a/src/Containers/Results/Results.jsx
+++ b/src/Containers/Results/Results.jsx
@@ -47,6 +47,14 @@ class Results extends Component {
     this.debounced = debounce(() => {});
   }
 
+  getChildContext() {
+    const { tandem } = queryString.parse(get(this.state, 'query.value', ''));
+    const isTandemSearch = tandem === 'tandem';
+    return {
+      isTandemSearch,
+    };
+  }
+
   UNSAFE_componentWillMount() {
     const { isAuthorized, onNavigateTo } = this.props;
     // store default search
@@ -293,6 +301,10 @@ class Results extends Component {
 
 Results.contextTypes = {
   router: PropTypes.object,
+};
+
+Results.childContextTypes = {
+  isTandemSearch: PropTypes.bool,
 };
 
 Results.propTypes = {

--- a/src/actions/filters/filters.js
+++ b/src/actions/filters/filters.js
@@ -143,7 +143,7 @@ export function filtersFetchData(items = { filters: [] }, queryParams = {}, save
           // Remove duplicates by this new property
           responses$.mappedParams = removeDuplicates(
             responses$.mappedParams,
-            'descCode',
+            ['descCode', 'isTandem'],
           );
           // Determine which objects duplicates by description,
           // and give them with a new prop to identify them
@@ -209,13 +209,22 @@ export function filtersFetchData(items = { filters: [] }, queryParams = {}, save
       if (queryParamObject) {
         responses.filters.forEach((response) => {
           const filterRef = response.item.selectionRef;
+          const isTandem = response.item.isTandem;
+          const isCommon = response.item.isCommon;
+          const isToggle = response.item.isToggle;
           Object.keys(queryParamObject).forEach((key) => {
             if (key === filterRef) {
               // convert the string to an array
               const paramArray = queryParamObject[key].split(',');
               paramArray.forEach((paramArrayItem) => {
                 // create a base config object
-                const mappedObject = { selectionRef: filterRef, codeRef: paramArrayItem };
+                const mappedObject = {
+                  selectionRef: filterRef,
+                  codeRef: paramArrayItem,
+                  isTandem,
+                  isCommon,
+                  isToggle,
+                };
                 responses.filters.forEach((filterItem, i) => {
                   filterItem.data.forEach((filterItemObject, j) => {
                     // Check if code or ID matches, since we use both.

--- a/src/reducers/filters/filters.js
+++ b/src/reducers/filters/filters.js
@@ -31,6 +31,7 @@ const items =
           isToggle: true,
           description: 'projectedVacancy',
           selectionRef: ENDPOINT_PARAMS.projectedVacancy,
+          isCommon: true,
           text: 'Toggle between available and projected vacancy positions',
           choices: [
           ],
@@ -47,6 +48,7 @@ const items =
           isToggle: true,
           description: 'tandem-toggle',
           selectionRef: ENDPOINT_PARAMS.tandem,
+          isCommon: true,
           text: 'Toggle between available and projected vacancy positions',
           choices: [
           ],
@@ -473,7 +475,7 @@ const items =
           description: 'COLA',
           selectionRef: ENDPOINT_PARAMS.cola,
           text: 'Include only positions with COLA',
-          isTandemCommon: true,
+          isCommon: true,
           choices: [
           ],
         },
@@ -490,7 +492,7 @@ const items =
           selectionRef: ENDPOINT_PARAMS.postDiff,
           text: 'Include only positions with a post differential',
           tryCache: true,
-          isTandemCommon: true,
+          isCommon: true,
           choices: [
           ],
         },
@@ -515,7 +517,7 @@ const items =
           selectionRef: ENDPOINT_PARAMS.danger,
           text: 'Include only positions with danger pay',
           tryCache: true,
-          isTandemCommon: true,
+          isCommon: true,
           choices: [
           ],
         },
@@ -535,6 +537,7 @@ const items =
           description: 'domestic',
           selectionRef: ENDPOINT_PARAMS.domestic,
           text: 'Include only domestic positions',
+          isCommon: true,
           choices: [
           ],
         },
@@ -573,7 +576,7 @@ const items =
           selectionRef: ENDPOINT_PARAMS.post,
           selectionRefAP: ENDPOINT_PARAMS.postAP,
           tryCache: true,
-          isTandemCommon: true,
+          isCommon: true,
           choices: [
           ],
         },

--- a/src/sass/_profile.scss
+++ b/src/sass/_profile.scss
@@ -973,8 +973,19 @@ $padding-no-border: $total-padding - $border;
   padding: 2px .7em 0;
 }
 
-.pill--projected-vacancy {
+.pill--projected-vacancy,
+.pill--tandem-search {
   background-color: $primary-blue-darkest;
+}
+
+// This will override previous color declarations
+.pill--tandem2 {
+  background-color: $color-blue-mariner;
+}
+
+// This will override previous color declarations
+.pill--common {
+  background-color: $color-blue-chill;
 }
 
 .pill--highlight {

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -2,7 +2,7 @@ import Scroll from 'react-scroll';
 import { distanceInWords, format } from 'date-fns';
 import { cloneDeep, get, has, intersection, isArray, isEmpty, isEqual, isFunction,
   isNumber, isObject, isString, keys, lowerCase, merge as merge$, orderBy, split,
-  startCase, take, toLower, toString, transform } from 'lodash';
+  startCase, take, toLower, toString, transform, uniqBy } from 'lodash';
 import numeral from 'numeral';
 import queryString from 'query-string';
 import shortid from 'shortid';
@@ -110,16 +110,6 @@ export function fetchJWT() {
   }
   return null;
 }
-
-export const pillSort = (a, b) => {
-  const A = lowerCase(toString((get(a, 'description') || get(a, 'code'))));
-  const B = lowerCase(toString((get(b, 'description') || get(b, 'code'))));
-  if (A < B) { // sort string ascending
-    return -1;
-  }
-  if (A > B) { return 1; }
-  return 0; // default return value (no sorting)
-};
 
 export const sortTods = (data) => {
   const sortingArray = ['T', 'C', 'H', 'O', 'V', '1', '2', 'U', 'A', 'B', 'E', 'N', 'S', 'G', 'D', 'F', 'R', 'Q', 'J', 'I', 'P', 'W', 'L', 'K', 'M', 'Y', 'Z', 'X'];
@@ -298,8 +288,8 @@ export const ifEnter = (e) => {
 export const formQueryString = queryObject => queryString.stringify(queryObject);
 
 // remove duplicates from an array by object property
-export const removeDuplicates = (myArr, prop) => (
-  myArr.filter((obj, pos, arr) => arr.map(mapObj => mapObj[prop]).indexOf(obj[prop]) === pos)
+export const removeDuplicates = (myArr, props = ['']) => (
+  uniqBy(myArr, elem => props.map(m => elem[m]).join())
 );
 
 // Format date for notifications.

--- a/src/utilities.test.js
+++ b/src/utilities.test.js
@@ -4,7 +4,6 @@ import { validStateEmail,
   localStorageFetchValue,
   localStorageToggleValue,
   fetchUserToken,
-  pillSort,
   formExploreRegionDropdown,
   scrollToTop,
   getItemLabel,
@@ -14,7 +13,6 @@ import { validStateEmail,
   formQueryString,
   propSort,
   existsInNestedObject,
-  removeDuplicates,
   getTimeDistanceInWords,
   formatDate,
   focusById,
@@ -117,7 +115,6 @@ describe('fetchUserToken', () => {
 
 describe('sort functions', () => {
   const items = [{ title: 'a', description: 'a' }, { title: 'b', description: 'b' }];
-  const pills = [{ description: 'a' }, { code: 'b' }];
   const grades = [{ code: '01' }, { code: '02' }, { code: 'fake' }, { code: 'MC' }];
 
   it('can sort by description', () => {
@@ -130,12 +127,6 @@ describe('sort functions', () => {
     expect(propSort('title')(items[0], items[1])).toBe(-1);
     expect(propSort('title')(items[1], items[0])).toBe(1);
     expect(propSort('title')(items[0], items[0])).toBe(0);
-  });
-
-  it('can sort by description or code', () => {
-    expect(pillSort(pills[0], pills[1])).toBe(-1);
-    expect(pillSort(pills[1], pills[0])).toBe(1);
-    expect(pillSort(pills[0], pills[0])).toBe(0);
   });
 
   it('can apply custom sorting to grades', () => {
@@ -233,32 +224,6 @@ describe('existsInNestedObject', () => {
 
   it('can return false when something does not exist in a nested object', () => {
     expect(existsInNestedObject(1, [{ position: { otherId: 2 } }])).toBe(false);
-  });
-});
-
-describe('removeDuplicates', () => {
-  const arr = [
-    { id: 1, prop: 'a' },
-    { id: 2, prop: 'b' },
-    { id: 1, prop: 'c' },
-  ];
-  it('removes duplicate objects from an array by property', () => {
-    // it should remove the last object since id is a duplicate
-    const newArr = removeDuplicates(arr, 'id');
-    expect(newArr.length).toBe(2);
-    expect(newArr[0].id).toBe(1);
-    expect(newArr[0].prop).toBe('a');
-    expect(newArr[1].id).toBe(2);
-  });
-  it('retains duplicates by properties other than the one specified', () => {
-    // no objects should be removed since all prop properties are unique
-    const newArr = removeDuplicates(arr, 'prop');
-    expect(newArr.length).toBe(3);
-    expect(newArr[0].id).toBe(1);
-    expect(newArr[0].prop).toBe('a');
-    expect(newArr[1].id).toBe(2);
-    expect(newArr[2].id).toBe(1);
-    expect(newArr[2].prop).toBe('c');
   });
 });
 


### PR DESCRIPTION
~~Relies on #884 (merge first)~~

- Conditional coloring for tandem search pills, to differentiate among Tandem 1, Tandem 2, and common
- Hover text for pills, so that the user knows which pills associate with which tandem user
- Different ordering of the pills based on individual vs tandem search
- Hide any `isToggle` filters from the Pill List
- Refactor some functions 