### PR TITLE
Bug: Empty Favorites, forever homepage spinner

### DIFF
--- a/src/Components/HomePagePositionsSection/HomePagePositionsSection.jsx
+++ b/src/Components/HomePagePositionsSection/HomePagePositionsSection.jsx
@@ -40,6 +40,7 @@ const HomePagePositionsSection = ({ title, icon, viewMoreLink, positions,
   const shouldShowAlert = !hasErrored && positions && !positions.length;
   const shouldShowErrorAlert = hasErrored && !isLoading;
   const shouldDisplaySpinner = useSpinner && isLoading;
+  const isFavorites = title === 'Favorited Positions';
 
   const wrappedInLink = wrapInLink ?
     (
@@ -78,7 +79,10 @@ const HomePagePositionsSection = ({ title, icon, viewMoreLink, positions,
           />
       }
       {
-        shouldShowAlert && <Alert title="No results match this criteria" />
+        shouldShowAlert && isFavorites && <Alert title="No available positions added to Favorites" />
+      }
+      {
+        shouldShowAlert && !isFavorites && <Alert title="No results match this criteria" />
       }
       {
         shouldShowErrorAlert && <Alert title="An error occurred loading positions" type="error" />

--- a/src/Containers/HomePagePositionsContainer/HomePagePositionsContainer.jsx
+++ b/src/Containers/HomePagePositionsContainer/HomePagePositionsContainer.jsx
@@ -49,7 +49,6 @@ class HomePagePositionsContainer extends Component {
           (userProfileIsLoading || homePagePositionsIsLoading || !hasFetched)
             ?
             <div className="usa-grid-full homepage-positions-section-container">
-
               <Spinner type="homepage-position-results" size="big" />
             </div>
             :

--- a/src/actions/homePagePositions.js
+++ b/src/actions/homePagePositions.js
@@ -78,7 +78,7 @@ export function homePagePositionsFetchData(skills = [], grade) {
         let shouldSkip = false;
         results.forEach((result, i) => {
           // if our query returned no results, we will want to fall to the next arrangement
-          if (!result.data.results.length) {
+          if (!result.data.results.length && queryTypes[i].name !== 'favoritedPositions') {
             shouldSkip = true;
             if (queryTypes[i].name === 'userSkillAndGradePositions') {
               dispatch(homePagePositionsFetchData([], grade));


### PR DESCRIPTION
Handles last fall-back case of empty Favorites for Homepage Positions.

To see fix: on dev branch, for Admin (bc they have no Grade) empty out their Available Positions Favorites. Go to Home Page and see the incessant(!) loading. Do the same for this branch and behold the beauty. 🌷 