### PR TITLE
Add fixes for available bidders

### DIFF
--- a/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
@@ -74,8 +74,17 @@ const AvailableBidderRow = (props) => {
     });
   };
 
+  const getTRClass = () => {
+    if (CDOView) {
+      return '';
+    } else if (shared) {
+      return 'ab-active';
+    }
+    return 'ab-inactive';
+  };
+
   return (
-    <tr className={!CDOView && !shared ? 'ab-inactive' : ''}>
+    <tr className={getTRClass()}>
       {
         keys(sections).map(i => (
           <td>{sections[i]}</td>

--- a/src/Components/AvailableBidder/EditBidder/EditBidder.jsx
+++ b/src/Components/AvailableBidder/EditBidder/EditBidder.jsx
@@ -53,13 +53,28 @@ const EditBidder = (props) => {
   return (
     <div>
       <form className="available-bidder-form">
+        <hr />
+        <div>
+          <span>* Internal CDO field only, not shared with Bureaus</span>
+        </div>
+        <hr />
         <div>
           <label htmlFor="name">Client Name:</label>
           <input type="text" name="name" disabled value={name} />
         </div>
         <div>
-          <label htmlFor="status">Status:</label>
-          <select id="status" defaultValue={status} onChange={(e) => setStatus(e.target.value)}>
+          <label htmlFor="status">*Status:</label>
+          <select
+            id="status"
+            defaultValue={status}
+            onChange={(e) => {
+              setStatus(e.target.value);
+              if (e.target.value !== 'OC') {
+                setOCReason('');
+                setOCBureau('');
+              }
+            }}
+          >
             <option value="">None listed</option>
             <option value="OC">OC: Overcompliment</option>
             <option value="UA">UA: Unassigned</option>
@@ -84,8 +99,8 @@ const EditBidder = (props) => {
           <input type="text" name="currentPost" disabled value={sections.Current_Post} />
         </div>
         <div>
-          <label htmlFor="ocBureau">OC Bureau:</label>
-          <select id="ocBureau" defaultValue={ocBureau} onChange={(e) => setOCBureau(e.target.value)} >
+          <label htmlFor="ocBureau">*OC Bureau:</label>
+          <select id="ocBureau" defaultValue={ocBureau} onChange={(e) => setOCBureau(e.target.value)} disabled={status !== 'OC'} >
             <option value="">None listed</option>
             {bureauOptions.map(o => (
               <option value={o.short_description}>{o.custom_description}</option>
@@ -93,8 +108,8 @@ const EditBidder = (props) => {
           </select>
         </div>
         <div>
-          <label htmlFor="ocReason">OC Reason:</label>
-          <select id="ocReason" defaultValue={ocReason} onChange={(e) => setOCReason(e.target.value)} >
+          <label htmlFor="ocReason">*OC Reason:</label>
+          <select id="ocReason" defaultValue={ocReason} onChange={(e) => setOCReason(e.target.value)} disabled={status !== 'OC'} >
             <option value="">None listed</option>
             {reasons.map(r => (
               <option value={r}>{r}</option>
@@ -106,7 +121,7 @@ const EditBidder = (props) => {
           <input type="text" name="cdo" disabled value={sections.CDO} />
         </div>
         <div>
-          <label htmlFor="comment">Comment:</label>
+          <label htmlFor="comment">*Comment:</label>
           <input type="text" name="comment" defaultValue={comment} onChange={(e) => setComment(e.target.value)} />
         </div>
         <button onClick={submit} type="submit">Submit</button>

--- a/src/sass/_availableBidders.scss
+++ b/src/sass/_availableBidders.scss
@@ -124,6 +124,18 @@
   }
 }
 
+.ab-active {
+  td:nth-of-type(2), td:nth-of-type(7), td:nth-of-type(8), td:nth-of-type(10) {
+    color: #272e3247;
+    background-color: #aeb0b59e;
+    transition: 1.5s;
+    a {
+      color: #272e3247;
+    }
+  }
+}
+
+
 .ab-action-buttons {
   display: flex;
   flex-direction: row;
@@ -144,6 +156,9 @@
 }
 
 .bureau-view-toggle {
+  display: flex;
+  justify-content: center;
+
   .active {
     text-shadow: 0 0 10px $color-dodger-blue;
   }
@@ -170,4 +185,8 @@
   input select textarea {
     width: 75%;
   }
+}
+
+#ocReason:disabled, #ocBureau:disabled {
+  background: darkgrey;
 }


### PR DESCRIPTION
- Gray out columns in bureau view
- Fix alignment of toggle button header
- Add asterisks and notes in edit modal
- Create selection constraint dependent on OC status for OC reason and bureau

Known Issues: Selecting a non-OC status disables the OC reason and bureau, but does not reset the UI selection. The value is updated, so the request will never save a NON- OC status with OC reasons and bureaus 