### PR TITLE
remove us codes flag TM-3066

### DIFF
--- a/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
+++ b/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
@@ -19,7 +19,6 @@ import { getPostName, mapDuplicates, propOrDefault, propSort, sortGrades, sortTo
 import { colorBlueChill } from '../../../sass/sass-vars/variables';
 
 const usePostIndicators = () => checkFlag('flags.indicators');
-const useUS = () => checkFlag('flags.us_codes');
 
 class SearchFiltersContainer extends Component {
   constructor(props) {
@@ -146,11 +145,6 @@ class SearchFiltersContainer extends Component {
     if (!usePostIndicators()) {
       remove(multiSelectFilterNames, f => f === 'postIndicators');
       remove(multiSelectFilterNamesTandemCommon, f => f === 'postIndicators');
-    }
-
-    if (!useUS()) {
-      remove(multiSelectFilterNames, f => f === 'unaccompaniedStatus');
-      remove(multiSelectFilterNamesTandemCommon, f => f === 'unaccompaniedStatus');
     }
 
     const blackList = []; // don't create accordions for these

--- a/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
+++ b/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
@@ -1,10 +1,9 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
-import { get, includes, indexOf, remove, sortBy } from 'lodash';
+import { get, includes, indexOf, sortBy } from 'lodash';
 import ToggleButton from 'Components/ToggleButton';
 import { FILTER_ITEMS_ARRAY, POST_DETAILS_ARRAY } from 'Constants/PropTypes';
 import { COMMON_PROPERTIES, ENDPOINT_PARAMS } from 'Constants/EndpointParams';
-import { checkFlag } from '../../../flags';
 import MultiSelectFilterContainer from '../MultiSelectFilterContainer/MultiSelectFilterContainer';
 import MultiSelectFilter from '../MultiSelectFilter/MultiSelectFilter';
 import BooleanFilterContainer from '../BooleanFilterContainer/BooleanFilterContainer';
@@ -17,8 +16,6 @@ import ProjectedVacancyFilter from '../ProjectedVacancyFilter';
 import TandemSelectionFilter from '../TandemSelectionFilter';
 import { getPostName, mapDuplicates, propOrDefault, propSort, sortGrades, sortTods } from '../../../utilities';
 import { colorBlueChill } from '../../../sass/sass-vars/variables';
-
-const useUS = () => checkFlag('flags.us_codes');
 
 class SearchFiltersContainer extends Component {
   constructor(props) {
@@ -141,11 +138,6 @@ class SearchFiltersContainer extends Component {
       'hardToFill'];
     const multiSelectFilterNamesTandem2 = ['bidSeason-tandem', 'bidCycle-tandem', 'skill-tandem', 'grade-tandem',
       'region-tandem', 'tod-tandem', 'language-tandem', 'handshake-tandem', 'hardToFill-tandem'];
-
-    if (!useUS()) {
-      remove(multiSelectFilterNames, f => f === 'unaccompaniedStatus');
-      remove(multiSelectFilterNamesTandemCommon, f => f === 'unaccompaniedStatus');
-    }
 
     const blackList = []; // don't create accordions for these
 


### PR DESCRIPTION
**Feature Flag Part 3 Removal**
[Config File Part 3 Changes PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2197)


When the `us_codes` flag is set to false, the `Unaccompanied Status` Filter option should show when under Open Positions/PV (tandem option as well):

**OP w/o Tandem**
<img width="266" alt="image" src="https://user-images.githubusercontent.com/55964163/175366328-a576d9f1-14dd-4615-b791-5c5e40838974.png">

**OP w/ Tandem**
<img width="224" alt="image" src="https://user-images.githubusercontent.com/55964163/175366419-9c3a7a3c-cd05-41ec-a734-bb957596cae1.png">

**PV w/o Tandem**
<img width="269" alt="image" src="https://user-images.githubusercontent.com/55964163/175366502-4d9013cf-aa51-4c5e-bac6-ead5d1c47ce9.png">

**PV w/ Tandem**
<img width="225" alt="image" src="https://user-images.githubusercontent.com/55964163/175366461-472d83b1-1f2a-4634-8bc1-884f7575ec45.png">
