### PR TITLE
showing panel notification on overlay collapse

### DIFF
--- a/src/Components/BidTracker/BidStep/BidSteps.jsx
+++ b/src/Components/BidTracker/BidStep/BidSteps.jsx
@@ -64,10 +64,7 @@ const BidSteps = (props, context) => {
       {
         BID_STEPS.map((status) => {
           const icon = getIcon(status);
-          console.log('bid steps:', collapseOverlay);
-          console.log('bidata value:', bidData[status.prop].hasBidPreparingTooltip);
-          // const showBidPrepToolTip =
-          //   false ? (bidData[status.prop].hasBidPreparingTooltip && collapseOverlay) : false;
+          const showBidPrepToolTip = bidData[status.prop].hasBidPreparingTooltip && collapseOverlay;
           return (<Step
             key={shortId.generate()}
             className={`
@@ -83,8 +80,7 @@ const BidSteps = (props, context) => {
               </div>
             }
             tailContent={
-              bidData[status.prop].hasBidPreparingTooltip ? <BidPreparingIcon /> : null
-              // showBidPrepToolTip ? <BidPreparingIcon /> : null
+              showBidPrepToolTip ? <BidPreparingIcon /> : null
             }
             icon={icon}
           />

--- a/src/Components/BidTracker/BidStep/BidSteps.jsx
+++ b/src/Components/BidTracker/BidStep/BidSteps.jsx
@@ -24,7 +24,7 @@ const getUseConfetti = () => checkFlag('flags.confetti');
 // by bidClassesFromCurrentStatus.
 // These classes determine colors, whether to use an icon or a number, the title text, etc.
 const BidSteps = (props, context) => {
-  const { bid } = props;
+  const { bid, collapseOverlay } = props;
   const { condensedView } = context;
   const bidData = bidClassesFromCurrentStatus(bid).stages || {};
   const handshakeRegisteredAnotherClient =
@@ -64,6 +64,10 @@ const BidSteps = (props, context) => {
       {
         BID_STEPS.map((status) => {
           const icon = getIcon(status);
+          console.log('bid steps:', collapseOverlay);
+          console.log('bidata value:', bidData[status.prop].hasBidPreparingTooltip);
+          // const showBidPrepToolTip =
+          //   false ? (bidData[status.prop].hasBidPreparingTooltip && collapseOverlay) : false;
           return (<Step
             key={shortId.generate()}
             className={`
@@ -80,6 +84,7 @@ const BidSteps = (props, context) => {
             }
             tailContent={
               bidData[status.prop].hasBidPreparingTooltip ? <BidPreparingIcon /> : null
+              // showBidPrepToolTip ? <BidPreparingIcon /> : null
             }
             icon={icon}
           />
@@ -96,6 +101,7 @@ BidSteps.contextTypes = {
 
 BidSteps.propTypes = {
   bid: BID_OBJECT.isRequired,
+  collapseOverlay: PropTypes.bool.isRequired,
 };
 
 export default BidSteps;

--- a/src/Components/BidTracker/BidTrackerCard/BidTrackerCard.jsx
+++ b/src/Components/BidTracker/BidTrackerCard/BidTrackerCard.jsx
@@ -19,9 +19,23 @@ import { CriticalNeed, Handshake, HardToFill, ServiceNeedDifferential } from '..
 import MediaQuery from '../../MediaQuery';
 
 class BidTrackerCard extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      flipArrow: true,
+    };
+  }
+
   getChildContext() {
     const { bid, condensedView, priorityExists, readOnly } = this.props;
     return { condensedView, priorityExists, isPriority: bid.is_priority, readOnly };
+  }
+
+  childToParent = () => {
+    const { flipArrow } = this.state;
+    this.setState({ flipArrow: !flipArrow });
+    console.log('bid tracker comp');
+    console.log(flipArrow);
   }
   render() {
     const { bid, acceptBid, condensedView, declineBid, priorityExists, submitBid, deleteBid,
@@ -55,6 +69,9 @@ class BidTrackerCard extends Component {
     }
 
     const bidStepsClasses$ = bidStepsClass.join(' ');
+
+    const { flipArrow } = this.state;
+    // console.log(isCollapsible);
 
     return (
       <BoxShadow className={containerClass} id={`bid-${bid.id}`}>
@@ -104,7 +121,10 @@ class BidTrackerCard extends Component {
             useCDOView={useCDOView}
           />
           <div className={bidStepsClasses$}>
-            <BidSteps bid={bid} />
+            <BidSteps
+              bid={bid}
+              collapseOverlay={flipArrow}
+            />
             {
               showAlert &&
                 <OverlayAlert
@@ -119,6 +139,7 @@ class BidTrackerCard extends Component {
                   unregisterHandshake={unregisterHandshake}
                   useCDOView={useCDOView}
                   isCollapsible={isCollapsible}
+                  childToParent={this.childToParent}
                   condensedView={condensedView}
                 />
             }

--- a/src/Components/BidTracker/BidTrackerCard/BidTrackerCard.jsx
+++ b/src/Components/BidTracker/BidTrackerCard/BidTrackerCard.jsx
@@ -22,7 +22,7 @@ class BidTrackerCard extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      flipArrow: true,
+      showPanelAlert: false,
     };
   }
 
@@ -31,11 +31,8 @@ class BidTrackerCard extends Component {
     return { condensedView, priorityExists, isPriority: bid.is_priority, readOnly };
   }
 
-  childToParent = () => {
-    const { flipArrow } = this.state;
-    this.setState({ flipArrow: !flipArrow });
-    console.log('bid tracker comp');
-    console.log(flipArrow);
+  tooglePanelAlert = collapseOverlay => {
+    this.setState({ showPanelAlert: collapseOverlay });
   }
   render() {
     const { bid, acceptBid, condensedView, declineBid, priorityExists, submitBid, deleteBid,
@@ -59,6 +56,7 @@ class BidTrackerCard extends Component {
     ].join(' ');
     const showBidCount$ = showBidCount && !priorityExists;
     // const questionText = get(BID_EXPLANATION_TEXT, `[${bid.status}]`);
+    const { showPanelAlert } = this.state;
     const bidTakenFlag = (get(bid, 'position_info.bid_statistics[0].has_handshake_offered'))
       && (bid.status !== HAND_SHAKE_ACCEPTED_PROP && bid.status !== DRAFT_PROP);
     const bidTaken = bidTakenFlag ? ' bid-tracker-hs-another-client' : '';
@@ -69,9 +67,6 @@ class BidTrackerCard extends Component {
     }
 
     const bidStepsClasses$ = bidStepsClass.join(' ');
-
-    const { flipArrow } = this.state;
-    // console.log(isCollapsible);
 
     return (
       <BoxShadow className={containerClass} id={`bid-${bid.id}`}>
@@ -124,7 +119,7 @@ class BidTrackerCard extends Component {
           <div className={bidStepsClasses$}>
             <BidSteps
               bid={bid}
-              collapseOverlay={flipArrow}
+              collapseOverlay={showPanelAlert}
             />
             {
               showAlert &&
@@ -140,7 +135,7 @@ class BidTrackerCard extends Component {
                   unregisterHandshake={unregisterHandshake}
                   useCDOView={useCDOView}
                   isCollapsible={isCollapsible}
-                  childToParent={this.childToParent}
+                  tooglePanelAlert={this.tooglePanelAlert}
                   condensedView={condensedView}
                 />
             }

--- a/src/Components/BidTracker/BidTrackerCard/__snapshots__/BidTrackerCard.test.jsx.snap
+++ b/src/Components/BidTracker/BidTrackerCard/__snapshots__/BidTrackerCard.test.jsx.snap
@@ -161,6 +161,7 @@ exports[`BidTrackerCardComponent matches snapshot 1`] = `
             "user": "rehmant",
           }
         }
+        collapseOverlay={false}
       />
       <OverlayAlert
         acceptBid={[Function]}
@@ -234,6 +235,7 @@ exports[`BidTrackerCardComponent matches snapshot 1`] = `
         isCollapsible={true}
         registerHandshake={[Function]}
         submitBid={[Function]}
+        tooglePanelAlert={[Function]}
         unregisterHandshake={[Function]}
         useCDOView={false}
         userId=""

--- a/src/Components/BidTracker/OverlayAlert/OverlayAlert.jsx
+++ b/src/Components/BidTracker/OverlayAlert/OverlayAlert.jsx
@@ -22,7 +22,7 @@ import { getBidIdUrl } from './helpers';
 
 // Alert rendering based on status is handled here.
 const OverlayAlert = ({ bid, submitBid, userId, registerHandshake,
-  unregisterHandshake, useCDOView, isCollapsible, userName },
+  unregisterHandshake, useCDOView, isCollapsible, userName, childToParent },
 { condensedView, readOnly }) => {
   const CLASS_PENDING = 'bid-tracker-overlay-alert--pending';
   const CLASS_CLOSED = 'bid-tracker-overlay-alert--closed';
@@ -49,10 +49,18 @@ const OverlayAlert = ({ bid, submitBid, userId, registerHandshake,
   };
 
   const [collapseOverlay, setCollapseOverlay] = useState(false);
+  // const collapseOverlay = false;
 
+  // eslint-disable-next-line no-unused-vars
   function toggleOverlay() {
     setCollapseOverlay(!collapseOverlay);
   }
+
+  // function childToParent() {
+  //   setCollapseOverlay(!collapseOverlay);
+  // }
+
+  // console.log('childToParent', childToParent);
 
   switch (bid.status) {
     case HAND_SHAKE_NEEDS_REGISTER_PROP:
@@ -151,7 +159,7 @@ const OverlayAlert = ({ bid, submitBid, userId, registerHandshake,
     overlayContent ?
       <div className={`bid-tracker-overlay-alert ${overlayClass}${collapseOverlay ? ' collapse-overlay' : ''}`}>
         {isCollapsible$ &&
-          <InteractiveElement onClick={toggleOverlay}>
+          <InteractiveElement onClick={childToParent}>
             <Tooltip
               title={collapseOverlay ? 'Expand overlay' : 'Collapse overlay'}
               arrow
@@ -181,6 +189,7 @@ OverlayAlert.propTypes = {
   useCDOView: PropTypes.bool,
   userName: PropTypes.string,
   isCollapsible: PropTypes.bool,
+  childToParent: PropTypes.func.isRequired,
 };
 
 OverlayAlert.defaultProps = {

--- a/src/Components/BidTracker/OverlayAlert/OverlayAlert.jsx
+++ b/src/Components/BidTracker/OverlayAlert/OverlayAlert.jsx
@@ -22,7 +22,7 @@ import { getBidIdUrl } from './helpers';
 
 // Alert rendering based on status is handled here.
 const OverlayAlert = ({ bid, submitBid, userId, registerHandshake,
-  unregisterHandshake, useCDOView, isCollapsible, userName, childToParent },
+  unregisterHandshake, useCDOView, isCollapsible, userName, tooglePanelAlert },
 { condensedView, readOnly }) => {
   const CLASS_PENDING = 'bid-tracker-overlay-alert--pending';
   const CLASS_CLOSED = 'bid-tracker-overlay-alert--closed';
@@ -49,18 +49,11 @@ const OverlayAlert = ({ bid, submitBid, userId, registerHandshake,
   };
 
   const [collapseOverlay, setCollapseOverlay] = useState(false);
-  // const collapseOverlay = false;
 
-  // eslint-disable-next-line no-unused-vars
   function toggleOverlay() {
+    tooglePanelAlert(!collapseOverlay);
     setCollapseOverlay(!collapseOverlay);
   }
-
-  // function childToParent() {
-  //   setCollapseOverlay(!collapseOverlay);
-  // }
-
-  // console.log('childToParent', childToParent);
 
   switch (bid.status) {
     case HAND_SHAKE_NEEDS_REGISTER_PROP:
@@ -159,7 +152,7 @@ const OverlayAlert = ({ bid, submitBid, userId, registerHandshake,
     overlayContent ?
       <div className={`bid-tracker-overlay-alert ${overlayClass}${collapseOverlay ? ' collapse-overlay' : ''}`}>
         {isCollapsible$ &&
-          <InteractiveElement onClick={childToParent}>
+          <InteractiveElement onClick={toggleOverlay}>
             <Tooltip
               title={collapseOverlay ? 'Expand overlay' : 'Collapse overlay'}
               arrow
@@ -189,7 +182,7 @@ OverlayAlert.propTypes = {
   useCDOView: PropTypes.bool,
   userName: PropTypes.string,
   isCollapsible: PropTypes.bool,
-  childToParent: PropTypes.func.isRequired,
+  tooglePanelAlert: PropTypes.func.isRequired,
 };
 
 OverlayAlert.defaultProps = {


### PR DESCRIPTION
Panel alert should be hidden when the `undo register handshake` overlay is expanded/initial render and hidden when collapsed.

The alert does not show for the `register handshake` overlay.