### PR TITLE
Decrease max-height for bid season dropdown

### DIFF
--- a/src/Components/BidderPortfolio/BidControls/BidCyclePicker/BidCyclePicker.jsx
+++ b/src/Components/BidderPortfolio/BidControls/BidCyclePicker/BidCyclePicker.jsx
@@ -114,7 +114,7 @@ class BidCyclePicker extends Component {
           onChange={this.selectMultipleOption}
           numberDisplayed={1}
           multiple
-          dropdownHeight={600}
+          dropdownHeight={225}
           renderList={renderList}
           disabled={isLoading}
           includeSelectAll

--- a/src/Components/BidderPortfolio/BidControls/BidCyclePicker/__snapshots__/BidCyclePicker.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidControls/BidCyclePicker/__snapshots__/BidCyclePicker.test.jsx.snap
@@ -11,7 +11,7 @@ exports[`BidControlsComponent matches snapshot 1`] = `
   </div>
   <r
     disabled={false}
-    dropdownHeight={600}
+    dropdownHeight={225}
     filterDebounce={150}
     id="picky"
     includeSelectAll={true}


### PR DESCRIPTION
Dropdown height of 600px caused overflowing past the bottom of the screen at some resolutions. Decreased to 225px.