### PR TITLE
Fix double data fetch

### DIFF
--- a/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
@@ -35,7 +35,7 @@ const AvailableBidderTable = props => {
   const isLoading = availableBiddersIsLoading || filtersIsLoading;
 
 
-  const bureaus = filterData.filters.find(f => f.item.description === 'region');
+  const bureaus = (get(filterData, 'filters') || []).find(f => f.item.description === 'region');
 
   const bidders = isLoading ? [...new Array(10)] : get(biddersData, 'results', []);
 

--- a/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
@@ -13,6 +13,7 @@ import Alert from 'Components/Alert/Alert';
 import FA from 'react-fontawesome';
 import { Tooltip } from 'react-tippy';
 import shortid from 'shortid';
+import { useMount, usePrevious } from 'hooks';
 
 
 const AvailableBidderTable = props => {
@@ -38,16 +39,20 @@ const AvailableBidderTable = props => {
 
   const bidders = isLoading ? [...new Array(10)] : get(biddersData, 'results', []);
 
+  const prevSort = usePrevious(sort);
+
   // Actions
   const dispatch = useDispatch();
 
-  useEffect(() => {
+  useMount(() => {
     dispatch(availableBiddersFetchData(isCDO, sort));
     dispatch(filtersFetchData(filterData, {}));
-  }, []);
+  });
 
   useEffect(() => {
-    dispatch(availableBiddersFetchData(isCDO, sort));
+    if (prevSort && sort && sort !== prevSort) {
+      dispatch(availableBiddersFetchData(isCDO, sort));
+    }
   }, [sort]);
 
   const tableHeaders = isCDO ? [

--- a/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.test.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.test.jsx
@@ -1,0 +1,25 @@
+import TestUtils from 'react-dom/test-utils';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import AvailableBidderTable from './AvailableBidderTable';
+
+const middlewares = [thunk];
+const mockStore = configureStore(middlewares);
+
+describe('AvailableBidderTable', () => {
+  const props = {
+    bidders: [],
+    onSort: () => {},
+    onFilter: () => {},
+    isCDO: true,
+  };
+
+  it('mounts', () => {
+    const wrapper = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
+      <AvailableBidderTable {...props} />
+    </MemoryRouter></Provider>);
+    expect(wrapper).toBeDefined();
+  });
+});


### PR DESCRIPTION
Available Bidders page was loading data twice on mount. This PR updates the re-render logic to only re-fetch data if the sort option changes (which it shouldn't because it's not exposed in the UI).