### PR TITLE
abl sort presist TM-2802

### DIFF
--- a/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
@@ -4,7 +4,7 @@ import Skeleton from 'react-loading-skeleton';
 import { get, keys, omit } from 'lodash';
 import { checkFlag } from 'flags';
 import { formatDate, getCustomLocation, useCloseSwalOnUnmount } from 'utilities';
-import { availableBidderEditData, availableBiddersFetchData, availableBiddersToggleUser } from 'actions/availableBidders';
+import { availableBidderEditData, availableBiddersToggleUser } from 'actions/availableBidders';
 import { useDispatch } from 'react-redux';
 import {
   NO_BUREAU, NO_CDO, NO_COMMENTS, NO_DATE, NO_END_DATE, NO_GRADE, NO_LANGUAGE,
@@ -226,13 +226,9 @@ const AvailableBidderRow = (props) => {
   const dispatch = useDispatch();
 
   const submitAction = (userInputs) => {
+    // persisitng sort
     dispatch(availableBidderEditData(id, userInputs, sort));
     swal.close();
-  };
-
-  // persisitng sort
-  const fetchData = (isExternalorInteralView, sortType) => {
-    dispatch(availableBiddersFetchData(isExternalorInteralView, sortType));
   };
 
   // See sweet alert library docs
@@ -255,9 +251,6 @@ const AvailableBidderRow = (props) => {
             formattedCreated,
             stepLetterOne,
             stepLetterTwo }}
-          isCDOorAO={isCDOorAO}
-          fetchData={fetchData}
-          sort={sort}
         />
       ),
     });
