### PR TITLE
Remove data_sync_admin flag

### DIFF
--- a/src/Constants/Menu.js
+++ b/src/Constants/Menu.js
@@ -103,24 +103,22 @@ export const GET_PROFILE_MENU = () => MenuConfig([
       'glossary_editors',
     ],
     children: [
-      checkFlag('flags.data_sync_admin') ?
-        {
-          text: 'Dashboard',
-          route: '/profile/administrator/dashboard/',
-          icon: 'tachometer',
-          roles: [
-            'superuser',
-          ],
-        } : null,
-      checkFlag('flags.data_sync_admin') ?
-        {
-          text: 'Logs',
-          route: '/profile/administrator/logs/',
-          icon: 'sitemap',
-          roles: [
-            'superuser',
-          ],
-        } : null,
+      {
+        text: 'Dashboard',
+        route: '/profile/administrator/dashboard/',
+        icon: 'tachometer',
+        roles: [
+          'superuser',
+        ],
+      },
+      {
+        text: 'Logs',
+        route: '/profile/administrator/logs/',
+        icon: 'sitemap',
+        roles: [
+          'superuser',
+        ],
+      },
       {
         text: 'Statistics',
         route: '/profile/administrator/stats/',


### PR DESCRIPTION
To Test: Login as admin. Set ff `data_sync_admin` flag false. Verify you can:
- See admin dashboard menu
- See logs menu item