### PR TITLE
Keep consistent height of pagination container on Favorites

### DIFF
--- a/src/Components/FavoritePositions/FavoritePositions.jsx
+++ b/src/Components/FavoritePositions/FavoritePositions.jsx
@@ -91,14 +91,16 @@ const FavoritePositions = props => {
         denominator={null}
       />
       <div className="usa-grid-full favorites-top-section">
-        {
-          !favoritePositionsIsLoading &&
-          <TotalResults
-            total={paginationTotal[selected]}
-            pageNumber={page}
-            pageSize={pageSize}
-          />
-        }
+        <div className="total-results-container">
+          {
+            !favoritePositionsIsLoading &&
+            <TotalResults
+              total={paginationTotal[selected]}
+              pageNumber={page}
+              pageSize={pageSize}
+            />
+          }
+        </div>
         <div className="favorites-top-section--controls">
           <div className="results-dropdown results-dropdown-sort">
             <SelectForm

--- a/src/Components/FavoritePositions/__snapshots__/FavoritePositions.test.jsx.snap
+++ b/src/Components/FavoritePositions/__snapshots__/FavoritePositions.test.jsx.snap
@@ -38,12 +38,16 @@ exports[`FavoritePositionsComponent matches snapshot 1`] = `
   <div
     className="usa-grid-full favorites-top-section"
   >
-    <TotalResults
-      pageNumber={1}
-      pageSize={12}
-      suffix="Results"
-      total={2}
-    />
+    <div
+      className="total-results-container"
+    >
+      <TotalResults
+        pageNumber={1}
+        pageSize={12}
+        suffix="Results"
+        total={2}
+      />
+    </div>
     <div
       className="favorites-top-section--controls"
     >

--- a/src/sass/_profile.scss
+++ b/src/sass/_profile.scss
@@ -128,6 +128,10 @@
       margin-top: 0;
     }
 
+    .total-results-container {
+      min-height: 20px;
+    }
+
     .favorites-top-section {
       margin-bottom: 1.2em;
 


### PR DESCRIPTION
Ensures the height of the pagination container is consistent, so that when it disappears due to Favorites loading, the rest of the display is not moved out of line.