### PR TITLE
remove client profiles flag TM-3030

### DIFF
--- a/src/Constants/Menu.js
+++ b/src/Constants/Menu.js
@@ -310,18 +310,17 @@ export const GET_PROFILE_MENU = () => MenuConfig([
       'cdo',
     ],
     children: [
-      checkFlag('flags.client_profiles') ?
-        {
-          text: 'Client Profiles', // aka Bidder Portfolio
-          route: '/profile/cdo/bidderportfolio',
-          icon: 'address-book',
-          roles: [
-            'cdo',
-          ],
-          params: {
-            type: 'all',
-          },
-        } : null,
+      {
+        text: 'Client Profiles', // aka Bidder Portfolio
+        route: '/profile/cdo/bidderportfolio',
+        icon: 'address-book',
+        roles: [
+          'cdo',
+        ],
+        params: {
+          type: 'all',
+        },
+      },
       checkFlag('flags.available_bidders') ?
         {
           text: 'Available Bidders',


### PR DESCRIPTION
**Feature Flag Part 2 Removal**
[Config File Changes PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2182)

When the `client_profiles` flag is set to false, `Client Profiles` should show when under the CDO Menu:
<img width="145" alt="image" src="https://user-images.githubusercontent.com/55964163/173915820-efeba312-5117-4c4f-a7dc-700e8eecd558.png">
