### PR TITLE
Available Bidders PATCH fix

### DIFF
--- a/src/Components/AvailableBidder/EditBidder/EditBidder.jsx
+++ b/src/Components/AvailableBidder/EditBidder/EditBidder.jsx
@@ -47,7 +47,7 @@ const EditBidder = (props) => {
     const userInputs = {
       oc_bureau: ocBureau || '',
       oc_reason: ocReason || '',
-      status,
+      status: status || '',
       comments: comment || '',
       is_shared: shared,
       step_letter_one: stepLetterOne,


### PR DESCRIPTION
Previous behavior:
- Edit an Available Bidder who does not have a status set
- Click the Submit button
- Returns an error, since `null` is being passed for the status, which is not a valid status on the API

This fix falls back to an empty string `''`, which is a valid status on the API (represents "no status)