### PR TITLE
fix to admin role table styling

### DIFF
--- a/src/Components/AdministratorPage/UserRoles/UserRoles.jsx
+++ b/src/Components/AdministratorPage/UserRoles/UserRoles.jsx
@@ -154,7 +154,7 @@ class UserRoles extends Component {
                <tr>
                  <th key="username" className="delegate-role-header">
                    <div className="header-text" role="button" tabIndex={0} onClick={() => this.onSortTable('username')}>
-                    User Name
+                    Username
                      {sortArrow('username')}
                    </div>
                    <div className="filter-row">
@@ -165,7 +165,7 @@ class UserRoles extends Component {
                        onChangeText={e => this.changeText(e, 'q_username')}
                        onSubmitSearch={e => this.submitText(e, 'q_username')}
                        onClear={e => this.clearText(e, 'q_username')}
-                       placeholder="Search by User Name"
+                       placeholder="Search by Username"
                        showClear
                        submitText="Search"
                        type="small"

--- a/src/sass/_administrator.scss
+++ b/src/sass/_administrator.scss
@@ -408,7 +408,7 @@
       border: none;
       border-left: 1px solid $bg-gray-medium-0;
       padding: 10px;
-      text-align: center;
+      text-align: left;
     }
 
     td:nth-child(1) {
@@ -419,9 +419,6 @@
       cursor: grabbing;
     }
     tr {
-      td {
-        text-align: left;
-      }
       .delegateRoleCell {
         text-align: center;
       }


### PR DESCRIPTION
Feedback that was not done on this [PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/1918)

To-Do:

- [x] Update `User Name` to `Username`
- [x] Left-align text