### PR TITLE
Deduplicate CDOs

### DIFF
--- a/src/Components/BidderPortfolio/helpers.js
+++ b/src/Components/BidderPortfolio/helpers.js
@@ -1,14 +1,18 @@
 // Temporary helpers used for static data
 
-import { orderBy } from 'lodash';
+import { orderBy, uniqBy } from 'lodash';
 import { filterByProps } from '../../utilities';
 
 function filterUsers(term = '', cdos = []) {
   const getOrdered = a => orderBy(a, ['isCurrentUser', 'last_name']);
 
-  return term.length ?
+  const data = term.length ?
     getOrdered(filterByProps(term, ['first_name', 'last_name'], cdos)) :
     getOrdered(cdos);
+
+  // It is possible that a single CDO is returned twice if they match multiple rolecodes,
+  // so deduplicate here.
+  return uniqBy(data, 'id');
 }
 
 export default filterUsers;


### PR DESCRIPTION
Fixes a React `key` bug when multiple CDOs with the same `hru_id` are returned.