### PR TITLE
external/internal abl export TM-2785

### DIFF
--- a/src/Components/AvailableBidder/AvailableBidderContainer/AvailableBidderContainer.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderContainer/AvailableBidderContainer.jsx
@@ -4,26 +4,29 @@ import AvailableBidderTable from '../AvailableBidderTable';
 import AvailableBidderStats from '../AvailableBidderStats';
 
 
-const AvailableBidderContainer = ({ isCDO, isAO, isPost }) => (
-  <div className="position-manager-details bidder-manager-page">
-    <div className={'usa-grid-full profile-content-inner-container'}>
-      <div className="usa-grid-full">
-        <ProfileSectionTitle title="Available Bidders" icon="users" />
-      </div>
-      {
-        (isCDO || isAO) &&
-      <div className="usa-grid-full">
-        <AvailableBidderStats />
-      </div>
-      }
-      <div className="usa-width-one-whole">
+const AvailableBidderContainer = ({ isCDO, isAO, isPost }) => {
+  const isInternalCDA = (isCDO || isAO);
+  return (
+    <div className="position-manager-details bidder-manager-page">
+      <div className={'usa-grid-full profile-content-inner-container'}>
         <div className="usa-grid-full">
-          <AvailableBidderTable isCDO={isCDO} isAO={isAO} isPost={isPost} />
+          <ProfileSectionTitle title="Available Bidders" icon="users" />
+        </div>
+        {
+          (isInternalCDA) &&
+        <div className="usa-grid-full">
+          <AvailableBidderStats />
+        </div>
+        }
+        <div className="usa-width-one-whole">
+          <div className="usa-grid-full">
+            <AvailableBidderTable isInternalCDA={isInternalCDA} isAO={isAO} isPost={isPost} />
+          </div>
         </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 AvailableBidderContainer.propTypes = {
   isCDO: PropTypes.bool,

--- a/src/Components/AvailableBidder/AvailableBidderContainer/AvailableBidderContainer.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderContainer/AvailableBidderContainer.jsx
@@ -13,7 +13,7 @@ const AvailableBidderContainer = ({ isCDO, isAO, isPost }) => {
           <ProfileSectionTitle title="Available Bidders" icon="users" />
         </div>
         {
-          (isInternalCDA) &&
+          isInternalCDA &&
         <div className="usa-grid-full">
           <AvailableBidderStats />
         </div>

--- a/src/Components/AvailableBidder/AvailableBidderContainer/__snapshots__/AvailableBidderContainer.test.jsx.snap
+++ b/src/Components/AvailableBidder/AvailableBidderContainer/__snapshots__/AvailableBidderContainer.test.jsx.snap
@@ -29,7 +29,7 @@ exports[`AvailableBidderContainerComponent matches snapshot when CDO 1`] = `
         <AvailableBidderTable
           bidders={Array []}
           isAO={false}
-          isCDO={true}
+          isInternalCDA={true}
           isPost={false}
           onFilter={[Function]}
           onSort={[Function]}
@@ -64,7 +64,7 @@ exports[`AvailableBidderContainerComponent matches snapshot when not CDO 1`] = `
         <AvailableBidderTable
           bidders={Array []}
           isAO={false}
-          isCDO={false}
+          isInternalCDA={false}
           isPost={false}
           onFilter={[Function]}
           onSort={[Function]}

--- a/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
@@ -23,7 +23,8 @@ const useStepLetter = () => checkFlag('flags.step_letters');
 
 
 const AvailableBidderRow = (props) => {
-  const { bidder, internalCDAView, isLoading, isAO, isPost, isInternalCDA, bureaus, sort } = props;
+  const { bidder, internalViewToggle, isLoading, isAO, isPost,
+    isInternalCDA, bureaus, sort } = props;
 
   useCloseSwalOnUnmount();
 
@@ -255,7 +256,7 @@ const AvailableBidderRow = (props) => {
   };
 
   const getTRClass = () => {
-    if (internalCDAView) {
+    if (internalViewToggle) {
       return '';
     } else if (shared) {
       return 'ab-active';
@@ -341,7 +342,7 @@ const AvailableBidderRow = (props) => {
 
 AvailableBidderRow.propTypes = {
   bidder: AVAILABLE_BIDDER_OBJECT,
-  internalCDAView: PropTypes.bool,
+  internalViewToggle: PropTypes.bool,
   isLoading: PropTypes.bool,
   isAO: PropTypes.bool,
   isPost: PropTypes.bool,
@@ -352,7 +353,7 @@ AvailableBidderRow.propTypes = {
 
 AvailableBidderRow.defaultProps = {
   bidder: {},
-  internalCDAView: false,
+  internalViewToggle: false,
   isLoading: false,
   isAO: false,
   isPost: false,

--- a/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
@@ -23,8 +23,7 @@ const useStepLetter = () => checkFlag('flags.step_letters');
 
 
 const AvailableBidderRow = (props) => {
-  const { bidder, CDOView, isLoading, isCDO, isAO, isPost, bureaus, sort } = props;
-  const isInternal = (isCDO || isAO);
+  const { bidder, internalCDAView, isLoading, isAO, isPost, isInternalCDA, bureaus, sort } = props;
 
   useCloseSwalOnUnmount();
 
@@ -191,7 +190,7 @@ const AvailableBidderRow = (props) => {
     // $abl-actions-td and $abl-gray-config variables
     const comments$ = isModal ? get(bidder, 'available_bidder_details.comments') || NO_COMMENTS : commentsToolTip;
     const ted$ = isModal ? formattedTedTooltip : tedToolTip;
-    return isInternal ? omit({
+    return isInternalCDA ? omit({
       name: (<Link to={`/profile/public/${id}${isAO ? '/bureau' : ''}`}>{name}</Link>),
       status: getStatus(),
       step_letters: stepLettersToolTip,
@@ -256,7 +255,7 @@ const AvailableBidderRow = (props) => {
   };
 
   const getTRClass = () => {
-    if (CDOView) {
+    if (internalCDAView) {
       return '';
     } else if (shared) {
       return 'ab-active';
@@ -277,8 +276,8 @@ const AvailableBidderRow = (props) => {
         })
       }
       {
-        isLoading && isInternal ? <td><Skeleton /></td> :
-          isInternal &&
+        isLoading && isInternalCDA ? <td><Skeleton /></td> :
+          isInternalCDA &&
           <td>
             <div className="ab-action-buttons">
               <Tooltip
@@ -342,22 +341,22 @@ const AvailableBidderRow = (props) => {
 
 AvailableBidderRow.propTypes = {
   bidder: AVAILABLE_BIDDER_OBJECT,
-  CDOView: PropTypes.bool,
+  internalCDAView: PropTypes.bool,
   isLoading: PropTypes.bool,
-  isCDO: PropTypes.bool,
   isAO: PropTypes.bool,
   isPost: PropTypes.bool,
+  isInternalCDA: PropTypes.bool,
   bureaus: FILTER,
   sort: PropTypes.string,
 };
 
 AvailableBidderRow.defaultProps = {
   bidder: {},
-  CDOView: false,
+  internalCDAView: false,
   isLoading: false,
-  isCDO: false,
   isAO: false,
   isPost: false,
+  isInternalCDA: false,
   bureaus: [],
   sort: 'Name',
 };

--- a/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
@@ -256,7 +256,7 @@ const AvailableBidderRow = (props) => {
   };
 
   const getTRClass = () => {
-    if (internalViewToggle) {
+    if (internalViewToggle || !isInternalCDA) {
       return '';
     } else if (shared) {
       return 'ab-active';

--- a/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
@@ -20,11 +20,11 @@ const useStepLetter = () => checkFlag('flags.step_letters');
 
 const AvailableBidderTable = props => {
   const { isCDO, isAO, isPost } = props;
-  const isCDOorAO = (isCDO || isAO);
+  const isInternalCDA = (isCDO || isAO);
 
   // Local state
   // Toggle view state within CDO version
-  const [cdoView, setCdoView] = useState(true);
+  const [internalCDAView, setInternalCDAView] = useState(true);
   const [sort, setSort] = useState('Name');
   const [exportIsLoading, setExportIsLoading] = useState(false);
 
@@ -47,20 +47,20 @@ const AvailableBidderTable = props => {
   const dispatch = useDispatch();
 
   useMount(() => {
-    dispatch(availableBiddersFetchData(isCDOorAO, sort));
+    dispatch(availableBiddersFetchData(isInternalCDA, sort));
     dispatch(filtersFetchData(filterData, {}));
   });
 
   useEffect(() => {
     if (prevSort && sort && sort !== prevSort) {
-      dispatch(availableBiddersFetchData(isCDOorAO, sort));
+      dispatch(availableBiddersFetchData(isInternalCDA, sort));
     }
   }, [sort]);
 
-  let tableHeaders = isCDOorAO ? [
+  let tableHeaders = isInternalCDA ? [
     'Name',
     'Status',
-    isCDOorAO && useStepLetter() ? 'Step Letters' : undefined,
+    isInternalCDA && useStepLetter() ? 'Step Letters' : undefined,
     'Skill',
     'Grade',
     'Languages',
@@ -95,15 +95,15 @@ const AvailableBidderTable = props => {
   );
 
   let title = '';
-  if (isCDOorAO) {
-    title = cdoView ? 'Internal CDA View' : 'External CDA View';
+  if (isInternalCDA) {
+    title = internalCDAView ? 'Internal CDA View' : 'External CDA View';
   }
 
   const getTitleCount = () => {
     let bidderCountTitle = '';
     if (!isLoading) {
-      if (isCDOorAO) {
-        bidderCountTitle = cdoView ? `(${bidders.length})` : `(${bidders.filter(b => get(b, 'available_bidder_details.is_shared')).length})`;
+      if (isInternalCDA) {
+        bidderCountTitle = internalCDAView ? `(${bidders.length})` : `(${bidders.filter(b => get(b, 'available_bidder_details.is_shared')).length})`;
       } else {
         bidderCountTitle = `Shared Available Bidders (${bidders.length})`;
       }
@@ -114,7 +114,7 @@ const AvailableBidderTable = props => {
   const exportBidders = () => {
     if (!isLoading) {
       setExportIsLoading(true);
-      availableBidderExport(isCDOorAO, sort)
+      availableBidderExport(!internalCDAView && isInternalCDA ? false : isInternalCDA, sort)
         .then(() => {
           setExportIsLoading(false);
         })
@@ -130,7 +130,7 @@ const AvailableBidderTable = props => {
         <Alert
           title="Available Bidders List is Empty"
           messages={[{
-            body: isCDOorAO ?
+            body: isInternalCDA ?
               'Please navigate to the CDO Client Profiles to begin searching and adding bidders.' :
               'Please wait for CDOs to share available bidders.',
           }]}
@@ -145,6 +145,7 @@ const AvailableBidderTable = props => {
               onClick={exportBidders}
               isLoading={exportIsLoading}
               disabled={!bidders.length}
+              text={internalCDAView ? 'Export' : 'Export External View'}
             />
           </div>
         </div>
@@ -173,7 +174,7 @@ const AvailableBidderTable = props => {
                   ))
                 }
                 {
-                  isCDOorAO &&
+                  isInternalCDA &&
                     <th>
                       <div className="bureau-view-toggle">
                         <ToggleButton
@@ -185,7 +186,7 @@ const AvailableBidderTable = props => {
                               position="top-end"
                               tabIndex="0"
                             >
-                              <FA name="street-view" className={`fa-lg ${cdoView ? 'active' : ''}`} />
+                              <FA name="street-view" className={`fa-lg ${internalCDAView ? 'active' : ''}`} />
                             </Tooltip>
                           }
                           labelTextRight={
@@ -196,11 +197,11 @@ const AvailableBidderTable = props => {
                               position="top-end"
                               tabIndex="0"
                             >
-                              <FA name="building" className={`fa-lg ${!cdoView ? 'active' : ''}`} />
+                              <FA name="building" className={`fa-lg ${!internalCDAView ? 'active' : ''}`} />
                             </Tooltip>
                           }
-                          checked={!cdoView}
-                          onChange={() => setCdoView(!cdoView)}
+                          checked={!internalCDAView}
+                          onChange={() => setInternalCDAView(!internalCDAView)}
                           onColor="#888888"
                           offColor="#888888"
                           onHandleColor="#FFFFFF"
@@ -219,9 +220,9 @@ const AvailableBidderTable = props => {
                   <AvailableBidderRow
                     key={shortid.generate()}
                     bidder={bidder}
-                    CDOView={cdoView}
-                    isCDO={isCDO}
+                    internalCDAView={internalCDAView}
                     isAO={isAO}
+                    isInternalCDA={isInternalCDA}
                     isPost={isPost}
                     isLoading={isLoading}
                     bureaus={bureaus}

--- a/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
@@ -19,12 +19,12 @@ import { useMount, usePrevious } from 'hooks';
 const useStepLetter = () => checkFlag('flags.step_letters');
 
 const AvailableBidderTable = props => {
-  const { isCDO, isAO, isPost } = props;
-  const isInternalCDA = (isCDO || isAO);
+  const { isInternalCDA, isAO, isPost } = props;
 
   // Local state
   // Toggle view state within Internal CDA version
-  const [internalCDAView, setInternalCDAView] = useState(true);
+  const [internalViewToggle, setInternalViewToggle] = useState(true);
+  const [internalCDAView, setInternalCDAView] = useState(isInternalCDA);
   const [sort, setSort] = useState('Name');
   const [exportIsLoading, setExportIsLoading] = useState(false);
 
@@ -96,14 +96,14 @@ const AvailableBidderTable = props => {
 
   let title = '';
   if (isInternalCDA) {
-    title = internalCDAView ? 'Internal CDA View' : 'External CDA View';
+    title = internalViewToggle ? 'Internal CDA View' : 'External CDA View';
   }
 
   const getTitleCount = () => {
     let bidderCountTitle = '';
     if (!isLoading) {
       if (isInternalCDA) {
-        bidderCountTitle = internalCDAView ? `(${bidders.length})` : `(${bidders.filter(b => get(b, 'available_bidder_details.is_shared')).length})`;
+        bidderCountTitle = internalViewToggle ? `(${bidders.length})` : `(${bidders.filter(b => get(b, 'available_bidder_details.is_shared')).length})`;
       } else {
         bidderCountTitle = `Shared Available Bidders (${bidders.length})`;
       }
@@ -111,10 +111,15 @@ const AvailableBidderTable = props => {
     return bidderCountTitle;
   };
 
+  const internalCDAExportToggle = () => {
+    setInternalViewToggle(!internalViewToggle);
+    setInternalCDAView(!internalCDAView);
+  };
+
   const exportBidders = () => {
     if (!isLoading) {
       setExportIsLoading(true);
-      availableBidderExport(!internalCDAView && isInternalCDA ? false : isInternalCDA, sort)
+      availableBidderExport(internalCDAView, sort)
         .then(() => {
           setExportIsLoading(false);
         })
@@ -145,7 +150,7 @@ const AvailableBidderTable = props => {
               onClick={exportBidders}
               isLoading={exportIsLoading}
               disabled={!bidders.length}
-              text={internalCDAView ? 'Export' : 'Export External View'}
+              text={internalViewToggle ? 'Export' : 'Export External View'}
             />
           </div>
         </div>
@@ -176,7 +181,7 @@ const AvailableBidderTable = props => {
                 {
                   isInternalCDA &&
                     <th>
-                      <div className="external-internal-view-toggle">
+                      <div className="external-view-toggle">
                         <ToggleButton
                           labelTextLeft={
                             <Tooltip
@@ -186,7 +191,7 @@ const AvailableBidderTable = props => {
                               position="top-end"
                               tabIndex="0"
                             >
-                              <FA name="street-view" className={`fa-lg ${internalCDAView ? 'active' : ''}`} />
+                              <FA name="street-view" className={`fa-lg ${internalViewToggle ? 'active' : ''}`} />
                             </Tooltip>
                           }
                           labelTextRight={
@@ -197,11 +202,12 @@ const AvailableBidderTable = props => {
                               position="top-end"
                               tabIndex="0"
                             >
-                              <FA name="building" className={`fa-lg ${!internalCDAView ? 'active' : ''}`} />
+                              <FA name="building" className={`fa-lg ${!internalViewToggle ? 'active' : ''}`} />
                             </Tooltip>
                           }
-                          checked={!internalCDAView}
-                          onChange={() => setInternalCDAView(!internalCDAView)}
+                          checked={!internalViewToggle}
+                          // onChange={() => setInternalViewToggle(!internalViewToggle)}
+                          onChange={() => internalCDAExportToggle()}
                           onColor="#888888"
                           offColor="#888888"
                           onHandleColor="#FFFFFF"
@@ -220,7 +226,7 @@ const AvailableBidderTable = props => {
                   <AvailableBidderRow
                     key={shortid.generate()}
                     bidder={bidder}
-                    internalCDAView={internalCDAView}
+                    internalViewToggle={internalViewToggle}
                     isAO={isAO}
                     isInternalCDA={isInternalCDA}
                     isPost={isPost}
@@ -238,7 +244,7 @@ const AvailableBidderTable = props => {
 };
 
 AvailableBidderTable.propTypes = {
-  isCDO: PropTypes.bool,
+  isInternalCDA: PropTypes.bool,
   isAO: PropTypes.bool,
   isPost: PropTypes.bool,
 };
@@ -247,7 +253,7 @@ AvailableBidderTable.defaultProps = {
   bidders: [],
   onSort: EMPTY_FUNCTION,
   onFilter: EMPTY_FUNCTION,
-  isCDO: false,
+  isInternalCDA: false,
   isAO: false,
   isPost: false,
 };

--- a/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
@@ -23,7 +23,7 @@ const AvailableBidderTable = props => {
   const isInternalCDA = (isCDO || isAO);
 
   // Local state
-  // Toggle view state within CDO version
+  // Toggle view state within Internal CDA version
   const [internalCDAView, setInternalCDAView] = useState(true);
   const [sort, setSort] = useState('Name');
   const [exportIsLoading, setExportIsLoading] = useState(false);
@@ -176,7 +176,7 @@ const AvailableBidderTable = props => {
                 {
                   isInternalCDA &&
                     <th>
-                      <div className="bureau-view-toggle">
+                      <div className="external-internal-view-toggle">
                         <ToggleButton
                           labelTextLeft={
                             <Tooltip

--- a/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
@@ -23,7 +23,7 @@ const AvailableBidderTable = props => {
 
   // Local state
   // Toggle view state within Internal CDA version
-  const [internalViewToggle, setInternalViewToggle] = useState(true);
+  const [internalViewToggle, setInternalViewToggle] = useState(isInternalCDA);
   const [internalCDAView, setInternalCDAView] = useState(isInternalCDA);
   const [sort, setSort] = useState('Name');
   const [exportIsLoading, setExportIsLoading] = useState(false);
@@ -150,7 +150,7 @@ const AvailableBidderTable = props => {
               onClick={exportBidders}
               isLoading={exportIsLoading}
               disabled={!bidders.length}
-              text={internalViewToggle ? 'Export' : 'Export External View'}
+              text={internalViewToggle || !isInternalCDA ? 'Export' : 'Export External View'}
             />
           </div>
         </div>
@@ -206,7 +206,6 @@ const AvailableBidderTable = props => {
                             </Tooltip>
                           }
                           checked={!internalViewToggle}
-                          // onChange={() => setInternalViewToggle(!internalViewToggle)}
                           onChange={() => internalCDAExportToggle()}
                           onColor="#888888"
                           offColor="#888888"

--- a/src/actions/availableBidders.js
+++ b/src/actions/availableBidders.js
@@ -232,9 +232,9 @@ export function availableBidderEditData(id, data, sortType = 'Name') {
   };
 }
 
-export function availableBidderExport(cdo, isSort = 'Name') {
+export function availableBidderExport(isInternalCDAExport, isSort = 'Name') {
   return api()
-    .get(`${cdo ? '/cdo' : '/bureau'}/availablebidders/export/?ordering=${isSort}`)
+    .get(`${isInternalCDAExport ? '/cdo' : '/bureau'}/availablebidders/export/?ordering=${isSort}`)
     .then((response) => {
       downloadFromResponse(response, `Available_Bidders_${formatDate(new Date().getTime(), 'YYYY_M_D_Hms')}`);
     });

--- a/src/actions/availableBidders.js
+++ b/src/actions/availableBidders.js
@@ -232,9 +232,9 @@ export function availableBidderEditData(id, data, sortType = 'Name') {
   };
 }
 
-export function availableBidderExport(isInternalCDAExport, isSort = 'Name') {
+export function availableBidderExport(isInternalCDAView, isSort = 'Name') {
   return api()
-    .get(`${isInternalCDAExport ? '/cdo' : '/bureau'}/availablebidders/export/?ordering=${isSort}`)
+    .get(`${isInternalCDAView ? '/cdo' : '/bureau'}/availablebidders/export/?ordering=${isSort}`)
     .then((response) => {
       downloadFromResponse(response, `Available_Bidders_${formatDate(new Date().getTime(), 'YYYY_M_D_Hms')}`);
     });

--- a/src/sass/_availableBidders.scss
+++ b/src/sass/_availableBidders.scss
@@ -246,7 +246,7 @@
   }
 }
 
-.external-internal-view-toggle {
+.external-view-toggle {
   display: flex;
   justify-content: center;
 

--- a/src/sass/_availableBidders.scss
+++ b/src/sass/_availableBidders.scss
@@ -246,7 +246,7 @@
   }
 }
 
-.bureau-view-toggle {
+.external-internal-view-toggle {
   display: flex;
   justify-content: center;
 


### PR DESCRIPTION
To-Do:
- [x] `Export` turns to `Export External View` on Toggle (vice versa)
- [x] As an Internal CDA user, clicking `Export` returns the Internal View .csv (the entire ABL table, nothing is removed)
- [x] As an Internal CDA user, clicking `Export External View` returns the External View .csv (removes Status, Step Letters, Comments)
- [x] As an External CDA user, clicking `Export` returns the External View .csv