### PR TITLE
remove client counts flag TM-3030

### DIFF
--- a/src/Components/BidderPortfolio/BidderPortfolioPage/BidderPortfolioPage.jsx
+++ b/src/Components/BidderPortfolio/BidderPortfolioPage/BidderPortfolioPage.jsx
@@ -54,11 +54,10 @@ class BidderPortfolioPage extends Component {
       bidderPortfolioHasErrored, pageSize, queryParamUpdate, pageNumber,
       classificationsIsLoading,
       classificationsHasErrored, classifications, defaultHandshake, defaultOrdering } = this.props;
-    const navDataIsLoading = false;
     // for bidder results, however, we'll wait until everything is loaded
     const bidderPortfolioIsLoadingNotErrored = (bidderPortfolioIsLoading ||
       classificationsIsLoading) && !bidderPortfolioHasErrored && !classificationsHasErrored;
-    const isLoading = bidderPortfolioIsLoadingNotErrored || navDataIsLoading;
+    const isLoading = bidderPortfolioIsLoadingNotErrored;
     // whether or not we should use the list view
     const isListView = this.state.viewType.value === 'grid';
 
@@ -93,7 +92,6 @@ class BidderPortfolioPage extends Component {
             </div>
           </div>
           {
-            !navDataIsLoading &&
             <div>
               <BidControls
                 queryParamUpdate={queryParamUpdate}

--- a/src/Components/BidderPortfolio/BidderPortfolioPage/BidderPortfolioPage.jsx
+++ b/src/Components/BidderPortfolio/BidderPortfolioPage/BidderPortfolioPage.jsx
@@ -1,21 +1,17 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
-import { BIDDER_LIST, BIDDER_PORTFOLIO_COUNTS, CLASSIFICATIONS } from 'Constants/PropTypes';
+import { BIDDER_LIST, CLASSIFICATIONS } from 'Constants/PropTypes';
 import StaticDevContent from 'Components/StaticDevContent';
 import TotalResults from 'Components/TotalResults/TotalResults';
 import ErrorBoundary from 'Components/ErrorBoundary';
 import Spinner from '../../Spinner';
 import BidderPortfolioContainer from '../BidderPortfolioContainer';
-import TopNav from '../TopNav';
 import BidControls from '../BidControls';
 import BidderPortfolioSearch from '../BidderPortfolioSearch';
 import ProfileSectionTitle from '../../ProfileSectionTitle';
 import ExportLink from '../ExportLink';
 import EditButtons from '../EditButtons';
-import { checkFlag } from '../../../flags';
-
-const getUseClientCounts = () => checkFlag('flags.client_counts');
 
 class BidderPortfolioPage extends Component {
   constructor(props) {
@@ -53,19 +49,15 @@ class BidderPortfolioPage extends Component {
   };
 
   render() {
-    const useClientCounts = getUseClientCounts();
     const { editType } = this.state;
     const { bidderPortfolio, bidderPortfolioIsLoading, cdosLength,
       bidderPortfolioHasErrored, pageSize, queryParamUpdate, pageNumber,
-      bidderPortfolioCounts, bidderPortfolioCountsIsLoading, classificationsIsLoading,
+      classificationsIsLoading,
       classificationsHasErrored, classifications, defaultHandshake, defaultOrdering } = this.props;
     // Here we just want to check that the 'all_clients' prop exists,
     // because we want the nav section to appear
     // even when we reload the counts.
-    let navDataIsLoading = false;
-    if (useClientCounts) {
-      navDataIsLoading = bidderPortfolioCountsIsLoading && !bidderPortfolioCounts.all_clients;
-    }
+    const navDataIsLoading = false;
     // for bidder results, however, we'll wait until everything is loaded
     const bidderPortfolioIsLoadingNotErrored = (bidderPortfolioIsLoading ||
       classificationsIsLoading) && !bidderPortfolioHasErrored && !classificationsHasErrored;
@@ -106,9 +98,6 @@ class BidderPortfolioPage extends Component {
           {
             !navDataIsLoading &&
             <div>
-              { useClientCounts &&
-                <TopNav bidderPortfolioCounts={bidderPortfolioCounts} />
-              }
               <BidControls
                 queryParamUpdate={queryParamUpdate}
                 viewType={this.state.viewType.value}
@@ -168,8 +157,6 @@ BidderPortfolioPage.propTypes = {
   pageSize: PropTypes.number.isRequired,
   queryParamUpdate: PropTypes.func.isRequired,
   pageNumber: PropTypes.number.isRequired,
-  bidderPortfolioCounts: BIDDER_PORTFOLIO_COUNTS.isRequired,
-  bidderPortfolioCountsIsLoading: PropTypes.bool.isRequired,
   classificationsIsLoading: PropTypes.bool.isRequired,
   classificationsHasErrored: PropTypes.bool.isRequired,
   classifications: CLASSIFICATIONS,
@@ -179,7 +166,6 @@ BidderPortfolioPage.propTypes = {
 };
 
 BidderPortfolioPage.defaultProps = {
-  bidderPortfolioCountsIsLoading: false,
   classifications: [],
   cdosLength: 0,
 };

--- a/src/Components/BidderPortfolio/BidderPortfolioPage/BidderPortfolioPage.jsx
+++ b/src/Components/BidderPortfolio/BidderPortfolioPage/BidderPortfolioPage.jsx
@@ -54,9 +54,6 @@ class BidderPortfolioPage extends Component {
       bidderPortfolioHasErrored, pageSize, queryParamUpdate, pageNumber,
       classificationsIsLoading,
       classificationsHasErrored, classifications, defaultHandshake, defaultOrdering } = this.props;
-    // Here we just want to check that the 'all_clients' prop exists,
-    // because we want the nav section to appear
-    // even when we reload the counts.
     const navDataIsLoading = false;
     // for bidder results, however, we'll wait until everything is loaded
     const bidderPortfolioIsLoadingNotErrored = (bidderPortfolioIsLoading ||

--- a/src/Containers/BidderPortfolio/BidderPortfolio.jsx
+++ b/src/Containers/BidderPortfolio/BidderPortfolio.jsx
@@ -13,9 +13,6 @@ import { BIDDER_LIST, BIDDER_PORTFOLIO_COUNTS, CLASSIFICATIONS, EMPTY_FUNCTION }
 import { BIDDER_PORTFOLIO_PARAM_OBJECTS } from 'Constants/EndpointParams';
 import queryParamUpdate from '../queryParams';
 import BidderPortfolioPage from '../../Components/BidderPortfolio/BidderPortfolioPage';
-import { checkFlag } from '../../flags';
-
-const getUseClientCounts = () => checkFlag('flags.client_counts');
 
 class BidderPortfolio extends Component {
   constructor(props) {
@@ -35,9 +32,6 @@ class BidderPortfolio extends Component {
   UNSAFE_componentWillMount() {
     if (get(this.props, 'cdos', []).length) {
       this.getBidderPortfolio();
-      if (getUseClientCounts()) {
-        this.props.fetchBidderPortfolioCounts();
-      }
     }
     this.props.fetchBidderPortfolioCDOs();
     this.props.fetchClassifications();


### PR DESCRIPTION
**Feature Flag Part 2 Removal**
[Config File Changes PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2182)

This was deprecated/set to false. Finally removing.

When the `client_counts` flag is set to true, this should not show when under Client Profiles:
<img width="1091" alt="image" src="https://user-images.githubusercontent.com/55964163/173680968-21c638b7-1c86-4c4a-b70a-90244a3681d6.png">


