### PR TITLE
assignment hist integration

### DIFF
--- a/src/Components/Agenda/AgendaItemResearchPane/AgendaItemResearchPane.jsx
+++ b/src/Components/Agenda/AgendaItemResearchPane/AgendaItemResearchPane.jsx
@@ -49,9 +49,28 @@ const AgendaItemResearchPane = props => {
   const [selectedNav, setSelectedNav] = useState(get(tabs, '[0].value') || '');
 
   // assignments
-  const { data, error, loading /* , retry */ } = useDataLoader(api().get, `/fsbid/client/${perdet}/`);
-  const assignments = get(data, 'data.assignments') || [];
+  const { data, error, loading } = useDataLoader(api().get, `/fsbid/assignment_history/${perdet}/`);
+  // const assignments = get(data, 'data.results') || [];
   const languages = get(data, 'data.languages') || [];
+  const assignments = [
+    {
+      asg_perdet_seq_num: 8364589,
+      asg_pos_seq_num: 141475,
+      asgd_asg_seq_num: 9394,
+      asgd_eta_date: '2019-08-17T00:00:00.000Z',
+      asgd_etd_ted_date: '2022-10-21T00:00:00.000Z',
+      asgd_tod_desc_text: '1 YR(3R&R)/HL/1 YR(3R&R)',
+      asgs_code: 'EF',
+      position: {
+        language: 'Test Language',
+        position_number: 'Test Number',
+        post: 'Test Post',
+        skill: 'Test Skill',
+        title: 'Test Title',
+      },
+      className: 'bid-list-card-title-post',
+    },
+  ];
 
   const onFPClick = pos => {
     // TODO - do something with this

--- a/src/Components/ProfileDashboard/Assignments/AssignmentsList.jsx
+++ b/src/Components/ProfileDashboard/Assignments/AssignmentsList.jsx
@@ -3,9 +3,20 @@ import SectionTitle from '../SectionTitle';
 import BorderedList from '../../BorderedList';
 import AssignmentsListResultsCard from './AssignmentsListResultsCard';
 
+// eslint-disable-next-line no-unused-vars
 const AssignmentList = ({ assignments }) => {
+  const defaultClassName = 'bid-list-card-title-post';
+  const assignments$ = {
+    data: {
+      asg_className: defaultClassName,
+      data_point: 'FACILITY MAINTENANCE (6217)',
+      position_number: 12345,
+      title: 'Skill',
+      default: 'None listed',
+    },
+  };
   const positionArray = [];
-  assignments.forEach(assignment => (
+  assignments$.data.forEach(assignment => (
     positionArray.push(
       <AssignmentsListResultsCard
         assignment={assignment}

--- a/src/Components/ProfileDashboard/Assignments/AssignmentsListResultsCard/AssignmentsContent/AssignmentsContent.jsx
+++ b/src/Components/ProfileDashboard/Assignments/AssignmentsListResultsCard/AssignmentsContent/AssignmentsContent.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import { get } from 'lodash';
 // import { Link } from 'react-router-dom';
 import {
@@ -18,8 +19,8 @@ const AssignmentsContent = ({ assignment }) => (
       <span className="usa-sr-only">Position number: </span>
       <span className="bid-list-card-title-post bid-list-card-title-lg">
         {
-          get(assignment, 'asg_pos_seq_num') ?
-            `(${get(assignment, 'asg_pos_seq_num')}) ` : NO_POSITION_NUMBER
+          get(assignment, 'position_number') ?
+            `(${get(assignment, 'position_number')}) ` : NO_POSITION_NUMBER
         }
       </span>
       {/* <Link to={`/archived/${get(assignment, 'position.position_id')}`}>View Position</Link> */}
@@ -28,10 +29,17 @@ const AssignmentsContent = ({ assignment }) => (
       <span className="bid-list-card-title-post">Location: </span>
       {getPostName(get(assignment, 'position.post', NO_POST))}
     </div>
-    <div>
-      <span className="bid-list-card-title-post">Skill: </span>
-      {get(assignment, 'position.skill', NO_SKILL)}
-    </div>
+    {[assignment].map(a => (
+      <div>
+        <span className={a.asg_className}>{a.title}: </span>
+        {a.data_point}
+        {/* {get(assignment, a.data_point, a.default)} */}
+      </div>
+    ))}
+    {/* <div>
+        <span className="bid-list-card-title-post">Skill: </span>
+        {get(assignment, 'position.skill', NO_SKILL)}
+      </div> */}
     <div>
       <span className="bid-list-card-title-post">Language: </span>
       {get(assignment, 'position.language', NO_LANGUAGES)}

--- a/src/Components/ProfileDashboard/Assignments/AssignmentsListResultsCard/AssignmentsContent/AssignmentsContent.jsx
+++ b/src/Components/ProfileDashboard/Assignments/AssignmentsListResultsCard/AssignmentsContent/AssignmentsContent.jsx
@@ -1,6 +1,9 @@
 import { get } from 'lodash';
 // import { Link } from 'react-router-dom';
-import { NO_LANGUAGES, NO_POSITION_NUMBER, NO_POST, NO_SKILL } from 'Constants/SystemMessages';
+import {
+  NO_ASSIGNMENT_STATUS, NO_ASSIGNMENT_TOD_DESC, NO_LANGUAGES, NO_POSITION_NUMBER,
+  NO_POST, NO_SKILL,
+} from 'Constants/SystemMessages';
 import { POSITION_DETAILS } from 'Constants/PropTypes';
 import { formatDate, getPostName } from '../../../../../utilities';
 import StartEnd from '../../../PositionInformation/StartEnd';
@@ -15,8 +18,8 @@ const AssignmentsContent = ({ assignment }) => (
       <span className="usa-sr-only">Position number: </span>
       <span className="bid-list-card-title-post bid-list-card-title-lg">
         {
-          get(assignment, 'position.position_number') ?
-            `(${get(assignment, 'position.position_number')}) ` : NO_POSITION_NUMBER
+          get(assignment, 'asg_pos_seq_num') ?
+            `(${get(assignment, 'asg_pos_seq_num')}) ` : NO_POSITION_NUMBER
         }
       </span>
       {/* <Link to={`/archived/${get(assignment, 'position.position_id')}`}>View Position</Link> */}
@@ -34,10 +37,18 @@ const AssignmentsContent = ({ assignment }) => (
       {get(assignment, 'position.language', NO_LANGUAGES)}
     </div>
     <div>
+      <span className="bid-list-card-title-post">Status: </span>
+      {get(assignment, 'asgs_code', NO_ASSIGNMENT_STATUS)}
+    </div>
+    <div>
+      <span className="bid-list-card-title-post">TOD Description: </span>
+      {get(assignment, 'asgd_tod_desc_text', NO_ASSIGNMENT_TOD_DESC)}
+    </div>
+    <div>
       <span className="bid-list-card-title-post">Start date and End date: </span>
       <StartEnd
-        start={formatDate(assignment.start_date)}
-        end={formatDate(assignment.end_date)}
+        start={formatDate(assignment.asgd_eta_date)}
+        end={formatDate(assignment.asgd_etd_ted_date)}
       />
     </div>
   </div>

--- a/src/Constants/SystemMessages.js
+++ b/src/Constants/SystemMessages.js
@@ -14,6 +14,8 @@ export const DEFAULT_TEXT = 'None listed';
 
 export const NO_ASSIGNMENT_DATE = DEFAULT_TEXT;
 export const NO_ASSIGNMENT_POSITION = DEFAULT_TEXT;
+export const NO_ASSIGNMENT_STATUS = DEFAULT_TEXT;
+export const NO_ASSIGNMENT_TOD_DESC = DEFAULT_TEXT;
 export const NO_BID_CYCLE = DEFAULT_TEXT;
 export const NO_BIRTHDAY = DEFAULT_TEXT;
 export const NO_BUREAU = DEFAULT_TEXT;


### PR DESCRIPTION
[Orignial PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/1993) was closed due to rework being done on this PR

[BE PR](https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/668)

- [ ] Integrate with the new Assignment endpoint
- [ ] Add status to assignment history for agenda item (Eg. EF, CP, AP)
- [ ] Add additional information as appropriate (TOD description has been added as well)