### PR TITLE
Use date instead of id to sort

### DIFF
--- a/src/Components/SavedSearches/__snapshots__/SavedSearches.test.jsx.snap
+++ b/src/Components/SavedSearches/__snapshots__/SavedSearches.test.jsx.snap
@@ -42,7 +42,7 @@ exports[`SavedSearchesComponent matches snapshot 1`] = `
             },
             Object {
               "text": "Date created: Most recent",
-              "value": "-id",
+              "value": "-date_created",
             },
           ]
         }

--- a/src/Constants/Sort.js
+++ b/src/Constants/Sort.js
@@ -99,7 +99,7 @@ export const SAVED_SEARCH_SORTS = {
   options: [
     { value: '', text: 'Sort option', disabled: true },
     { value: 'name', text: 'Name: A-Z' },
-    { value: '-id', text: 'Date created: Most recent' },
+    { value: '-date_created', text: 'Date created: Most recent' },
   ],
 };
 


### PR DESCRIPTION
Initially used ID because I thought date sorting wasn't working, but that's actually not the case.