### PR TITLE
Change default sort to -posted date TM-2376

### DIFF
--- a/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
+++ b/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
@@ -69,6 +69,7 @@ class SearchFiltersContainer extends Component {
   };
 
   onTandemSearchClick = value => {
+    const { isProjectedVacancy } = this.context;
     let config = {};
     if (!value) {
       config = {
@@ -78,6 +79,7 @@ class SearchFiltersContainer extends Component {
     } else {
       config = {
         ...config,
+        ordering: isProjectedVacancy ? 'ted' : '-posted_date',
         tandem: 'tandem',
       };
       this.setState({ showTandem2: false }); // reset showTandem2 to false

--- a/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
+++ b/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
@@ -78,7 +78,7 @@ class SearchFiltersContainer extends Component {
     } else {
       config = {
         ...config,
-        ordering: 'ted',
+        ordering: '-posted_date',
         tandem: 'tandem',
       };
       this.setState({ showTandem2: false }); // reset showTandem2 to false

--- a/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
+++ b/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
@@ -78,7 +78,6 @@ class SearchFiltersContainer extends Component {
     } else {
       config = {
         ...config,
-        ordering: '-posted_date',
         tandem: 'tandem',
       };
       this.setState({ showTandem2: false }); // reset showTandem2 to false

--- a/src/Constants/Sort.js
+++ b/src/Constants/Sort.js
@@ -19,7 +19,7 @@ const POSITION_SEARCH_SORTS$ = {
 };
 
 POSITION_SEARCH_SORTS$.defaultSort = POSITION_SEARCH_SORTS$.options.find(o =>
-  o.value === 'ted',
+  o.value === '-posted_date',
 ).value;
 
 export const POSITION_SEARCH_SORTS = POSITION_SEARCH_SORTS$;


### PR DESCRIPTION
How to Test:
 - [ ] Initial Available Position Search uses default sort of "Posted Date - Most Recent" 
 - [ ] After selecting tandem, the tandem sort should be "Posted Date - Most Recent" 
 - [ ] Initial Projected Vacancy Position Search REMAINS default sort of "TED - Soonest" 
 - [ ] After selecting tandem, the PV tandem sort should be "TED - Soonest" 