### PR TITLE
Fix revoke after expiration TM-2281

### DIFF
--- a/src/Components/Handshake/EditHandshake/EditHandshake.jsx
+++ b/src/Components/Handshake/EditHandshake/EditHandshake.jsx
@@ -5,11 +5,12 @@ import { EMPTY_FUNCTION } from 'Constants/PropTypes';
 import swal from '@sweetalert/with-react';
 import Calendar from 'react-calendar';
 import TimePicker from 'react-time-picker';
-import { add, differenceInCalendarDays, format, getDate, getHours, getMinutes, getMonth, getYear, isFuture } from 'date-fns-v2';
+import { add, differenceInCalendarDays, format, getDate, getHours, getMinutes, getMonth, getYear, isFuture, isPast } from 'date-fns-v2';
 import { useCloseSwalOnUnmount } from 'utilities';
 
 const EditHandshake = props => {
-  const { submitAction, expiration, infoOnly, uneditable, submitText, offer, bidCycle } = props;
+  const { submitAction, expiration, infoOnly, currentlyOffered,
+    submitText, offer, bidCycle } = props;
   const expirationFormatted = expiration ? new Date(expiration) : add(new Date(), { days: 1 });
   const [expirationDate, setExpirationDate] = useState(expirationFormatted);
   const [expirationTime, setExpirationTime] =
@@ -37,8 +38,9 @@ const EditHandshake = props => {
     return new Date(year, month, date, hour, minute);
   };
 
-  const readOnly = uneditable || infoOnly;
-  const disabledButton = isNil(expirationTime) || !isFuture(validateExpiration());
+  const readOnly = currentlyOffered || infoOnly;
+  const disabledButton = !currentlyOffered &&
+    (isNil(expirationTime) || isPast(validateExpiration()));
 
 
   const cancel = (e) => {
@@ -164,7 +166,7 @@ EditHandshake.propTypes = {
   infoOnly: PropTypes.bool,
   expiration: PropTypes.string,
   offer: PropTypes.string,
-  uneditable: PropTypes.bool,
+  currentlyOffered: PropTypes.bool,
 };
 
 EditHandshake.defaultProps = {
@@ -173,7 +175,7 @@ EditHandshake.defaultProps = {
   submitText: 'Submit',
   infoOnly: true,
   expiration: '',
-  uneditable: true,
+  currentlyOffered: true,
   offer: '',
 };
 

--- a/src/Components/Handshake/HandshakeBureauButton/HandshakeBureauButton.jsx
+++ b/src/Components/Handshake/HandshakeBureauButton/HandshakeBureauButton.jsx
@@ -56,7 +56,7 @@ const HandshakeBureauButton = props => {
           bidCycle={bidCycle}
           expiration={hs_date_expiration}
           offer={hs_date_offered}
-          uneditable={hs_status_code === 'handshake_offered'}
+          currentlyOffered={hs_status_code === 'handshake_offered'}
           infoOnly={infoOnly}
           submitText={buttonText()}
         />


### PR DESCRIPTION
To test: 
1. Before checking out, Go offer HS and set expiration to same day in a couple minutes. 
2. Wait the couple minutes for expiration
3. Refresh Page
4. Now that HS is expired, try to revoke. Button Is disabled

FIX: After checking this out, you should be able to revoke after the HS expires 

(faulty button disabled check for creating HS not taking capturing edge cases)

**CASE 1:**
Creating a HS w/ Errors

> -> Button Should be disabled until you've set the date and time appropriately

**CASE 2:**
Reading a HS w/ expiration (use info button)

> -> Normal data with no ability to edit and NO submit button (only close)

**CASE 3:** 
Revoking a HS w/ expiration before AND after expiration time

> -> This was the problem, you can't edit the HS at all, but you should be able to still take actions with the button to revoke it