### PR TITLE
Historical HS vs New HS fix TM-2282

### DIFF
--- a/src/Components/Handshake/HandshakeBureauButton/HandshakeBureauButton.jsx
+++ b/src/Components/Handshake/HandshakeBureauButton/HandshakeBureauButton.jsx
@@ -23,7 +23,6 @@ const HandshakeBureauButton = props => {
 
   const {
     hs_status_code,
-    hs_date_expiration,
     hs_date_offered,
   } = handshake;
 
@@ -54,9 +53,7 @@ const HandshakeBureauButton = props => {
         <EditHandshake
           submitAction={submitAction}
           bidCycle={bidCycle}
-          expiration={hs_date_expiration}
-          offer={hs_date_offered}
-          currentlyOffered={hs_status_code === 'handshake_offered'}
+          handshake={handshake}
           infoOnly={infoOnly}
           submitText={buttonText()}
         />


### PR DESCRIPTION
Easy way to test: 
Note -> Use extreme values for expirations to easily tell what is being overwritten or not

> 1. Offer HS
> 2. Check revoke modal values for Reveal and Expiration
> 3. Check same values for info only modal (all of them should align)

> 4. Revoke HS
> 5. View Info Only modal of revoked hs (Should show historical expiration and reveal) -> reveal might be iffy
> 6. View Re-Offer modal version - all those values should be defaulted to be identical to any OTHER brand new offer modal
> 7. Check against brand new offer to make sure both re-offer and offer are identical modals