### PR TITLE
remove bureau flag TM-3066

### DIFF
--- a/src/Components/ProfileMenu/ProfileMenuCollapsed/__snapshots__/ProfileMenuCollapsed.test.jsx.snap
+++ b/src/Components/ProfileMenu/ProfileMenuCollapsed/__snapshots__/ProfileMenuCollapsed.test.jsx.snap
@@ -34,6 +34,13 @@ exports[`ProfileMenuCollapsedComponent matches snapshot 1`] = `
     />
     <withRouter(NavLink)
       hidden={true}
+      iconName="building"
+      key="Bureau"
+      link="/profile/bureau/positionmanager/"
+      search=""
+    />
+    <withRouter(NavLink)
+      hidden={true}
       iconName="street-view"
       key="CDO"
       link="/profile/cdo/bidderportfolio"
@@ -73,6 +80,13 @@ exports[`ProfileMenuCollapsedComponent matches snapshot when isGlossaryEditor is
       iconName="sitemap"
       key="Administrator"
       link="/profile/administrator/"
+      search=""
+    />
+    <withRouter(NavLink)
+      hidden={true}
+      iconName="building"
+      key="Bureau"
+      link="/profile/bureau/positionmanager/"
       search=""
     />
     <withRouter(NavLink)

--- a/src/Constants/Menu.js
+++ b/src/Constants/Menu.js
@@ -153,7 +153,7 @@ export const GET_PROFILE_MENU = () => MenuConfig([
       },
     ],
   },
-  checkFlag('flags.bureau') ? {
+  {
     text: 'Bureau',
     route: '/profile/bureau/positionmanager/',
     icon: 'building',
@@ -204,7 +204,7 @@ export const GET_PROFILE_MENU = () => MenuConfig([
           ],
         } : null,
     ],
-  } : null,
+  },
   checkFlag('flags.post') ? {
     text: 'Post',
     route: '/profile/post/dashboard/',


### PR DESCRIPTION
**Feature Flag Part 3 Removal**
[Config File Part 3 Changes PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2197)

When the `bureau` flag is set to false, this should show when under the Profile Menu options (expanded/collapsed views) as an Admin or Bureau user:

**Expanded**
<img width="166" alt="image" src="https://user-images.githubusercontent.com/55964163/175348606-4a73e8af-be16-4fdb-9494-4c59d5da88c1.png">

**Collapsed**
<img width="58" alt="image" src="https://user-images.githubusercontent.com/55964163/175349164-7a4484ef-b3b6-4729-8d14-6c0f642ebdb8.png">
