### PR TITLE
remove ao flag TM-3066

### DIFF
--- a/src/Components/ProfileMenu/ProfileMenuCollapsed/__snapshots__/ProfileMenuCollapsed.test.jsx.snap
+++ b/src/Components/ProfileMenu/ProfileMenuCollapsed/__snapshots__/ProfileMenuCollapsed.test.jsx.snap
@@ -34,6 +34,13 @@ exports[`ProfileMenuCollapsedComponent matches snapshot 1`] = `
     />
     <withRouter(NavLink)
       hidden={true}
+      iconName="building-o"
+      key="AO"
+      link="/profile/ao/dashboard/"
+      search=""
+    />
+    <withRouter(NavLink)
+      hidden={true}
       iconName="street-view"
       key="CDO"
       link="/profile/cdo/bidderportfolio"
@@ -73,6 +80,13 @@ exports[`ProfileMenuCollapsedComponent matches snapshot when isGlossaryEditor is
       iconName="sitemap"
       key="Administrator"
       link="/profile/administrator/"
+      search=""
+    />
+    <withRouter(NavLink)
+      hidden={true}
+      iconName="building-o"
+      key="AO"
+      link="/profile/ao/dashboard/"
       search=""
     />
     <withRouter(NavLink)

--- a/src/Components/ProfileMenu/ProfileMenuCollapsed/__snapshots__/ProfileMenuCollapsed.test.jsx.snap
+++ b/src/Components/ProfileMenu/ProfileMenuCollapsed/__snapshots__/ProfileMenuCollapsed.test.jsx.snap
@@ -34,6 +34,16 @@ exports[`ProfileMenuCollapsedComponent matches snapshot 1`] = `
     />
     <withRouter(NavLink)
       hidden={true}
+      iconName="building-o"
+      key="AO"
+      link="/profile/ao/dashboard/"
+      search=""
+    />
+    <withRouter(NavLink)
+      hidden={true}
+      iconName="building"
+      key="Bureau"
+      link="/profile/bureau/positionmanager/"
       search=""
     />
     <withRouter(NavLink)
@@ -81,6 +91,16 @@ exports[`ProfileMenuCollapsedComponent matches snapshot when isGlossaryEditor is
     />
     <withRouter(NavLink)
       hidden={true}
+      iconName="building-o"
+      key="AO"
+      link="/profile/ao/dashboard/"
+      search=""
+    />
+    <withRouter(NavLink)
+      hidden={true}
+      iconName="building"
+      key="Bureau"
+      link="/profile/bureau/positionmanager/"
       search=""
     />
     <withRouter(NavLink)

--- a/src/Constants/Menu.js
+++ b/src/Constants/Menu.js
@@ -247,7 +247,7 @@ export const GET_PROFILE_MENU = () => MenuConfig([
         } : null,
     ],
   } : null,
-  checkFlag('flags.ao') ? {
+  {
     text: 'AO',
     route: '/profile/ao/dashboard/',
     icon: 'building-o',
@@ -289,7 +289,7 @@ export const GET_PROFILE_MENU = () => MenuConfig([
           ],
         } : null,
     ],
-  } : null,
+  },
   {
     text: 'CDO',
     route: '/profile/cdo/bidderportfolio',


### PR DESCRIPTION
**Feature Flag Part 3 Removal**
[Config File Part 3 Changes PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2197)

When the `ao` flag is set to false, this should show when under the Profile Menu options (expanded/collapsed views) as an Admin or AO user:

**Expanded**
<img width="160" alt="image" src="https://user-images.githubusercontent.com/55964163/175569148-98f16e8c-e392-48a2-9f30-82ce66297b7b.png">

**Collapsed**
<img width="63" alt="image" src="https://user-images.githubusercontent.com/55964163/175569180-d8a69089-12a5-49d7-abc9-f42a24e25fd0.png">

