### PR TITLE
Fix/rework hs edge cases

### DIFF
--- a/src/Components/Handshake/EditHandshake/EditHandshake.jsx
+++ b/src/Components/Handshake/EditHandshake/EditHandshake.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { get, isNil } from 'lodash';
 import PropTypes from 'prop-types';
-import { EMPTY_FUNCTION } from 'Constants/PropTypes';
+import { EMPTY_FUNCTION, HANDSHAKE_DETAILS } from 'Constants/PropTypes';
 import swal from '@sweetalert/with-react';
 import Calendar from 'react-calendar';
 import TimePicker from 'react-time-picker';
@@ -13,52 +13,63 @@ const EditHandshake = props => {
   const { hs_date_expiration, hs_date_offered, hs_status_code } = handshake;
   const currentlyOffered = hs_status_code === 'handshake_offered';
 
-  const calculateExpiration = () => {
-    let e = hs_date_expiration;
-    // If already revoked, but in create mode, reset the expiration
-    if (!infoOnly && (hs_status_code === 'handshake_revoked')) {
-      e = false;
-    }
-    return e ? new Date(e) : add(new Date(), { days: 1 });
-  };
+  const officialReveal = get(bidCycle, 'handshake_allowed_date');
 
-  const [expirationDate, setExpirationDate] = useState(calculateExpiration());
-  const [expirationTime, setExpirationTime] =
-    useState(`${getHours(expirationDate)}:${getMinutes(expirationDate)}`);
+  const beforeReveal = (d) => isBefore(new Date(d), new Date(officialReveal));
 
-  useCloseSwalOnUnmount();
-
-  // Date when bidders are able to begin seeing HS offers
-  const revealDate = get(bidCycle, 'handshake_allowed_date');
-
-  const calculateReveal = () => {
-    // Case 1:
-    // We have a reveal date and its in the future
-    //   a) INFO-ONLY => show reveal
-    //   b) CREATE-MODE => show reveal
-    // Case 2:
-    // We have a reveal date and its in the past
-    //  a) INFO-ONLY && (offer_dt < reveal_dt) => show reveal_dt
-    //  b) INFO-ONLY && (offer_dt > reveal_dt) => show offer_dt
-    //  c) CREATE-MODE => show today
-    // Case 3:
-    // No reveal date
-    //   a) INFO-ONLY => show offer_dt
-    //   b) create-mode => show today
-    if (revealDate && isFuture(new Date(revealDate))) {
-      return new Date(revealDate);
-    } else if (revealDate && infoOnly) {
-      if (isBefore(new Date(hs_date_offered), new Date(revealDate))) {
-        return new Date(revealDate);
+  const revealDate = (useExistingHS) => {
+    // Official Reveal date set
+    if (officialReveal) {
+      if (useExistingHS) { //
+        if (beforeReveal(hs_date_offered)) {
+          return new Date(officialReveal);
+        }
+        return new Date(hs_date_offered);
       }
-      return new Date(hs_date_offered);
-    } else if (revealDate && !infoOnly) {
+      if (beforeReveal(new Date())) {
+        return new Date(officialReveal);
+      }
       return new Date();
-    } else if (infoOnly) {
+    }
+    // Official Reveal date not set
+    if (useExistingHS) {
       return new Date(hs_date_offered);
     }
     return new Date();
   };
+
+  const calculateExpiration = () => {
+    if (officialReveal && isFuture(new Date(officialReveal))) {
+      return new Date(officialReveal);
+    }
+    return add(new Date(), { days: 1 });
+  };
+
+  const modes = {
+    readOnly: {
+      expiration: new Date(hs_date_expiration),
+      reveal: revealDate(true),
+    },
+    create: {
+      expiration: calculateExpiration(),
+      reveal: revealDate(false),
+    },
+  };
+
+  const getMode = () => {
+    if (infoOnly) {
+      return modes.readOnly;
+    } else if ((hs_status_code === 'handshake_revoked') || !hs_status_code) {
+      return modes.create;
+    }
+    return modes.readOnly;
+  };
+
+  const [expirationDate, setExpirationDate] = useState(getMode().expiration);
+  const [expirationTime, setExpirationTime] =
+    useState(`${getHours(expirationDate)}:${getMinutes(expirationDate)}`);
+
+  useCloseSwalOnUnmount();
 
   const validateExpiration = () => {
     const [hour, minute] = expirationTime.split(':');
@@ -99,7 +110,7 @@ const EditHandshake = props => {
       if (isSameDay(expirationDate, date)) {
         return 'react-calendar__tile--endDate';
       }
-      if (isSameDay(calculateReveal(), date)) {
+      if (isSameDay(getMode().reveal, date)) {
         return 'react-calender__tile--startDate';
       }
       // TO-DO: Add dates from bidCycle object to complete
@@ -119,13 +130,13 @@ const EditHandshake = props => {
             <input
               type="text"
               name="handshakeStartDate"
-              value={getDate$(calculateReveal())}
+              value={getDate$(getMode().reveal)}
               disabled
             />
             <input
               type="text"
               name="handshakeStartTime"
-              value={getTime$(calculateReveal())}
+              value={getTime$(getMode().reveal)}
               disabled
             />
           </div>
@@ -151,7 +162,7 @@ const EditHandshake = props => {
         {/* TO-DO: Use this class yet for calendar to disable all interation */}
         <div className={`calendar-wrapper ${readOnly ? 'disabled' : ''}`}>
           <Calendar
-            minDate={calculateReveal()}
+            minDate={getMode().reveal}
             // TO-DO: maxDate={fakeBureauTimeline[1]}
             onChange={readOnly ? () => {} : setExpirationDate}
             value={expirationDate}
@@ -196,18 +207,18 @@ const EditHandshake = props => {
 
 EditHandshake.propTypes = {
   bidCycle: PropTypes.shape({}),
+  handshake: HANDSHAKE_DETAILS,
   submitAction: PropTypes.func,
   submitText: PropTypes.string,
   infoOnly: PropTypes.bool,
-  handshake: PropTypes.shape({}),
 };
 
 EditHandshake.defaultProps = {
   bidCycle: {},
+  handshake: {},
   submitAction: EMPTY_FUNCTION,
   submitText: 'Submit',
   infoOnly: true,
-  handshake: {},
 };
 
 export default EditHandshake;

--- a/src/Components/Handshake/EditHandshake/EditHandshake.jsx
+++ b/src/Components/Handshake/EditHandshake/EditHandshake.jsx
@@ -20,12 +20,12 @@ const EditHandshake = props => {
   const revealDate = (useExistingHS) => {
     // Official Reveal date set
     if (officialReveal) {
-      if (useExistingHS) { //
+      if (useExistingHS) {
         if (beforeReveal(hs_date_offered)) {
           return new Date(officialReveal);
         }
         return new Date(hs_date_offered);
-      }
+      } // New HS
       if (beforeReveal(new Date())) {
         return new Date(officialReveal);
       }
@@ -34,7 +34,7 @@ const EditHandshake = props => {
     // Official Reveal date not set
     if (useExistingHS) {
       return new Date(hs_date_offered);
-    }
+    } // New HS
     return new Date();
   };
 

--- a/src/Constants/PropTypes.js
+++ b/src/Constants/PropTypes.js
@@ -680,3 +680,14 @@ export const HOME_PAGE_RECOMMENDED_POSITIONS = PropTypes.shape({
   positions: PropTypes.arrayOf(POSITION_DETAILS),
   name: PropTypes.string,
 });
+
+export const HANDSHAKE_DETAILS = PropTypes.shape({
+  hs_status_code: PropTypes.string,
+  bidder_hs_code: PropTypes.string,
+  hs_date_accepted: PropTypes.string,
+  hs_date_declined: PropTypes.string,
+  hs_date_offered: PropTypes.string,
+  hs_date_revoked: PropTypes.string,
+  hs_date_expiration: PropTypes.string,
+  hs_cdo_indicator: PropTypes.bool,
+});


### PR DESCRIPTION
RELIES ON: https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/572

All the edge cases revolve around the following scenarios:

- ReadOnly or Create Mode 
- Reveal Date Officially Set or NOT set

> `ReadOnly` of Modal includes when you click the INFO BUTTON for any previously offered HS (must have something offered to have any info on it i.e. offered, revoked)
> `ReadOnly` is **also** when the modal CANNOT be edited, but actions _can_ still be taken (Single Case: already offered, preparing to revoke)
> `CreateMode` is when we DON'T HAVE or DON'T CARE about the previous HS. "Starting fresh" means modal should show new defaults (First Offer, Any re-offer) 

The complication is clearly defining what values we expect for reveal/expiration when we press the action (Offer, Re-offer, Revoke) and what values we expect for `i` button for info only. 

I have tried to clearly set up more finite constants to deal with all the different cases including: 

- Function for determining create or readOnly mode
- Modes object for standardizing expected expiration and reveal
- revealDate func for considering official reveal date set and existing HS param
- getExpiration setting appropriate expiration