@@ -303,7 +296,7 @@ const AvailableBidderRow = (props) => {
               {
                 status === 'OC' || status === 'UA' ?
                   <Tooltip
-                    title={shared ? 'Unshare with External CDA View' : 'Share with External CDA View'}
+                    title={shared ? 'Unshare with External CDA' : 'Share with External CDA'}
                     arrow
                     offset={-95}
                     position="top-end"
@@ -319,7 +312,7 @@ const AvailableBidderRow = (props) => {
                   </Tooltip>
                   :
                   <Tooltip
-                    title={'Status must be UA or OC to share with External CDA View'}
+                    title={'Status must be UA or OC to share with External CDA'}
                     arrow
                     offset={-95}
                     position="top-end"

--- a/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
@@ -4,7 +4,7 @@ import Skeleton from 'react-loading-skeleton';
 import { get, keys, omit } from 'lodash';
 import { checkFlag } from 'flags';
 import { formatDate, getCustomLocation, useCloseSwalOnUnmount } from 'utilities';
-import { availableBidderEditData, availableBiddersToggleUser } from 'actions/availableBidders';
+import { availableBidderEditData, availableBiddersFetchData, availableBiddersToggleUser } from 'actions/availableBidders';
 import { useDispatch } from 'react-redux';
 import {
   NO_BUREAU, NO_CDO, NO_COMMENTS, NO_DATE, NO_END_DATE, NO_GRADE, NO_LANGUAGE,
@@ -226,8 +226,13 @@ const AvailableBidderRow = (props) => {
   const dispatch = useDispatch();
 
   const submitAction = (userInputs) => {
-    dispatch(availableBidderEditData(id, userInputs));
+    dispatch(availableBidderEditData(id, userInputs, sort));
     swal.close();
+  };
+
+  // persisitng sort
+  const fetchData = (isExternalorInteralView, sortType) => {
+    dispatch(availableBiddersFetchData(isExternalorInteralView, sortType));
   };
 
   // See sweet alert library docs
@@ -250,6 +255,8 @@ const AvailableBidderRow = (props) => {
             formattedCreated,
             stepLetterOne,
             stepLetterTwo }}
+          isCDOorAO={isCDOorAO}
+          fetchData={fetchData}
           sort={sort}
         />
       ),
@@ -296,21 +303,23 @@ const AvailableBidderRow = (props) => {
               {
                 status === 'OC' || status === 'UA' ?
                   <Tooltip
-                    title={shared ? 'Unshare with Bureaus' : 'Share with Bureaus'}
+                    title={shared ? 'Unshare with External CDA View' : 'Share with External CDA View'}
                     arrow
                     offset={-95}
                     position="top-end"
                     tabIndex="0"
                   >
                     <InteractiveElement
-                      onClick={() => dispatch(availableBidderEditData(id, { is_shared: !shared }))}
+                      onClick={() =>
+                        dispatch(availableBidderEditData(id, { is_shared: !shared }, sort))
+                      }
                     >
                       <FA name={shared ? 'building' : 'building-o'} className="fa-lg" />
                     </InteractiveElement>
                   </Tooltip>
                   :
                   <Tooltip
-                    title={'Status must be UA or OC to share with bureau'}
+                    title={'Status must be UA or OC to share with External CDA View'}
                     arrow
                     offset={-95}
                     position="top-end"
@@ -327,7 +336,7 @@ const AvailableBidderRow = (props) => {
                 tabIndex="0"
               >
                 <InteractiveElement
-                  onClick={() => dispatch(availableBiddersToggleUser(id, true, true))}
+                  onClick={() => dispatch(availableBiddersToggleUser(id, true, true, sort))}
                 >
                   <FA name="trash-o" className="fa-lg" />
                 </InteractiveElement>

--- a/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
@@ -23,7 +23,7 @@ const useStepLetter = () => checkFlag('flags.step_letters');
 
 
 const AvailableBidderRow = (props) => {
-  const { bidder, CDOView, isLoading, isCDO, isAO, isPost, bureaus } = props;
+  const { bidder, CDOView, isLoading, isCDO, isAO, isPost, bureaus, sort } = props;
   const isCDOorAO = (isCDO || isAO);
 
   useCloseSwalOnUnmount();
@@ -250,6 +250,7 @@ const AvailableBidderRow = (props) => {
             formattedCreated,
             stepLetterOne,
             stepLetterTwo }}
+          sort={sort}
         />
       ),
     });
@@ -346,6 +347,7 @@ AvailableBidderRow.propTypes = {
   isAO: PropTypes.bool,
   isPost: PropTypes.bool,
   bureaus: FILTER,
+  sort: PropTypes.string,
 };
 
 AvailableBidderRow.defaultProps = {
@@ -356,6 +358,7 @@ AvailableBidderRow.defaultProps = {
   isAO: false,
   isPost: false,
   bureaus: [],
+  sort: 'Name',
 };
 
 export default AvailableBidderRow;

--- a/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
@@ -24,7 +24,7 @@ const useStepLetter = () => checkFlag('flags.step_letters');
 
 const AvailableBidderRow = (props) => {
   const { bidder, CDOView, isLoading, isCDO, isAO, isPost, bureaus, sort } = props;
-  const isCDOorAO = (isCDO || isAO);
+  const isInternal = (isCDO || isAO);
 
   useCloseSwalOnUnmount();
 
@@ -191,7 +191,7 @@ const AvailableBidderRow = (props) => {
     // $abl-actions-td and $abl-gray-config variables
     const comments$ = isModal ? get(bidder, 'available_bidder_details.comments') || NO_COMMENTS : commentsToolTip;
     const ted$ = isModal ? formattedTedTooltip : tedToolTip;
-    return isCDOorAO ? omit({
+    return isInternal ? omit({
       name: (<Link to={`/profile/public/${id}${isAO ? '/bureau' : ''}`}>{name}</Link>),
       status: getStatus(),
       step_letters: stepLettersToolTip,
@@ -226,7 +226,6 @@ const AvailableBidderRow = (props) => {
   const dispatch = useDispatch();
 
   const submitAction = (userInputs) => {
-    // persisitng sort
     dispatch(availableBidderEditData(id, userInputs, sort));
     swal.close();
   };
@@ -278,8 +277,8 @@ const AvailableBidderRow = (props) => {
         })
       }
       {
-        isLoading && isCDOorAO ? <td><Skeleton /></td> :
-          isCDOorAO &&
+        isLoading && isInternal ? <td><Skeleton /></td> :
+          isInternal &&
           <td>
             <div className="ab-action-buttons">
               <Tooltip

--- a/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
@@ -25,7 +25,7 @@ const AvailableBidderTable = props => {
   // Local state
   // Toggle view state within CDO version
   const [cdoView, setCdoView] = useState(true);
-  const [sort, setSort] = useState('Name');
+  const [sort, setSort] = useState('Grade');
   const [exportIsLoading, setExportIsLoading] = useState(false);
 
   // App state
@@ -41,7 +41,9 @@ const AvailableBidderTable = props => {
 
   const bidders = isLoading ? [...new Array(10)] : get(biddersData, 'results', []);
 
+  console.log('original sort', sort);
   const prevSort = usePrevious(sort);
+  console.log('prev sort', prevSort);
 
   // Actions
   const dispatch = useDispatch();
@@ -225,6 +227,7 @@ const AvailableBidderTable = props => {
                     isPost={isPost}
                     isLoading={isLoading}
                     bureaus={bureaus}
+                    sort={sort}
                   />
                 ))
               }

--- a/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
@@ -25,7 +25,7 @@ const AvailableBidderTable = props => {
   // Local state
   // Toggle view state within CDO version
   const [cdoView, setCdoView] = useState(true);
-  const [sort, setSort] = useState('Grade');
+  const [sort, setSort] = useState('Name');
   const [exportIsLoading, setExportIsLoading] = useState(false);
 
   // App state
@@ -41,9 +41,7 @@ const AvailableBidderTable = props => {
 
   const bidders = isLoading ? [...new Array(10)] : get(biddersData, 'results', []);
 
-  console.log('original sort', sort);
   const prevSort = usePrevious(sort);
-  console.log('prev sort', prevSort);
 
   // Actions
   const dispatch = useDispatch();
@@ -98,7 +96,7 @@ const AvailableBidderTable = props => {
 
   let title = '';
   if (isCDOorAO) {
-    title = cdoView ? 'Internal CDA View' : 'External Bureau/Post View';
+    title = cdoView ? 'Internal CDA View' : 'External CDA View';
   }
 
   const getTitleCount = () => {
@@ -181,7 +179,7 @@ const AvailableBidderTable = props => {
                         <ToggleButton
                           labelTextLeft={
                             <Tooltip
-                              title="CDO View"
+                              title="Internal CDA View"
                               arrow
                               offset={-95}
                               position="top-end"
@@ -192,7 +190,7 @@ const AvailableBidderTable = props => {
                           }
                           labelTextRight={
                             <Tooltip
-                              title="Bureau/Post View"
+                              title="External CDA View"
                               arrow
                               offset={-95}
                               position="top-end"

--- a/src/Components/AvailableBidder/EditBidder/EditBidder.jsx
+++ b/src/Components/AvailableBidder/EditBidder/EditBidder.jsx
@@ -17,7 +17,7 @@ const DATE_FORMAT = 'MMMM d, yyyy';
 
 // eslint-disable-next-line complexity
 const EditBidder = (props) => {
-  const { name, sections, submitAction, bureaus, details } = props;
+  const { name, sections, submitAction, bureaus, details, sort } = props;
   const [status, setStatus] = useState(details.status);
   const [comment, setComment] = useState(sections.comments);
   const [ocReason, setOCReason] = useState(details.ocReason);
@@ -31,6 +31,7 @@ const EditBidder = (props) => {
   const [stepLetterTwo, setStepLetterTwo] = useState(stepLetterTwoDate);
 
   const bureauOptions = uniqBy(bureaus.data, 'code');
+  console.log('sort edit bidder', sort);
 
   // To Do: Move these to the DB/Django backend after more user feedback
   const reasons = [
@@ -367,6 +368,7 @@ EditBidder.propTypes = {
   submitAction: PropTypes.func,
   bureaus: FILTER,
   details: AB_EDIT_DETAILS_OBJECT,
+  sort: PropTypes.string,
 };
 
 EditBidder.defaultProps = {
@@ -375,6 +377,7 @@ EditBidder.defaultProps = {
   submitAction: EMPTY_FUNCTION,
   bureaus: [],
   details: {},
+  sort: 'Name',
 };
 
 export default EditBidder;

--- a/src/Components/AvailableBidder/EditBidder/EditBidder.jsx
+++ b/src/Components/AvailableBidder/EditBidder/EditBidder.jsx
@@ -17,7 +17,7 @@ const DATE_FORMAT = 'MMMM d, yyyy';
 
 // eslint-disable-next-line complexity
 const EditBidder = (props) => {
-  const { name, sections, submitAction, bureaus, details, isCDOorAO, fetchData, sort } = props;
+  const { name, sections, submitAction, bureaus, details } = props;
   const [status, setStatus] = useState(details.status);
   const [comment, setComment] = useState(sections.comments);
   const [ocReason, setOCReason] = useState(details.ocReason);
@@ -62,9 +62,6 @@ const EditBidder = (props) => {
     forEach(userInputs, (v, k) => {
       if (v === 'None listed') userInputs[k] = '';
     });
-
-    // persisitng sort
-    fetchData(isCDOorAO, sort);
 
     submitAction(userInputs);
   };
@@ -142,7 +139,7 @@ const EditBidder = (props) => {
     <div>
       <form className="available-bidder-form">
         <div className="detail">
-          <span>* Internal CDA View field only, not shared with External CDA View</span>
+          <span>* Internal CDA field only, not shared with External CDA</span>
         </div>
         <div>
           <dt>Client Name:</dt>
@@ -339,7 +336,7 @@ const EditBidder = (props) => {
           {
             status === 'OC' || status === 'UA' ?
               <Tooltip
-                title={shared ? 'Unshare with External CDA View' : 'Share with External CDA View'}
+                title={shared ? 'Unshare with External CDA' : 'Share with External CDA'}
                 {...commonTooltipProps}
               >
                 <InteractiveElement
@@ -350,7 +347,7 @@ const EditBidder = (props) => {
               </Tooltip>
               :
               <Tooltip
-                title={'Status must be UA or OC to share with External CDA View'}
+                title={'Status must be UA or OC to share with External CDA'}
                 {...commonTooltipProps}
               >
                 <dd className="ab-action-buttons"><FA name="lock" className="fa-lg" /></dd>
@@ -370,9 +367,6 @@ EditBidder.propTypes = {
   submitAction: PropTypes.func,
   bureaus: FILTER,
   details: AB_EDIT_DETAILS_OBJECT,
-  isCDOorAO: PropTypes.bool,
-  fetchData: PropTypes.func,
-  sort: PropTypes.string,
 };
 
 EditBidder.defaultProps = {
@@ -381,9 +375,6 @@ EditBidder.defaultProps = {
   submitAction: EMPTY_FUNCTION,
   bureaus: [],
   details: {},
-  isCDOorAO: false,
-  fetchData: EMPTY_FUNCTION,
-  sort: 'Name',
 };
 
 export default EditBidder;

--- a/src/Components/AvailableBidder/EditBidder/EditBidder.jsx
+++ b/src/Components/AvailableBidder/EditBidder/EditBidder.jsx
@@ -17,7 +17,7 @@ const DATE_FORMAT = 'MMMM d, yyyy';
 
 // eslint-disable-next-line complexity
 const EditBidder = (props) => {
-  const { name, sections, submitAction, bureaus, details, sort } = props;
+  const { name, sections, submitAction, bureaus, details, isCDOorAO, fetchData, sort } = props;
   const [status, setStatus] = useState(details.status);
   const [comment, setComment] = useState(sections.comments);
   const [ocReason, setOCReason] = useState(details.ocReason);
@@ -31,7 +31,6 @@ const EditBidder = (props) => {
   const [stepLetterTwo, setStepLetterTwo] = useState(stepLetterTwoDate);
 
   const bureauOptions = uniqBy(bureaus.data, 'code');
-  console.log('sort edit bidder', sort);
 
   // To Do: Move these to the DB/Django backend after more user feedback
   const reasons = [
@@ -63,6 +62,9 @@ const EditBidder = (props) => {
     forEach(userInputs, (v, k) => {
       if (v === 'None listed') userInputs[k] = '';
     });
+
+    // persisitng sort
+    fetchData(isCDOorAO, sort);
 
     submitAction(userInputs);
   };
@@ -140,7 +142,7 @@ const EditBidder = (props) => {
     <div>
       <form className="available-bidder-form">
         <div className="detail">
-          <span>* Internal CDO field only, not shared with Bureaus</span>
+          <span>* Internal CDA View field only, not shared with External CDA View</span>
         </div>
         <div>
           <dt>Client Name:</dt>
@@ -333,11 +335,11 @@ const EditBidder = (props) => {
           <dd>{details.formattedCreated}</dd>
         </div>
         <div>
-          <dt>Bureau Share:</dt>
+          <dt>External Share:</dt>
           {
             status === 'OC' || status === 'UA' ?
               <Tooltip
-                title={shared ? 'Unshare with Bureaus' : 'Share with Bureaus'}
+                title={shared ? 'Unshare with External CDA View' : 'Share with External CDA View'}
                 {...commonTooltipProps}
               >
                 <InteractiveElement
@@ -348,7 +350,7 @@ const EditBidder = (props) => {
               </Tooltip>
               :
               <Tooltip
-                title={'Status must be UA or OC to share with bureau'}
+                title={'Status must be UA or OC to share with External CDA View'}
                 {...commonTooltipProps}
               >
                 <dd className="ab-action-buttons"><FA name="lock" className="fa-lg" /></dd>
@@ -368,6 +370,8 @@ EditBidder.propTypes = {
   submitAction: PropTypes.func,
   bureaus: FILTER,
   details: AB_EDIT_DETAILS_OBJECT,
+  isCDOorAO: PropTypes.bool,
+  fetchData: PropTypes.func,
   sort: PropTypes.string,
 };
 
@@ -377,6 +381,8 @@ EditBidder.defaultProps = {
   submitAction: EMPTY_FUNCTION,
   bureaus: [],
   details: {},
+  isCDOorAO: false,
+  fetchData: EMPTY_FUNCTION,
   sort: 'Name',
 };
 

--- a/src/Components/AvailableBidder/EditBidder/__snapshots__/EditBidder.test.jsx.snap
+++ b/src/Components/AvailableBidder/EditBidder/__snapshots__/EditBidder.test.jsx.snap
@@ -9,7 +9,7 @@ exports[`EditBidders Component matches snapshot 1`] = `
       className="detail"
     >
       <span>
-        * Internal CDA View field only, not shared with External CDA View
+        * Internal CDA field only, not shared with External CDA
       </span>
     </div>
     <div>
@@ -305,7 +305,7 @@ exports[`EditBidders Component matches snapshot 1`] = `
         style={Object {}}
         tag="div"
         theme="dark"
-        title="Status must be UA or OC to share with External CDA View"
+        title="Status must be UA or OC to share with External CDA"
         touchHold={false}
         trigger="mouseenter focus"
         unmountHTMLWhenHide={false}

--- a/src/Components/AvailableBidder/EditBidder/__snapshots__/EditBidder.test.jsx.snap
+++ b/src/Components/AvailableBidder/EditBidder/__snapshots__/EditBidder.test.jsx.snap
@@ -9,7 +9,7 @@ exports[`EditBidders Component matches snapshot 1`] = `
       className="detail"
     >
       <span>
-        * Internal CDO field only, not shared with Bureaus
+        * Internal CDA View field only, not shared with External CDA View
       </span>
     </div>
     <div>
@@ -260,7 +260,7 @@ exports[`EditBidders Component matches snapshot 1`] = `
     </div>
     <div>
       <dt>
-        Bureau Share:
+        External Share:
       </dt>
       <Tooltip
         animateFill={true}
@@ -305,7 +305,7 @@ exports[`EditBidders Component matches snapshot 1`] = `
         style={Object {}}
         tag="div"
         theme="dark"
-        title="Status must be UA or OC to share with bureau"
+        title="Status must be UA or OC to share with External CDA View"
         touchHold={false}
         trigger="mouseenter focus"
         unmountHTMLWhenHide={false}

--- a/src/actions/availableBidders.js
+++ b/src/actions/availableBidders.js
@@ -122,7 +122,6 @@ export function availableBiddersIds() {
 }
 
 export function availableBiddersFetchData(isCDO, sortType = 'Name') {
-  console.log('abl fetchdata url', `${isCDO ? 'cdo' : 'bureau'}/availablebidders/?ordering=${sortType}`);
   return (dispatch) => {
     batch(() => {
       dispatch(availableBiddersFetchDataLoading(true));
@@ -154,7 +153,7 @@ export function availableBiddersFetchData(isCDO, sortType = 'Name') {
   };
 }
 
-export function availableBiddersToggleUser(id, remove, refresh = false) {
+export function availableBiddersToggleUser(id, remove, refresh = false, sortType = 'Name') {
   return (dispatch) => {
     const config = {
       method: remove ? 'delete' : 'put',
@@ -178,7 +177,7 @@ export function availableBiddersToggleUser(id, remove, refresh = false) {
           dispatch(availableBiddersToggleUserIsLoading(false));
           dispatch(availableBiddersIds());
           if (refresh) {
-            dispatch(availableBiddersFetchData(true));
+            dispatch(availableBiddersFetchData(true, sortType));
           }
         });
       })
@@ -195,7 +194,7 @@ export function availableBiddersToggleUser(id, remove, refresh = false) {
   };
 }
 
-export function availableBidderEditData(id, data) {
+export function availableBidderEditData(id, data, sortType = 'Name') {
   return (dispatch) => {
     batch(() => {
       dispatch(availableBidderEditDataLoading(true));
@@ -211,7 +210,7 @@ export function availableBidderEditData(id, data) {
           dispatch(availableBidderEditDataLoading(false));
           dispatch(availableBidderEditDataSuccess(true));
           dispatch(toastSuccess(toastMessage, toastTitle));
-          dispatch(availableBiddersFetchData(true));
+          dispatch(availableBiddersFetchData(true, sortType));
         });
       })
       .catch((err) => {

--- a/src/actions/availableBidders.js
+++ b/src/actions/availableBidders.js
@@ -122,6 +122,7 @@ export function availableBiddersIds() {
 }
 
 export function availableBiddersFetchData(isCDO, sortType = 'Name') {
+  console.log('abl fetchdata url', `${isCDO ? 'cdo' : 'bureau'}/availablebidders/?ordering=${sortType}`);
   return (dispatch) => {
     batch(() => {
       dispatch(availableBiddersFetchDataLoading(true));


### PR DESCRIPTION
**Note: To test use the network tab and verify that the correct status is being passed to `?ordering='sortType'`**

To-Do
- [x] Persist sort preferences on the ABL for the duration of a session
- [x] Updated text from `Bureau/Post` to `External CDA View`, `Bureau Share` to `External Share`, `CDO View` to `Internal CDA View`



What to test to verify sort persists:
- on delete
- on edit fields submission
- on external cda view share/remove
- on export (this wasn't impacted but for sanity/jic)
- on initial load it should be `Name` (this wasn't impacted but for sanity/jic)
- on sort (this wasn't impacted but for sanity/jic)