### PR TITLE
Display secondary skill when available

### DIFF
--- a/src/Components/BureauPage/PositionManagerBidders/PositionManagerBidders.jsx
+++ b/src/Components/BureauPage/PositionManagerBidders/PositionManagerBidders.jsx
@@ -193,7 +193,6 @@ class PositionManagerBidders extends Component {
       Language: get(m, 'language'),
       TED: formattedTed,
       CDO: get(m, 'cdo.email') ? <MailToButton email={get(m, 'cdo.email')} textAfter={get(m, 'cdo.name')} /> : 'N/A',
-      Deconflict: m.has_competing_rank ? 'Yes' : 'No',
     };
 
     if (props.bidsIsLoading) {
@@ -244,7 +243,7 @@ class PositionManagerBidders extends Component {
       const { bids, bidsIsLoading, filtersSelected, filters } = this.props;
       const { hasLoaded, shortListVisible, unrankedVisible } = this.state;
 
-      const tableHeaders = ['Ranking', 'Name', 'Skill', 'Grade', 'Language', 'TED', 'CDO', 'Deconflict'].map(item => (
+      const tableHeaders = ['Ranking', 'Name', 'Skill', 'Grade', 'Language', 'TED', 'CDO'].map(item => (
         <th scope="col">{item}</th>
       ));
 

--- a/src/Components/BureauPage/PositionManagerBidders/PositionManagerBidders.jsx
+++ b/src/Components/BureauPage/PositionManagerBidders/PositionManagerBidders.jsx
@@ -193,6 +193,7 @@ class PositionManagerBidders extends Component {
       Language: get(m, 'language'),
       TED: formattedTed,
       CDO: get(m, 'cdo.email') ? <MailToButton email={get(m, 'cdo.email')} textAfter={get(m, 'cdo.name')} /> : 'N/A',
+      Deconflict: m.has_competing_rank ? 'Yes' : 'No',
     };
 
     if (props.bidsIsLoading) {
@@ -243,7 +244,7 @@ class PositionManagerBidders extends Component {
       const { bids, bidsIsLoading, filtersSelected, filters } = this.props;
       const { hasLoaded, shortListVisible, unrankedVisible } = this.state;
 
-      const tableHeaders = ['Ranking', 'Name', 'Skill', 'Grade', 'Language', 'TED', 'CDO'].map(item => (
+      const tableHeaders = ['Ranking', 'Name', 'Skill', 'Grade', 'Language', 'TED', 'CDO', 'Deconflict'].map(item => (
         <th scope="col">{item}</th>
       ));
 

--- a/src/Components/CondensedCardData/CondensedCardData.jsx
+++ b/src/Components/CondensedCardData/CondensedCardData.jsx
@@ -1,6 +1,7 @@
 import { get } from 'lodash';
+import PositionSkillCodeList from 'Components/PositionSkillCodeList';
 import { POSITION_DETAILS } from '../../Constants/PropTypes';
-import { NO_DATE, NO_GRADE, NO_SKILL } from '../../Constants/SystemMessages';
+import { NO_DATE, NO_GRADE } from '../../Constants/SystemMessages';
 import LanguageList from '../LanguageList';
 import CondensedCardDataPoint from './CondensedCardDataPoint';
 import { formatDate, propOrDefault } from '../../utilities';
@@ -17,7 +18,7 @@ const CondensedCardData = ({ position }) => {
       />
       <CondensedCardDataPoint
         title="Skill"
-        content={get(position, 'position.skill', NO_SKILL)}
+        content={<PositionSkillCodeList primarySkill={get(position, 'position.skill')} secondarySkill={get(position, 'position.skill_secondary')} />}
         hasFixedTitleWidth
       />
       <CondensedCardDataPoint

--- a/src/Components/CondensedCardData/__snapshots__/CondensedCardData.test.jsx.snap
+++ b/src/Components/CondensedCardData/__snapshots__/CondensedCardData.test.jsx.snap
@@ -10,7 +10,12 @@ exports[`CondensedCardDataComponent matches snapshot 1`] = `
     title="TED"
   />
   <CondensedCardDataPoint
-    content="OFFICE MANAGEMENT (9017)"
+    content={
+      <PositionSkillCodeList
+        primarySkill="OFFICE MANAGEMENT (9017)"
+        secondarySkill=""
+      />
+    }
     hasFixedTitleWidth={true}
     title="Skill"
   />
@@ -42,7 +47,12 @@ exports[`CondensedCardDataComponent matches snapshot with an empty estimated end
     title="TED"
   />
   <CondensedCardDataPoint
-    content="OFFICE MANAGEMENT (9017)"
+    content={
+      <PositionSkillCodeList
+        primarySkill="OFFICE MANAGEMENT (9017)"
+        secondarySkill=""
+      />
+    }
     hasFixedTitleWidth={true}
     title="Skill"
   />
@@ -74,7 +84,12 @@ exports[`CondensedCardDataComponent matches snapshot with an empty skill 1`] = `
     title="TED"
   />
   <CondensedCardDataPoint
-    content="OFFICE MANAGEMENT (9017)"
+    content={
+      <PositionSkillCodeList
+        primarySkill="OFFICE MANAGEMENT (9017)"
+        secondarySkill=""
+      />
+    }
     hasFixedTitleWidth={true}
     title="Skill"
   />

--- a/src/Components/PositionDetailsItem/PositionDetailsItem.jsx
+++ b/src/Components/PositionDetailsItem/PositionDetailsItem.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import Differentials from 'Components/Differentials';
 import BidCount from 'Components/BidCount';
+import PositionSkillCodeList from 'Components/PositionSkillCodeList';
 import { COMMON_PROPERTIES } from '../../Constants/EndpointParams';
 import LanguageList from '../../Components/LanguageList/LanguageList';
 import CondensedCardDataPoint from '../CondensedCardData/CondensedCardDataPoint';
@@ -27,7 +28,6 @@ import {
 import {
   NO_BUREAU,
   NO_GRADE,
-  NO_SKILL,
   NO_END_DATE,
   NO_TOUR_OF_DUTY,
   NO_USER_LISTED,
@@ -120,7 +120,7 @@ const PositionDetailsItem = (props) => {
           <div className="usa-grid-full data-point-section">
             {hideContact && <BidCount bidStatistics={stats} altStyle isCondensed />}
             <CondensedCardDataPoint ariaLabel={getAccessiblePositionNumber(get(position, 'position_number'))} title="Position number" content={get(position, 'position_number')} />
-            <CondensedCardDataPoint title="Skill" content={get(position, 'skill', NO_SKILL)} />
+            <CondensedCardDataPoint title="Skill" content={<PositionSkillCodeList primarySkill={get(position, 'skill')} secondarySkill={get(position, 'skill_secondary')} />} />
             <CondensedCardDataPoint title="Grade" content={get(position, 'grade', NO_GRADE)} />
             <CondensedCardDataPoint title="Bureau" content={formattedBureau} />
             <CondensedCardDataPoint title="Tour of duty" content={formattedTOD} />

--- a/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
+++ b/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
@@ -110,7 +110,12 @@ exports[`PositionDetailsItem matches snapshot 1`] = `
           title="Position number"
         />
         <CondensedCardDataPoint
-          content="OFFICE MANAGEMENT (9017)"
+          content={
+            <PositionSkillCodeList
+              primarySkill="OFFICE MANAGEMENT (9017)"
+              secondarySkill=""
+            />
+          }
           hasFixedTitleWidth={false}
           title="Skill"
         />
@@ -475,7 +480,12 @@ exports[`PositionDetailsItem matches snapshot when there is an obc id 1`] = `
           title="Position number"
         />
         <CondensedCardDataPoint
-          content="OFFICE MANAGEMENT (9017)"
+          content={
+            <PositionSkillCodeList
+              primarySkill="OFFICE MANAGEMENT (9017)"
+              secondarySkill=""
+            />
+          }
           hasFixedTitleWidth={false}
           title="Skill"
         />
@@ -842,7 +852,12 @@ exports[`PositionDetailsItem matches snapshot when various data is missing from 
           title="Position number"
         />
         <CondensedCardDataPoint
-          content="OFFICE MANAGEMENT (9017)"
+          content={
+            <PositionSkillCodeList
+              primarySkill="OFFICE MANAGEMENT (9017)"
+              secondarySkill=""
+            />
+          }
           hasFixedTitleWidth={false}
           title="Skill"
         />

--- a/src/Components/PositionSkillCodeList/PositionSkillCodeList.jsx
+++ b/src/Components/PositionSkillCodeList/PositionSkillCodeList.jsx
@@ -1,0 +1,26 @@
+import PropTypes from 'prop-types';
+import { NO_SKILL } from '../../Constants/SystemMessages';
+
+const PositionSkillCodeList = ({ primarySkill, secondarySkill }) => {
+  let skillCodeList = [];
+  if (primarySkill) { skillCodeList.push(primarySkill); }
+  if (secondarySkill) { skillCodeList.push(secondarySkill); }
+  skillCodeList = skillCodeList.join(', ') || NO_SKILL;
+  return (
+    <span>
+      {skillCodeList}
+    </span>
+  );
+};
+
+PositionSkillCodeList.propTypes = {
+  primarySkill: PropTypes.string,
+  secondarySkill: PropTypes.string,
+};
+
+PositionSkillCodeList.defaultProps = {
+  primarySkill: '',
+  secondarySkill: '',
+};
+
+export default PositionSkillCodeList;

--- a/src/Components/PositionSkillCodeList/PositionSkillCodeList.test.jsx
+++ b/src/Components/PositionSkillCodeList/PositionSkillCodeList.test.jsx
@@ -1,0 +1,52 @@
+import { shallow } from 'enzyme';
+import toJSON from 'enzyme-to-json';
+import PositionSkillCodeList from './PositionSkillCodeList';
+import { NO_SKILL } from '../../Constants/SystemMessages';
+
+describe('PositionSkillCodeList', () => {
+  const props = {
+    primarySkill: 'SKILL (1000)',
+    secondarySkill: 'OTHER SKILL (9001)',
+  };
+
+  it('is defined', () => {
+    const wrapper = shallow(<PositionSkillCodeList {...props} />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('is defined when props are falsey', () => {
+    const wrapper = shallow(<PositionSkillCodeList {...props} primarySkill={''} secondarySkill={''} />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('matches snapshot with only a primarySkill', () => {
+    const wrapper = shallow(<PositionSkillCodeList {...props} secondarySkill={''} />);
+    expect(wrapper.text()).toBe(props.primarySkill);
+  });
+
+  it('renders content correctly when both skills are present', () => {
+    const wrapper = shallow(<PositionSkillCodeList {...props} />);
+    expect(wrapper.text())
+      .toBe(`${props.primarySkill}, ${props.secondarySkill}`);
+  });
+
+  it('renders content correctly when props are falsey', () => {
+    const wrapper = shallow(<PositionSkillCodeList {...props} primarySkill={''} secondarySkill={''} />);
+    expect(wrapper.text()).toBe(NO_SKILL);
+  });
+
+  it('matches snapshot with only a primarySkill', () => {
+    const wrapper = shallow(<PositionSkillCodeList {...props} secondarySkill={''} />);
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
+  it('matches snapshot when both skills are present', () => {
+    const wrapper = shallow(<PositionSkillCodeList {...props} />);
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
+  it('matches snapshot when both skills are falsey', () => {
+    const wrapper = shallow(<PositionSkillCodeList {...props} primarySkill={''} secondarySkill={''} />);
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/PositionSkillCodeList/__snapshots__/PositionSkillCodeList.test.jsx.snap
+++ b/src/Components/PositionSkillCodeList/__snapshots__/PositionSkillCodeList.test.jsx.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PositionSkillCodeList matches snapshot when both skills are falsey 1`] = `
+<span>
+  None listed
+</span>
+`;
+
+exports[`PositionSkillCodeList matches snapshot when both skills are present 1`] = `
+<span>
+  SKILL (1000), OTHER SKILL (9001)
+</span>
+`;
+
+exports[`PositionSkillCodeList matches snapshot with only a primarySkill 1`] = `
+<span>
+  SKILL (1000)
+</span>
+`;

--- a/src/Components/PositionSkillCodeList/index.js
+++ b/src/Components/PositionSkillCodeList/index.js
@@ -1,0 +1,1 @@
+export { default } from './PositionSkillCodeList';

--- a/src/Components/ResultsCard/ResultsCard.jsx
+++ b/src/Components/ResultsCard/ResultsCard.jsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { get, isNull, isNumber } from 'lodash';
 import { Flag } from 'flag';
 import Differentials from 'Components/Differentials';
+import PositionSkillCodeList from 'Components/PositionSkillCodeList';
 import { COMMON_PROPERTIES } from '../../Constants/EndpointParams';
 import { Row, Column } from '../Layout';
 import DefinitionList from '../DefinitionList';
@@ -26,7 +27,7 @@ import { formatDate, propOrDefault, getPostName, shortenString,
 import { POSITION_DETAILS, FAVORITE_POSITIONS_ARRAY } from '../../Constants/PropTypes';
 import {
   NO_BUREAU, NO_BID_CYCLE, NO_GRADE, NO_POSITION_NUMBER,
-  NO_POST, NO_SKILL, NO_TOUR_OF_DUTY, NO_UPDATE_DATE, NO_DATE, NO_USER_LISTED,
+  NO_POST, NO_TOUR_OF_DUTY, NO_UPDATE_DATE, NO_DATE, NO_USER_LISTED,
 } from '../../Constants/SystemMessages';
 
 export const getPostNameText = pos => `${getPostName(pos.post, NO_POST)}${pos.organization ? `: ${pos.organization}` : ''}`;
@@ -144,7 +145,7 @@ class ResultsCard extends Component {
       {
         'TED': getResult(result, 'ted', NO_DATE),
         [bidTypeTitle]: getResult(result, 'bidcycle.name', NO_BID_CYCLE),
-        'Skill': getResult(pos, 'skill', NO_SKILL),
+        'Skill': <PositionSkillCodeList primarySkill={get(pos, 'skill')} secondarySkill={get(pos, 'skill_secondary')} />,
         'Grade': getResult(pos, 'grade', NO_GRADE),
         'Bureau': getResult(pos, 'bureau', NO_BUREAU),
       },


### PR DESCRIPTION
Use with https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/456

Displays the secondary skill code in
- Results cards
- Condensed results cards (i.e. homepage, favorites, similar)
- Position Details
- Bureau Position Details