### PR TITLE
abl stats grade styling fix

### DIFF
--- a/src/Components/AvailableBidder/AvailableBidderStats/AvailableBidderStats.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderStats/AvailableBidderStats.jsx
@@ -99,12 +99,22 @@ const AvailableBidderStats = () => {
                               className="legend-square"
                               style={{ backgroundColor: m.color }}
                             />
-                            <div className="legend-text">
-                              {`(${m.value}) ${m.name}`}
-                              <span className="percent-text">
-                                {`${m.percent}`}
-                              </span>
-                            </div>
+                            {
+                              selectedStat === 'Grade' ?
+                                <div className="legend-text">
+                                  {m.name}
+                                  <span className="percent-text">
+                                    {`${m.percent}`}
+                                  </span>
+                                  {`(${m.value})`}
+                                </div> :
+                                <div className="legend-text">
+                                  {`(${m.value}) ${m.name}`}
+                                  <span className="percent-text">
+                                    {`${m.percent}`}
+                                  </span>
+                                </div>
+                            }
                           </div>
                         ))
                       }

--- a/src/sass/_availableBidders.scss
+++ b/src/sass/_availableBidders.scss
@@ -66,7 +66,7 @@
 
     .percent-text {
       font-weight: bold;
-      margin-left: .4em;
+      margin: 0 .4em;
     }
 
     .chart-container {


### PR DESCRIPTION
Updating how grade is shown

old order: count, name, percent
<img width="232" alt="image" src="https://user-images.githubusercontent.com/55964163/161090259-bb15c4c4-3441-4ce2-9ef8-b5fc0b46d613.png">

new order: name, percent, count
<img width="240" alt="image" src="https://user-images.githubusercontent.com/55964163/161090372-635f0c86-e10d-4919-ab86-17d1c5c72f4d.png">
