### PR TITLE
Fix datepicker style

### DIFF
--- a/src/sass/_bidCycles.scss
+++ b/src/sass/_bidCycles.scss
@@ -8,7 +8,34 @@
 }
 
 .bid-cycles-container {
+  .react-datepicker {
+    font-size: 1rem;
+  }
+
   .react-datepicker__input-container {
     width: 300px;
+  }
+}
+
+.react-datepicker {
+  button {
+    font-size: initial;
+    font-weight: initial;
+    line-height: initial;
+    margin-top: initial;
+    margin-right: initial;
+    margin-bottom: initial;
+    border-radius: initial;
+    color: initial;
+    text-decoration: initial;
+    font: initial;
+    margin: initial;
+
+    &:hover {
+      background-color: initial;
+      border-bottom: initial;
+      color: initial;
+      text-decoration: initial;
+    }
   }
 }

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -34,6 +34,7 @@
 // react-day-picker
 @import '~react-day-picker/lib/style.css';
 
+// react-datepicker
 @import "~react-datepicker/dist/react-datepicker.css";
 
 // Global


### PR DESCRIPTION
The USWDS button styles were overriding the default styles for the datepicker. This PR fixes that, as well as increases the font size to make it more readable.

Before:
![Screen Shot 2021-08-11 at 10 47 21 AM](https://user-images.githubusercontent.com/11576347/129051097-58823f5e-69f3-439e-a0fd-5b35840e5c05.png)

After:
![Screen Shot 2021-08-11 at 10 43 49 AM](https://user-images.githubusercontent.com/11576347/129050613-0bf007b0-dcfc-4b6a-9ad1-2690e2964f64.png)
