### PR TITLE
remove tandem flag TM-3030

### DIFF
--- a/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
+++ b/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
@@ -19,7 +19,6 @@ import { getPostName, mapDuplicates, propOrDefault, propSort, sortGrades, sortTo
 import { colorBlueChill } from '../../../sass/sass-vars/variables';
 
 const usePostIndicators = () => checkFlag('flags.indicators');
-const useTandem = () => checkFlag('flags.tandem');
 const useUS = () => checkFlag('flags.us_codes');
 
 class SearchFiltersContainer extends Component {
@@ -451,7 +450,6 @@ class SearchFiltersContainer extends Component {
         </div>
         <div className="tandem-toggle-button-container">
           {
-            useTandem() &&
             <ToggleButton
               labelTextRight="Tandem Search"
               checked={tandemIsSelected}

--- a/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
+++ b/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
@@ -449,14 +449,12 @@ class SearchFiltersContainer extends Component {
           />
         </div>
         <div className="tandem-toggle-button-container">
-          {
-            <ToggleButton
-              labelTextRight="Tandem Search"
-              checked={tandemIsSelected}
-              onChange={this.onTandemSearchClick}
-              onColor={colorBlueChill}
-            />
-          }
+          <ToggleButton
+            labelTextRight="Tandem Search"
+            checked={tandemIsSelected}
+            onChange={this.onTandemSearchClick}
+            onColor={colorBlueChill}
+          />
         </div>
       </div>
     );


### PR DESCRIPTION
**Feature Flag Part 2 Removal**
[Config File Changes PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2182)

When the `tandem` flag is set to false, this should still show when under position search:
<img width="265" alt="image" src="https://user-images.githubusercontent.com/55964163/173921450-34651416-0162-4808-9787-b29e7046c8ce.png">
