### PR TITLE
Remove the build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,19 +220,17 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build
-      - docker-build:
-          requires:
-            - build
-          filters:
-            branches:
-              only:
-                - dev
-                - staging
-                - master
-      - yarn:
-          requires:
-            - build
+      # - build
+      # - docker-build:
+      #     requires:
+      #       - build
+      #     filters:
+      #       branches:
+      #         only:
+      #           - dev
+      #           - staging
+      #           - master
+      - yarn
       - site:
           requires:
             - yarn
@@ -248,14 +246,14 @@ workflows:
           filters:
             branches:
               only: dev
-      - zap:
-          requires:
-            - docker-build
-          filters:
-            tags:
-              only: /^zap.*/
-            branches:
-              ignore: /.*/
+      # - zap:s
+      #     requires:
+      #       - docker-build
+      #     filters:
+      #       tags:
+      #         only: /^zap.*/
+      #       branches:
+      #         ignore: /.*/
       #- push-stable:
       #    requires:
       #      - yarn


### PR DESCRIPTION
The `build` job doesn't really provide us with anything that we wouldn't already get in the other jobs