### PR TITLE
Allow specified number of lines to retrieve for log files

### DIFF
--- a/src/Components/AdministratorPage/Logs/Logs.jsx
+++ b/src/Components/AdministratorPage/Logs/Logs.jsx
@@ -2,6 +2,7 @@ import { Component } from 'react';
 import PropTypes from 'prop-types';
 import shortid from 'shortid';
 import { isEqual } from 'lodash';
+import TextInput from 'Components/TextInput';
 import ProfileSectionTitle from '../../ProfileSectionTitle';
 import Spinner from '../../Spinner';
 import LogRow from './LogRow';
@@ -19,6 +20,8 @@ class LogsPage extends Component {
       selected: '',
       page: 1,
       range: 3,
+      logSize: 1000,
+      logOffset: 0,
     };
   }
 
@@ -36,8 +39,9 @@ class LogsPage extends Component {
   };
 
   selectLog = selected => {
+    const { logSize, logOffset } = this.state;
     this.setState({ selected }, () => {
-      this.props.getLog(selected);
+      this.props.getLog(selected, logSize, logOffset);
     });
   };
 
@@ -51,7 +55,7 @@ class LogsPage extends Component {
       logHasErrored,
       onDownloadOne,
     } = this.props;
-    const { page, range, selected } = this.state;
+    const { page, range, selected, logSize } = this.state;
 
     const logsLen = logsList.length;
 
@@ -72,6 +76,7 @@ class LogsPage extends Component {
         {
           !logsListIsLoading && !logsListHasErrored &&
           <div>
+            <TextInput inputProps={{ type: 'number' }} id="logSize" label="Log size (lines)" value={logSize} changeText={e => this.setState({ logSize: e })} />
             <div className="usa-grid-full total-results">
               <TotalResults total={logsLen} pageNumber={page} pageSize={range} />
             </div>
@@ -83,7 +88,7 @@ class LogsPage extends Component {
                     key={m}
                     name={m}
                     onClick={this.selectLog}
-                    onDownloadClick={onDownloadOne}
+                    onDownloadClick={e => onDownloadOne(e, logSize)}
                     isSelected={isSelected}
                   />
                 );
@@ -119,7 +124,7 @@ class LogsPage extends Component {
               </div>
               {
                 logSuccess &&
-                <button onClick={() => onDownloadOne(this.state.selected)} className="usa-button">Download</button>
+                <button onClick={() => onDownloadOne(this.state.selected, logSize)} className="usa-button">Download</button>
               }
             </div>
           </div>

--- a/src/Components/TextInput/TextInput.jsx
+++ b/src/Components/TextInput/TextInput.jsx
@@ -83,7 +83,7 @@ TextInput.propTypes = {
   type: PropTypes.oneOf(['success', 'error', 'focus']),
   label: PropTypes.string,
   labelMessage: PropTypes.string,
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   placeholder: PropTypes.string,
   inputProps: PropTypes.shape({}),
 };

--- a/src/Containers/Administrator/Administrator.jsx
+++ b/src/Containers/Administrator/Administrator.jsx
@@ -58,14 +58,14 @@ class AdministratorContainer extends Component {
     }
   };
 
-  onDownloadOne = id => {
+  onDownloadOne = (id, size) => {
     if (!this.props.logToDownloadIsLoading) {
-      this.props.getLogToDownload(id);
+      this.props.getLogToDownload(id, size);
     }
   };
 
-  getLogById = id => {
-    this.props.getLog(id);
+  getLogById = (id, size) => {
+    this.props.getLog(id, size);
   };
 
   runAllJobs = () => {
@@ -202,8 +202,8 @@ const mapStateToProps = state => ({
 export const mapDispatchToProps = dispatch => ({
   getLogs: () => dispatch(getLogs()),
   getLogsList: () => dispatch(getLogsList()),
-  getLog: id => dispatch(getLog(id)),
-  getLogToDownload: id => dispatch(getLogToDownload(id)),
+  getLog: (id, size) => dispatch(getLog(id, size)),
+  getLogToDownload: (id, size) => dispatch(getLogToDownload(id, size)),
   getSyncJobs: () => dispatch(syncsFetchData()),
   putAllSyncJobs: () => dispatch(putAllSyncs()),
   patchSyncJob: data => dispatch(patchSync(data)),

--- a/src/actions/logs.js
+++ b/src/actions/logs.js
@@ -1,6 +1,7 @@
 import Q from 'q';
-import { get, takeRight } from 'lodash';
+import { get } from 'lodash';
 import { CancelToken } from 'axios';
+import q from 'query-string';
 import api from '../api';
 
 let cancel;
@@ -152,13 +153,17 @@ export function getLogsList() {
   };
 }
 
-export function getLog(id) {
+export function getLog(id, size) {
   if (cancel) { cancel('cancel'); }
   return (dispatch) => {
     dispatch(logIsLoading(true));
     dispatch(logHasErrored(false));
+
+    let q$ = { size };
+    q$ = q.stringify(q$);
+
     // get log by id
-    api().get(`/logs/${id}/`, {
+    api().get(`/logs/${id}/?${q$}`, {
       cancelToken: new CancelToken((c) => {
         cancel = c;
       }),
@@ -166,7 +171,6 @@ export function getLog(id) {
       .then((logList) => {
         let data = get(logList, 'data.data', []);
         data = data.split('\n');
-        data = takeRight(data, 500);
         if (data.length === 1 && !data[0]) {
           data = [];
         }
@@ -184,15 +188,18 @@ export function getLog(id) {
   };
 }
 
-export function getLogToDownload(id) {
+export function getLogToDownload(id, size = 1000) {
   return (dispatch) => {
     dispatch(logToDownloadIsLoading(true));
     dispatch(logToDownloadHasErrored(false));
 
+    let q$ = { size };
+    q$ = q.stringify(q$);
+
     let text = '';
 
     // get log by id
-    api().get(`/logs/${id}/`)
+    api().get(`/logs/${id}/?${q$}`)
       .then((response) => {
         const logText = get(response, 'data.data', '');
         const logName = id;

--- a/src/actions/logs.test.js
+++ b/src/actions/logs.test.js
@@ -15,7 +15,7 @@ describe('async actions', () => {
     mockAdapter.onGet('/logs/permissions/').reply(200,
       { data: 'log text' },
     );
-    mockAdapter.onGet('/logs/test.log/').reply(200,
+    mockAdapter.onGet('/logs/test.log/?').reply(200,
       { data: 'more log text' },
     );
   });
@@ -93,7 +93,7 @@ describe('async actions', () => {
   });
 
   it('can handle errors when fetching a log by id', (done) => {
-    mockAdapter.onGet('/logs/test.log/').reply(404,
+    mockAdapter.onGet('/logs/test.log/?').reply(404,
       null,
     );
 
@@ -121,7 +121,7 @@ describe('async actions', () => {
   });
 
   it('can handle errors when fetching a log by id, formatted to download', (done) => {
-    mockAdapter.onGet('/logs/test.log/').reply(404,
+    mockAdapter.onGet('/logs/test.log/?').reply(404,
       null,
     );
 

--- a/src/sass/_administrator.scss
+++ b/src/sass/_administrator.scss
@@ -106,6 +106,7 @@
 
   .log-line-item {
     margin: .3em 0;
+    max-width: 1200px;
   }
 
   .content-link-container {


### PR DESCRIPTION
Use with https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/460

- Adds user input for last x number of lines to retrieve for a given log file
- Sets a max-width for `.log-line-item`s so that they don't overflow horizontally on the screen