### PR TITLE
Update/add lang cycle filters

### DIFF
--- a/src/Components/BureauPage/PositionManager/PositionManager.jsx
+++ b/src/Components/BureauPage/PositionManager/PositionManager.jsx
@@ -42,6 +42,9 @@ const PositionManager = props => {
   const [selectedSkills, setSelectedSkills] = useState(userSelections.selectedSkills || []);
   const [selectedPosts, setSelectedPosts] = useState(userSelections.selectedPosts || []);
   const [selectedTODs, setSelectedTODs] = useState(userSelections.selectedTODs || []);
+  const [selectedCycles, setSelectedCycles] = useState(userSelections.selectedCycles || []);
+  const [selectedLanguages, setSelectedLanguages] =
+    useState(userSelections.selectedLanguages || []);
   const [selectedBureaus, setSelectedBureaus] =
     useState(userSelections.selectedBureaus || [props.bureauPermissions[0]]);
   const [isLoading, setIsLoading] = useState(userSelections.isLoading || false);
@@ -64,6 +67,10 @@ const PositionManager = props => {
   const bureauOptions = sortBy(bureauPermissions, [(b) => b.long_description]);
   const posts = bureauFilters$.find(f => f.item.description === 'post');
   const postOptions = uniqBy(sortBy(posts.data, [(p) => p.city]), 'code');
+  const cycles = bureauFilters$.find(f => f.item.description === 'bidCycle');
+  const cycleOptions = uniqBy(sortBy(cycles.data, [(c) => c.custom_description]), 'custom_description');
+  const languages = bureauFilters$.find(f => f.item.description === 'language');
+  const languageOptions = uniqBy(sortBy(languages.data, [(c) => c.custom_description]), 'custom_description');
   const sorts = BUREAU_POSITION_SORT;
 
   // Local state inputs to push to redux state
@@ -76,6 +83,8 @@ const PositionManager = props => {
     selectedPosts,
     selectedTODs,
     selectedBureaus,
+    selectedCycles,
+    selectedLanguages,
     textSearch,
     textInput,
   };
@@ -88,6 +97,8 @@ const PositionManager = props => {
     [posts.item.selectionRef]: selectedPosts.map(postObject => (postObject.code)),
     [tods.item.selectionRef]: selectedTODs.map(tedObject => (tedObject.code)),
     [bureaus.item.selectionRef]: selectedBureaus.map(bureauObject => (bureauObject.code)),
+    [cycles.item.selectionRef]: selectedCycles.map(cycleObject => (cycleObject.id)),
+    [languages.item.selectionRef]: selectedLanguages.map(langObject => (langObject.code)),
     ordering,
     page,
     limit,
@@ -114,6 +125,8 @@ const PositionManager = props => {
     selectedPosts,
     selectedTODs,
     selectedBureaus,
+    selectedCycles,
+    selectedLanguages,
     ordering,
     limit,
     textSearch,
@@ -140,6 +153,20 @@ const PositionManager = props => {
         {...rest}
         queryProp={queryProp}
         getIsSelected={getCodeSelected}
+      />),
+    );
+  }
+
+  function renderSelectionListById({ items, selected, ...rest }) {
+    const getIDSelected = item => !!selected.find(f => f.id === item.id);
+    const queryProp = get(items[0], 'custom_description', false) ? 'custom_description' : 'long_description';
+    return items.map(item =>
+      (<ListItem
+        key={item.id}
+        item={item}
+        {...rest}
+        queryProp={queryProp}
+        getIsSelected={getIDSelected}
       />),
     );
   }
@@ -202,6 +229,23 @@ const PositionManager = props => {
                 <div className="filterby-label">Filter by:</div>
                 <div className="usa-width-one-whole position-manager-filters results-dropdown">
                   <div className="small-screen-stack position-manager-filters-inner">
+                    <div className="filter-div">
+                      <div className="label">Cycle:</div>
+                      <Picky
+                        placeholder="Select cycle(s)"
+                        value={selectedCycles}
+                        options={cycleOptions}
+                        onChange={values => setSelectedCycles(values)}
+                        numberDisplayed={2}
+                        multiple
+                        includeFilter
+                        dropdownHeight={255}
+                        renderList={renderSelectionListById}
+                        valueKey="id"
+                        labelKey="custom_description"
+                        includeSelectAll
+                      />
+                    </div>
                     <div className="filter-div">
                       <div className="label">TOD:</div>
                       <Picky
@@ -276,6 +320,23 @@ const PositionManager = props => {
                         value={selectedGrades}
                         options={gradeOptions}
                         onChange={values => setSelectedGrades(values)}
+                        numberDisplayed={2}
+                        multiple
+                        includeFilter
+                        dropdownHeight={255}
+                        renderList={renderSelectionList}
+                        valueKey="code"
+                        labelKey="custom_description"
+                        includeSelectAll
+                      />
+                    </div>
+                    <div className="filter-div">
+                      <div className="label">Language:</div>
+                      <Picky
+                        placeholder="Select Language(s)"
+                        value={selectedLanguages}
+                        options={languageOptions}
+                        onChange={values => setSelectedLanguages(values)}
                         numberDisplayed={2}
                         multiple
                         includeFilter

--- a/src/Components/BureauPage/PositionManager/PositionManager.test.jsx
+++ b/src/Components/BureauPage/PositionManager/PositionManager.test.jsx
@@ -83,6 +83,37 @@ describe('BureauPage', () => {
             },
           ],
         },
+        {
+          item: { description: 'bidCycle' },
+          data: [
+            {
+              active: true,
+              custom_description: '2018 DCM/PO Cycle',
+              cycle_deadline_date: null,
+              cycle_end_date: null,
+              cycle_start_date: null,
+              id: 155,
+              isSelected: false,
+              name: '2018 DCM/PO Cycle',
+            },
+          ],
+        },
+        {
+          item: { description: 'language' },
+          data: [
+            {
+              code: 'AB',
+              custom_description: 'Albanian (AB)',
+              effective_date: null,
+              formal_description: 'Albanian',
+              group: 'languages',
+              id: 'AB',
+              isSelected: false,
+              long_description: 'Albanian',
+              short_description: 'Albanian',
+            },
+          ],
+        },
       ],
     },
     bureauPermissions: [
@@ -99,3 +130,4 @@ describe('BureauPage', () => {
     expect(wrapper).toBeDefined();
   });
 });
+

--- a/src/sass/_bureau.scss
+++ b/src/sass/_bureau.scss
@@ -97,7 +97,6 @@
     align-items: center;
     display: flex;
     margin-right: 10px;
-    z-index: 200;
     .label {
       margin-right: 10px;
     }

--- a/src/sass/_spinner.scss
+++ b/src/sass/_spinner.scss
@@ -94,6 +94,7 @@
   left: 45%;
   position: absolute;
   top: 350px;
+  z-index: 98;
 }
 
 .tm-spinner-bureau-filters {


### PR DESCRIPTION
- Add Language and Bid cycle filter
- Fix z-index of spinner so collapsable menus don't look weird (medium & small screens)
- Create extra function to deal with id vs code for rendering selection list (Need to rework response for bidCycles to include code instead of id on backend)

- Design Question: What's the best way to size everything? Should we make it all one static size that will be overly long, but consistent? Or do we leave it as is, even though the dropdowns will be aligned differently based on the selection options string length? 