### PR TITLE
scroll tabs & removing ai research pane headers TM-2725

### DIFF
--- a/src/Components/Agenda/AgendaItemResearchPane/AgendaItemResearchPane.jsx
+++ b/src/Components/Agenda/AgendaItemResearchPane/AgendaItemResearchPane.jsx
@@ -110,6 +110,7 @@ const AgendaItemResearchPane = forwardRef((props = { perdet: '' }, ref) => {
           !loading && error &&
             <Alert type="error" title="Error loading data" messages={[{ body: 'This data may not be available.' }]} />
         }
+        {/* headers should always be hidden in the nav view */}
         {
           selectedNav === ASGH && !loading && !error &&
             <AssignmentHistory
@@ -121,6 +122,7 @@ const AgendaItemResearchPane = forwardRef((props = { perdet: '' }, ref) => {
             <Languages
               languagesArray={languages}
               useWrapper
+              showHeader={false}
             />
         }
         {

--- a/src/Components/ProfileDashboard/Languages/Languages.jsx
+++ b/src/Components/ProfileDashboard/Languages/Languages.jsx
@@ -6,7 +6,7 @@ import SectionTitle from '../SectionTitle';
 import InformationDataPoint from '../InformationDataPoint';
 
 const Languages = props => {
-  const { languagesArray, useWrapper } = props;
+  const { languagesArray, useWrapper, showHeader } = props;
   const languagesArray$ = languagesArray || [];
 
   const getTestDate = (langObj) => {
@@ -47,7 +47,9 @@ const Languages = props => {
       <div className="usa-grid-full profile-section-container languages-container">
         <div className="usa-grid-full section-padded-inner-container">
           <div className="usa-width-one-whole">
-            <SectionTitle title="Language History" len={languagesArray$.length} icon="language" />
+            {showHeader &&
+              <SectionTitle title="Language History" len={languagesArray$.length} icon="language" />
+            }
           </div>
           {content}
         </div>
@@ -78,11 +80,13 @@ Languages.propTypes = {
     ),
   ),
   useWrapper: PropTypes.bool,
+  showHeader: PropTypes.bool,
 };
 
 Languages.defaultProps = {
   languagesArray: [],
   useWrapper: true,
+  showHeader: true,
 };
 
 export default Languages;

--- a/src/sass/_navTabs.scss
+++ b/src/sass/_navTabs.scss
@@ -1,4 +1,8 @@
 .navTabs {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  z-index: 1;
   .menu-style {
     display: grid;
     grid-template-columns: repeat(auto-fill,minmax(150px, 1fr));

--- a/src/sass/_navTabs.scss
+++ b/src/sass/_navTabs.scss
@@ -4,12 +4,13 @@
   top: 0;
   z-index: 1;
   .menu-style {
+    background-color: $bg-gray-medium-4;
+    border-bottom: 3px solid $color-black;
     display: grid;
     grid-template-columns: repeat(auto-fill,minmax(150px, 1fr));
     .tab {
-      background-color: $dos-blue;
+      background-color: $bg-gray-medium-4;
       border-top: 3px solid $bg-gray-medium-4;
-      color: $color-white;
       font-size: 13px;
       padding: 5px 10px;
       text-align: center;

--- a/src/sass/_navTabs.scss
+++ b/src/sass/_navTabs.scss
@@ -7,11 +7,12 @@
     display: grid;
     grid-template-columns: repeat(auto-fill,minmax(150px, 1fr));
     .tab {
-      text-align: center;
-      padding: 5px 10px;
-      font-size: 13px;
-      background-color: $bg-gray-medium-4;
+      background-color: $dos-blue;
       border-top: 3px solid $bg-gray-medium-4;
+      color: $color-white;
+      font-size: 13px;
+      padding: 5px 10px;
+      text-align: center;
     }
     .tab-active {
       background-color: $color-white;


### PR DESCRIPTION
To-do:

- [x] Remove headers from existing tabs - going forward tabs will not have headers (Language History tab: remove Language History ( # ) header)
- [x] On Scroll, the tabs should stay in view
- [x] Language Component on Profile View should be unchanged