### PR TITLE
Add sort and filter to bureau bidders TM-1864

### DIFF
--- a/src/Components/BureauPage/PositionManagerBidders/PositionManagerBidders.jsx
+++ b/src/Components/BureauPage/PositionManagerBidders/PositionManagerBidders.jsx
@@ -2,7 +2,9 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { get, keys } from 'lodash';
 import { NO_DATE, NO_GRADE } from 'Constants/SystemMessages';
+import { BUREAU_BIDDER_SORT, BUREAU_BIDDER_FILTERS } from 'Constants/Sort';
 import LanguageList from 'Components/LanguageList';
+import SelectForm from 'Components/SelectForm';
 import { propOrDefault } from 'utilities';
 import SkillCodeList from '../../SkillCodeList';
 import MailToButton from '../../MailToButton';
@@ -154,6 +156,22 @@ class PositionManagerBidders extends Component {
     );
     return (
       <div className="usa-width-one-whole position-manager-bidders">
+        <div className="bidders-controls">
+          <SelectForm
+            id="sort"
+            label="Sort by:"
+            onSelectOption={() => {}}
+            options={BUREAU_BIDDER_SORT.options}
+            disabled={false}
+          />
+          <SelectForm
+            id="filter"
+            options={BUREAU_BIDDER_FILTERS.options}
+            label="Filter By:"
+            defaultSort={''}
+            disabled={false}
+          />
+        </div>
         <table className="position-manager-bidders-table">
           <thead>
             <tr>

--- a/src/Constants/Sort.js
+++ b/src/Constants/Sort.js
@@ -142,3 +142,20 @@ export const BUREAU_POSITION_SORT = {
     { value: '-position__post__has_service_needs_differential', text: 'Featured positions', availableOnly: true },
   ],
 };
+
+export const BUREAU_BIDDER_SORT = {
+  options: [
+    { value: '', text: 'Sort option', disabled: true },
+    { value: '-bidder__grade', text: "Bidder's Grade" },
+    { value: '-bidder__handshake', text: "Bidder's Skill" },
+    { value: 'handshake', text: 'Handshake' },
+  ],
+};
+
+export const BUREAU_BIDDER_FILTERS = {
+  options: [
+    { value: '', text: 'All' },
+    { value: 'true', text: 'Handshake' },
+    { value: 'false', text: 'No Handshake' },
+  ],
+};

--- a/src/sass/_bureau.scss
+++ b/src/sass/_bureau.scss
@@ -297,6 +297,74 @@
     font-size: .85em;
     margin-left: auto;
   }
+
+  .left-col {
+    display: flex;
+    float: left;
+  }
+
+  .right-col {
+    display: flex;
+    float: right;
+
+    .usa-button-secondary {
+      margin-right: 0;
+    }
+  }
+}
+
+.position-manager-bidders {
+  margin-top: 50px;
+  table {
+    margin: 0;
+    width: 100%;
+    thead {
+      tr {
+        th {
+          text-align: center;
+          border: none;
+          background-color: $color-white;
+        }
+        .table-title {
+          font-size: 30px;
+          font-weight: bold;
+        }
+        @media screen and (max-width: 1600px) {
+          .table-title {
+            font-size: 25px;
+          }
+        }
+        @media screen and (max-width: 1400px) {
+          .table-title {
+            font-size: 20px;
+          }
+        }
+      }
+    }
+    tbody {
+      border: 1px solid black;
+      td {
+        text-align: center;
+        border-top: none;
+        border-right: none;
+        border-left: none;
+        padding: 20px 30px;
+        font-size: 20px;
+      }
+      @media screen and (max-width: 1700px) {
+        td {
+          padding: 10px 15px;
+          font-size: 15px;
+        }
+      }
+      @media screen and (max-width: 1400px) {
+        td {
+          padding: 5px 7px;
+          font-size: 13px;
+        }
+      }
+    }
+  }
 }
 
 .position-manager-bidders {
@@ -332,5 +400,14 @@
         }
       }
     }
+  }
+}
+
+.bidders-controls {
+  display: flex;
+  justify-content: flex-end;
+
+  div:first-child {
+    margin-right: 5px;
   }
 }


### PR DESCRIPTION
FE Only 

Adds two drop downs for filter and sort on bureau bidders on position details for bureaus. 

I merged off of Elizabeth's branch so there's some extra code in here that is part of her PR for the export that should be dismissed once that is merged.