### PR TITLE
Reset htf on PV selection

### DIFF
--- a/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
+++ b/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
@@ -63,6 +63,7 @@ class SearchFiltersContainer extends Component {
         projectedVacancy: value,
         ordering: 'ted',
         cps_codes: null,
+        htf_indicator: null,
       };
     }
     this.props.queryParamUpdate(config);

--- a/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.test.jsx
+++ b/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.test.jsx
@@ -112,6 +112,7 @@ describe('SearchFiltersContainerComponent', () => {
     wrapper.instance().onProjectedVacancyFilterClick('pv');
     expect(toggleValue.value).toEqual({
       cps_codes: null,
+      htf_indicator: null,
       is_available_in_bidcycle: null,
       is_available_in_current_bidcycle: null,
       ordering: 'ted',


### PR DESCRIPTION
Before this fix, the Hard to Fill pill would persist onto the Projected Vacancy position search