### PR TITLE
Improved form validation for available bidder step letters and OC

### DIFF
--- a/src/Components/AvailableBidder/EditBidder/EditBidder.jsx
+++ b/src/Components/AvailableBidder/EditBidder/EditBidder.jsx
@@ -112,7 +112,7 @@ const EditBidder = (props) => {
 
   const getStepLetterOneErrorText = () => {
     if (stepLetterOneError) {
-      return 'Step Letter 1 is blank. You must delete Step Letter 2 before saving.';
+      return 'You must delete Step Letter 2 or add back a Step Letter 1 date before saving.';
     }
     return null;
   };

--- a/src/Components/AvailableBidder/EditBidder/EditBidder.jsx
+++ b/src/Components/AvailableBidder/EditBidder/EditBidder.jsx
@@ -9,8 +9,11 @@ import { Tooltip } from 'react-tippy';
 import InteractiveElement from 'Components/InteractiveElement';
 import DatePicker from 'react-datepicker';
 import TextareaAutosize from 'react-textarea-autosize';
+import { format } from 'date-fns-v2';
 
 const useStepLetter = () => checkFlag('flags.step_letters');
+
+const DATE_FORMAT = 'MMMM d, yyyy';
 
 // eslint-disable-next-line complexity
 const EditBidder = (props) => {
@@ -99,11 +102,22 @@ const EditBidder = (props) => {
   const stepLetterOneFlag = stepLetterOne === null;
   const stepLetterTwoFlag = stepLetterTwo === null;
   const stepLetterOneError = stepLetterOneFlag && !stepLetterTwoFlag;
-  const stepLetterTwoError = ((!stepLetterTwoFlag) && ((stepLetterOne) > (stepLetterTwo)));
-  const stepLetterOneClearIconInactive = ((stepLetterOneFlag) ||
-    ((!stepLetterOneFlag) && (!stepLetterTwoFlag)));
+  const stepLetterTwoError = !stepLetterTwoFlag && stepLetterOne > stepLetterTwo;
+  const stepLetterOneClearIconInactive = stepLetterOneFlag ||
+    (!stepLetterOneFlag && !stepLetterTwoFlag);
   const submitDisabled = ocReasonError || ocBureauError ||
     stepLetterOneError || stepLetterTwoError;
+
+  const stepLetterTwoFormatted = stepLetterTwo ? format(stepLetterTwo, DATE_FORMAT) : 'None listed';
+
+  const getStepLetterOneErrorText = () => {
+    if (stepLetterOneError) {
+      return 'Step Letter 1 is blank. You must delete Step Letter 2 before saving.';
+    }
+    return null;
+  };
+
+  const stepLetterOneErrorText = getStepLetterOneErrorText();
 
   const updateStepLetterOne = (date) => {
     setStepLetterOne(date);
@@ -165,62 +179,64 @@ const EditBidder = (props) => {
               Required
             </span>
           }
-          <select
-            id="ocReason"
-            className={ocReasonError ? 'select-error' : ''}
-            defaultValue={ocReason}
-            onChange={(e) => setOCReason(e.target.value)}
-            disabled={status !== 'OC'}
-            aria-describedby={ocReasonError ? 'ocReason-error' : ''}
-            value={ocReason}
-          >
-            <option value="">None listed</option>
-            {
-              (status === 'OC') &&
-              reasons.map(r => (
-                <option key={r} value={r}>{r}</option>
-              ))
-            }
-          </select>
+          <span className="oc-validation-container">
+            <select
+              id="ocReason"
+              className={ocReasonError ? 'select-error' : ''}
+              defaultValue={ocReason}
+              onChange={(e) => setOCReason(e.target.value)}
+              disabled={status !== 'OC'}
+              aria-describedby={ocReasonError ? 'ocReason-error' : ''}
+              value={ocReason}
+            >
+              <option value="">None listed</option>
+              {
+                (status === 'OC') &&
+                reasons.map(r => (
+                  <option key={r} value={r}>{r}</option>
+                ))
+              }
+            </select>
+            {!!ocReasonError && <span className="usa-input-error-message" role="alert">OC Reason is required.</span>}
+          </span>
         </div>
         <div>
           <label htmlFor="ocBureau">*OC Bureau:</label>
-          {
-            // for accessibility only
-            ocBureauError &&
-            <span className="usa-sr-only" id="ocBureau-error" role="alert">
-              Required
-            </span>
-          }
-          <select
-            id="ocBureau"
-            className={ocBureauError ? 'select-error' : ''}
-            defaultValue={ocBureau}
-            onChange={(e) => setOCBureau(e.target.value)}
-            disabled={status !== 'OC'}
-            aria-describedby={ocReasonError ? 'ocBureau-error' : ''}
-            value={ocBureau}
-          >
-            <option value="">None listed</option>
-            {
-              (status === 'OC') &&
-                bureauOptions.map(o => (
-                  <option key={o.id} value={o.short_description}>{o.custom_description}</option>
-                ))
-            }
-          </select>
+          <span className="oc-validation-container">
+            <select
+              id="ocBureau"
+              className={ocBureauError ? 'select-error' : ''}
+              defaultValue={ocBureau}
+              onChange={(e) => setOCBureau(e.target.value)}
+              disabled={status !== 'OC'}
+              aria-describedby={ocReasonError ? 'ocBureau-error' : ''}
+              value={ocBureau}
+            >
+              <option value="">None listed</option>
+              {
+                (status === 'OC') &&
+                  bureauOptions.map(o => (
+                    <option key={o.id} value={o.short_description}>{o.custom_description}</option>
+                  ))
+              }
+            </select>
+            {!!ocBureauError && <span className="usa-input-error-message" role="alert">OC Bureau is required.</span>}
+          </span>
         </div>
         {
           useStepLetter() &&
           <>
             <div>
               <dt>*Step Letter 1:</dt>
-              <DatePicker
-                selected={stepLetterOne}
-                onChange={updateStepLetterOne}
-                dateFormat="MMMM d, yyyy"
-                className={stepLetterOneError ? 'select-error' : ''}
-              />
+              <span className="date-picker-validation-container">
+                <DatePicker
+                  selected={stepLetterOne}
+                  onChange={updateStepLetterOne}
+                  dateFormat={DATE_FORMAT}
+                  className={stepLetterOneError ? 'select-error' : ''}
+                />
+                {!!stepLetterOneErrorText && <span className="usa-input-error-message" role="alert">{stepLetterOneErrorText}</span>}
+              </span>
               {stepLetterOneClearIconInactive &&
               <div className="step-letter-clear-icon">
                 <FA name="times-circle fa-lg inactive" />
@@ -238,22 +254,24 @@ const EditBidder = (props) => {
             </div>
             <div>
               <dt>*Step Letter 2:</dt>
-              {stepLetterOneFlag ?
-                <select
-                  id="stepLetterTwo"
-                  disabled={stepLetterOneFlag}
-                >
-                  <option value="">None listed</option>
-                </select>
-                :
-                <DatePicker
-                  selected={stepLetterTwo}
-                  onChange={updateStepLetterTwo}
-                  dateFormat="MMMM d, yyyy"
-                  className={stepLetterTwoError ? 'select-error' : ''}
-                  minDate={stepLetterOne}
-                />
-              }
+              <span className="date-picker-validation-container">
+                {stepLetterOneFlag ?
+                  <select
+                    id="stepLetterTwo"
+                    disabled={stepLetterOneFlag}
+                  >
+                    <option value="">{stepLetterTwoFormatted}</option>
+                  </select>
+                  :
+                  <DatePicker
+                    selected={stepLetterTwo}
+                    onChange={updateStepLetterTwo}
+                    dateFormat={DATE_FORMAT}
+                    className={stepLetterTwoError ? 'select-error' : ''}
+                    minDate={stepLetterOne}
+                  />
+                }
+              </span>
               {stepLetterTwoFlag ?
                 <div className="step-letter-clear-icon">
                   <FA name="times-circle fa-lg inactive" />

--- a/src/Components/AvailableBidder/EditBidder/__snapshots__/EditBidder.test.jsx.snap
+++ b/src/Components/AvailableBidder/EditBidder/__snapshots__/EditBidder.test.jsx.snap
@@ -61,19 +61,23 @@ exports[`EditBidders Component matches snapshot 1`] = `
       >
         *OC Reason:
       </label>
-      <select
-        aria-describedby=""
-        className=""
-        disabled={true}
-        id="ocReason"
-        onChange={[Function]}
+      <span
+        className="oc-validation-container"
       >
-        <option
-          value=""
+        <select
+          aria-describedby=""
+          className=""
+          disabled={true}
+          id="ocReason"
+          onChange={[Function]}
         >
-          None listed
-        </option>
-      </select>
+          <option
+            value=""
+          >
+            None listed
+          </option>
+        </select>
+      </span>
     </div>
     <div>
       <label
@@ -81,80 +85,88 @@ exports[`EditBidders Component matches snapshot 1`] = `
       >
         *OC Bureau:
       </label>
-      <select
-        aria-describedby=""
-        className=""
-        disabled={true}
-        id="ocBureau"
-        onChange={[Function]}
+      <span
+        className="oc-validation-container"
       >
-        <option
-          value=""
+        <select
+          aria-describedby=""
+          className=""
+          disabled={true}
+          id="ocBureau"
+          onChange={[Function]}
         >
-          None listed
-        </option>
-      </select>
+          <option
+            value=""
+          >
+            None listed
+          </option>
+        </select>
+      </span>
     </div>
     <div>
       <dt>
         *Step Letter 1:
       </dt>
-      <r
-        allowSameDay={false}
-        className=""
-        customTimeInput={null}
-        dateFormat="MMMM d, yyyy"
-        dateFormatCalendar="LLLL yyyy"
-        disabled={false}
-        disabledKeyboardNavigation={false}
-        dropdownMode="scroll"
-        enableTabLoop={true}
-        excludeScrollbar={true}
-        focusSelectedMonth={false}
-        monthsShown={1}
-        nextMonthAriaLabel="Next Month"
-        nextMonthButtonLabel="Next Month"
-        nextYearAriaLabel="Next Year"
-        nextYearButtonLabel="Next Year"
-        onBlur={[Function]}
-        onCalendarClose={[Function]}
-        onCalendarOpen={[Function]}
-        onChange={[Function]}
-        onClickOutside={[Function]}
-        onFocus={[Function]}
-        onInputClick={[Function]}
-        onInputError={[Function]}
-        onKeyDown={[Function]}
-        onMonthChange={[Function]}
-        onSelect={[Function]}
-        onYearChange={[Function]}
-        preventOpenOnFocus={false}
-        previousMonthAriaLabel="Previous Month"
-        previousMonthButtonLabel="Previous Month"
-        previousYearAriaLabel="Previous Year"
-        previousYearButtonLabel="Previous Year"
-        readOnly={false}
-        renderDayContents={[Function]}
-        selected={null}
-        selectsDisabledDaysInRange={false}
-        shouldCloseOnSelect={true}
-        showFourColumnMonthYearPicker={false}
-        showFullMonthYearPicker={false}
-        showMonthYearPicker={false}
-        showPopperArrow={true}
-        showPreviousMonths={false}
-        showQuarterYearPicker={false}
-        showTimeInput={false}
-        showTimeSelect={false}
-        showTwoColumnMonthYearPicker={false}
-        showYearPicker={false}
-        strictParsing={false}
-        timeCaption="Time"
-        timeInputLabel="Time"
-        timeIntervals={30}
-        withPortal={false}
-        yearItemNumber={12}
-      />
+      <span
+        className="date-picker-validation-container"
+      >
+        <r
+          allowSameDay={false}
+          className=""
+          customTimeInput={null}
+          dateFormat="MMMM d, yyyy"
+          dateFormatCalendar="LLLL yyyy"
+          disabled={false}
+          disabledKeyboardNavigation={false}
+          dropdownMode="scroll"
+          enableTabLoop={true}
+          excludeScrollbar={true}
+          focusSelectedMonth={false}
+          monthsShown={1}
+          nextMonthAriaLabel="Next Month"
+          nextMonthButtonLabel="Next Month"
+          nextYearAriaLabel="Next Year"
+          nextYearButtonLabel="Next Year"
+          onBlur={[Function]}
+          onCalendarClose={[Function]}
+          onCalendarOpen={[Function]}
+          onChange={[Function]}
+          onClickOutside={[Function]}
+          onFocus={[Function]}
+          onInputClick={[Function]}
+          onInputError={[Function]}
+          onKeyDown={[Function]}
+          onMonthChange={[Function]}
+          onSelect={[Function]}
+          onYearChange={[Function]}
+          preventOpenOnFocus={false}
+          previousMonthAriaLabel="Previous Month"
+          previousMonthButtonLabel="Previous Month"
+          previousYearAriaLabel="Previous Year"
+          previousYearButtonLabel="Previous Year"
+          readOnly={false}
+          renderDayContents={[Function]}
+          selected={null}
+          selectsDisabledDaysInRange={false}
+          shouldCloseOnSelect={true}
+          showFourColumnMonthYearPicker={false}
+          showFullMonthYearPicker={false}
+          showMonthYearPicker={false}
+          showPopperArrow={true}
+          showPreviousMonths={false}
+          showQuarterYearPicker={false}
+          showTimeInput={false}
+          showTimeSelect={false}
+          showTwoColumnMonthYearPicker={false}
+          showYearPicker={false}
+          strictParsing={false}
+          timeCaption="Time"
+          timeInputLabel="Time"
+          timeIntervals={30}
+          withPortal={false}
+          yearItemNumber={12}
+        />
+      </span>
       <div
         className="step-letter-clear-icon"
       >
@@ -167,16 +179,20 @@ exports[`EditBidders Component matches snapshot 1`] = `
       <dt>
         *Step Letter 2:
       </dt>
-      <select
-        disabled={true}
-        id="stepLetterTwo"
+      <span
+        className="date-picker-validation-container"
       >
-        <option
-          value=""
+        <select
+          disabled={true}
+          id="stepLetterTwo"
         >
-          None listed
-        </option>
-      </select>
+          <option
+            value=""
+          >
+            None listed
+          </option>
+        </select>
+      </span>
       <div
         className="step-letter-clear-icon"
       >

--- a/src/sass/_availableBidders.scss
+++ b/src/sass/_availableBidders.scss
@@ -291,6 +291,15 @@
     box-shadow: 0px 0px 0px 2px $alert-red;
   }
 
+  .date-picker-validation-container,
+  .oc-validation-container {
+    width: 100%;
+  }
+
+  .usa-input-error-message {
+    text-align: left;
+  }
+
   .react-datepicker {
     font-size: 1em;
   }


### PR DESCRIPTION
Completes TM-2689 by doing the following:
- Display an error message if Step Letter 1 has been manually deleted before Step Letter 2 was removed
- If scenario 1 occurred, Step Letter 2 date is still displayed instead of displaying "None listed"
- Display an error message if OC status is selected, but OC Reason and OC Bureau are left blank

![Screen Shot 2022-03-24 at 12 52 38 PM](https://user-images.githubusercontent.com/11576347/159968849-25bec23a-8721-4cde-b639-8ffd43d1995a.png)
-----------------
![Screen Shot 2022-03-24 at 12 53 35 PM](https://user-images.githubusercontent.com/11576347/159969078-e3b062aa-a483-41db-93d5-2fb66d41e44f.png)
 