### PR TITLE
remove bid stats flag TM-3030

### DIFF
--- a/src/Constants/Menu.js
+++ b/src/Constants/Menu.js
@@ -83,15 +83,6 @@ export const GET_PROFILE_MENU = () => MenuConfig([
         } : null,
     ],
   },
-  checkFlag('flags.bid_stats') ?
-    {
-      text: 'Statistics',
-      icon: 'pie-chart',
-      route: '/profile/statistics',
-      roles: [
-        'cdo',
-      ],
-    } : null,
   {
     text: 'Administrator',
     route: '/profile/administrator/',


### PR DESCRIPTION
**Feature Flag Part 2 Removal**
[Config File Changes PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2182)

This was deprecated/set to false. Finally removing.

When the `bid_stats` flag is set to true, this should not show under the menu selection:
<img width="155" alt="image" src="https://user-images.githubusercontent.com/55964163/173908949-e3756084-54c3-456e-8659-ff59d0b4135d.png">
