### PR TITLE
Ribbon container clickable area

### DIFF
--- a/src/sass/_condensedCard.scss
+++ b/src/sass/_condensedCard.scss
@@ -128,6 +128,7 @@ $condensed-card-data-padding: 15px 20px 9px;
       position: absolute;
       right: -2px;
       top: -1px;
+      pointer-events: none;
       z-index: $ribbon-condensed-card-z;
 
       .ribbon-cn {


### PR DESCRIPTION
![Screen Shot 2021-04-20 at 10 33 08 AM](https://user-images.githubusercontent.com/11576347/115418028-21a5a600-a1c7-11eb-8289-e24ff41071dc.png)

Previously, any ribbon container items that were outside of the blue, clickable area of the card header were also clickable to navigate to the position details link. This fix ensures that any items that fall vertically below the clickable area are not also clickable.