### PR TITLE
Fix bureau sort direction on the bureau positions page

### DIFF
--- a/src/Constants/Sort.js
+++ b/src/Constants/Sort.js
@@ -141,7 +141,7 @@ export const BUREAU_POSITION_SORT = {
   options: [
     { value: 'position__title', text: 'Position title: A-Z' },
     { value: '-position__grade', text: 'Grade: Low to high' },
-    { value: '-position__bureau', text: 'Bureau: A-Z' },
+    { value: 'position__bureau', text: 'Bureau: A-Z' },
     { value: '-posted_date', text: 'Posted date: Most recent', availableOnly: true },
     { value: 'posted_date', text: 'Posted date: Oldest', availableOnly: true },
     { value: 'ted', text: 'TED: Soonest' },


### PR DESCRIPTION
Bureau page should now sort correctly when "Bureau A-Z" is selected