### PR TITLE
Add new message for missing score digits in ab TM-2283

### DIFF
--- a/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
@@ -7,7 +7,7 @@ import { availableBidderEditData, availableBiddersToggleUser } from 'actions/ava
 import { useDispatch } from 'react-redux';
 import {
   NO_BUREAU, NO_CDO, NO_COMMENTS, NO_DATE, NO_END_DATE, NO_GRADE, NO_LANGUAGE,
-  NO_LANGUAGES, NO_OC_REASON, NO_STATUS,
+  NO_LANGUAGES, NO_NUMBER, NO_OC_REASON, NO_STATUS,
 } from 'Constants/SystemMessages';
 import EditBidder from 'Components/AvailableBidder/EditBidder';
 import InteractiveElement from 'Components/InteractiveElement';
@@ -75,9 +75,9 @@ const AvailableBidderRow = (props) => {
         html={
           languages.map(l => (
             <div className="language-group">
-              <span className="language-name">{get(l, 'language', NO_LANGUAGE)}: </span>
-              <span className="title">Speaking:</span> <span className="text">{get(l, 'speaking_score') || NO_LANGUAGE} | </span>
-              <span className="title">Reading:</span> <span className="text">{get(l, 'reading_score') || NO_LANGUAGE}</span>
+              <span className="language-name">{get(l, 'language') || NO_LANGUAGE}: </span>
+              <span className="title">Speaking:</span> <span className="text">{get(l, 'speaking_score') || NO_NUMBER} | </span>
+              <span className="title">Reading:</span> <span className="text">{get(l, 'reading_score') || NO_NUMBER}</span>
             </div>
           ))
         }

--- a/src/Constants/SystemMessages.js
+++ b/src/Constants/SystemMessages.js
@@ -153,3 +153,5 @@ export const COMING_SOON = 'Coming Soon';
 
 export const UPDATE_CLASSIFICATIONS_SUCCESS = "Client's classifications updated";
 export const UPDATE_CLASSIFICATIONS_ERROR = "Error updating client's classifications";
+
+export const NO_NUMBER = '--';


### PR DESCRIPTION
In the unlikely case a language appears in the ab list without a reading and/or speaking score, this will default the 'score' to `--`