### PR TITLE
changing about text to help TM-524

### DIFF
--- a/src/Components/About/About.jsx
+++ b/src/Components/About/About.jsx
@@ -48,7 +48,7 @@ class About extends Component {
                 }
                 {
                   !isLoading && hasErrored &&
-                  <Alert type="error" title="Error loading About page" messages={[{ body: 'Please try again.' }]} />
+                  <Alert type="error" title="Error loading Help page" messages={[{ body: 'Please try again.' }]} />
                 }
                 {
                   !isLoading &&

--- a/src/Components/AdministratorPage/Dashboard/Dashboard.jsx
+++ b/src/Components/AdministratorPage/Dashboard/Dashboard.jsx
@@ -57,7 +57,7 @@ const AdministratorPage = (props) => {
                         <h3>Editable Content Areas</h3>
                         <Column className="content-link-container">
                           {getLink('/', 'Header')}
-                          {getLink('/about', 'About')}
+                          {getLink('/help', 'Help')}
                           {getLink('/results', 'Featured Positions')}
                           {getLink('/profile/glossaryeditor/', 'Glossary')}
                         </Column>

--- a/src/Components/Footer/Footer.jsx
+++ b/src/Components/Footer/Footer.jsx
@@ -19,7 +19,7 @@ const Footer = () => (
                 <Link className="usa-footer-primary-link" to="/">Home</Link>
               </li>
               <li className="usa-width-one-sixth usa-footer-primary-content">
-                <Link className="usa-footer-primary-link" to="/about">About</Link>
+                <Link className="usa-footer-primary-link" to="/help">Help</Link>
               </li>
             </ul>
           </nav>

--- a/src/Components/Footer/__snapshots__/Footer.test.jsx.snap
+++ b/src/Components/Footer/__snapshots__/Footer.test.jsx.snap
@@ -37,9 +37,9 @@ exports[`Footer Component matches snapshot 1`] = `
               <Link
                 className="usa-footer-primary-link"
                 replace={false}
-                to="/about"
+                to="/help"
               >
-                About
+                Help
               </Link>
             </li>
           </ul>

--- a/src/routes.js
+++ b/src/routes.js
@@ -9,7 +9,7 @@ const routesArray = [
   { path: '/archived/:id', componentName: 'Position', pageTitle: 'Archived Position details', props: { isArchived: true } },
   { path: '/compare/:ids', key: 'compareID', componentName: 'Compare', pageTitle: 'Compare Positions' },
   { path: '/compare', key: 'compareNoID', componentName: 'Compare', pageTitle: 'Compare Positions' },
-  { path: '/about', exact: true, componentName: 'About', pageTitle: 'About' },
+  { path: '/help', exact: true, componentName: 'About', pageTitle: 'About' },
   { path: '/tokenValidation', componentName: 'TokenValidation', pageTitle: 'Token Validation' },
   { path: '/loginRedirect', componentName: 'LoginRedirect', pageTitle: 'Login Redirect' },
   { path: '/biddingProcess', componentName: 'Faq', pageTitle: 'Bidding Process' },


### PR DESCRIPTION
Text has been changed from `About` to `Help` in the bottom footer as well as under the `Administrator Dashboard` under the Admin profile.
The url text has been updated as well.

![image](https://user-images.githubusercontent.com/55964163/139330325-68f69d65-df3e-4be8-b931-bc57c2af58f7.png)


![image](https://user-images.githubusercontent.com/55964163/139330359-bff660a4-94ea-4328-a36e-8d771328e75b.png)
