### PR TITLE
Reset the cps_codes filter upon switching to PV search

### DIFF
--- a/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
+++ b/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
@@ -61,6 +61,7 @@ class SearchFiltersContainer extends Component {
         is_available_in_current_bidcycle: null,
         projectedVacancy: value,
         ordering: 'ted',
+        cps_codes: null,
       };
     }
     this.props.queryParamUpdate(config);

--- a/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.test.jsx
+++ b/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.test.jsx
@@ -112,6 +112,7 @@ describe('SearchFiltersContainerComponent', () => {
     // check when value !== 'open'
     wrapper.instance().onProjectedVacancyFilterClick('pv');
     expect(toggleValue.value).toEqual({
+      cps_codes: null,
       is_available_in_bidcycle: null,
       is_available_in_current_bidcycle: null,
       ordering: 'ted',


### PR DESCRIPTION
Handshake filter is irrelevant for PV search, so reset it when the user switches from AP to PV search.