### PR TITLE
remove available bidders flag TM-3066

### DIFF
--- a/src/Components/BidderPortfolio/BidderPortfolioStatCard/BidderPortfolioStatCard.jsx
+++ b/src/Components/BidderPortfolio/BidderPortfolioStatCard/BidderPortfolioStatCard.jsx
@@ -1,6 +1,5 @@
 import { get } from 'lodash';
 import { Link } from 'react-router-dom';
-import { checkFlag } from 'flags';
 import { BIDDER_OBJECT, CLASSIFICATIONS } from 'Constants/PropTypes';
 import { NO_GRADE, NO_LANGUAGE, NO_POST, NO_TOUR_END_DATE } from 'Constants/SystemMessages';
 import { formatDate } from 'utilities';
@@ -9,8 +8,6 @@ import SkillCodeList from '../../SkillCodeList';
 import ClientBadgeList from '../ClientBadgeList';
 import SearchAsClientButton from '../SearchAsClientButton';
 import AddToInternalListButton from '../AddToInternalListButton';
-
-const useAvailableBidders = () => checkFlag('flags.available_bidders');
 
 const BidderPortfolioStatCard = ({ userProfile, classifications }) => {
   const currentAssignmentText = get(userProfile, 'pos_location');
@@ -57,7 +54,7 @@ const BidderPortfolioStatCard = ({ userProfile, classifications }) => {
         </div>
         <div className="button-container" style={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between' }}>
           <SearchAsClientButton user={userProfile} />
-          { useAvailableBidders() && <AddToInternalListButton refKey={perdet} /> }
+          <AddToInternalListButton refKey={perdet} />
         </div>
       </div>
     </BoxShadow>

--- a/src/Components/BidderPortfolio/BidderPortfolioStatRow/BidderPortfolioStatRow.jsx
+++ b/src/Components/BidderPortfolio/BidderPortfolioStatRow/BidderPortfolioStatRow.jsx
@@ -1,7 +1,6 @@
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { checkFlag } from 'flags';
 import { NO_GRADE, NO_LANGUAGE, NO_POST, NO_TOUR_END_DATE } from 'Constants/SystemMessages';
 import { formatDate } from 'utilities';
 import { BIDDER_OBJECT, CLASSIFICATIONS } from '../../../Constants/PropTypes';
@@ -10,8 +9,6 @@ import ClientBadgeList from '../ClientBadgeList';
 import CheckboxList from '../CheckboxList';
 import SearchAsClientButton from '../SearchAsClientButton';
 import AddToInternalListButton from '../AddToInternalListButton';
-
-const useAvailableBidders = () => checkFlag('flags.available_bidders');
 
 const BidderPortfolioStatRow = ({ userProfile, showEdit, classifications }) => {
   const currentAssignmentText = get(userProfile, 'pos_location');
@@ -61,7 +58,7 @@ const BidderPortfolioStatRow = ({ userProfile, showEdit, classifications }) => {
           !showEdit &&
           <div className="button-container">
             <SearchAsClientButton user={userProfile} />
-            { useAvailableBidders() && <AddToInternalListButton refKey={perdet} /> }
+            <AddToInternalListButton refKey={perdet} />
           </div>
         }
         {

--- a/src/Constants/Menu.js
+++ b/src/Constants/Menu.js
@@ -193,16 +193,15 @@ export const GET_PROFILE_MENU = () => MenuConfig([
           'bureau_user',
         ],
       },
-      checkFlag('flags.available_bidders') ?
-        {
-          text: 'Available Bidders',
-          route: '/profile/bureau/availablebidders',
-          icon: 'users',
-          roles: [
-            'super_user',
-            'bureau_user',
-          ],
-        } : null,
+      {
+        text: 'Available Bidders',
+        route: '/profile/bureau/availablebidders',
+        icon: 'users',
+        roles: [
+          'super_user',
+          'bureau_user',
+        ],
+      },
     ],
   } : null,
   checkFlag('flags.post') ? {
@@ -235,16 +234,15 @@ export const GET_PROFILE_MENU = () => MenuConfig([
           'post_user',
         ],
       },
-      checkFlag('flags.available_bidders') ?
-        {
-          text: 'Available Bidders',
-          route: '/profile/post/availablebidders',
-          icon: 'users',
-          roles: [
-            'superuser',
-            'post_user',
-          ],
-        } : null,
+      {
+        text: 'Available Bidders',
+        route: '/profile/post/availablebidders',
+        icon: 'users',
+        roles: [
+          'superuser',
+          'post_user',
+        ],
+      },
     ],
   } : null,
   checkFlag('flags.ao') ? {
@@ -278,16 +276,15 @@ export const GET_PROFILE_MENU = () => MenuConfig([
             'superuser',
           ],
         } : null,
-      checkFlag('flags.available_bidders') ?
-        {
-          text: 'Available Bidders',
-          route: '/profile/ao/availablebidders',
-          icon: 'users',
-          roles: [
-            'ao_user',
-            'superuser',
-          ],
-        } : null,
+      {
+        text: 'Available Bidders',
+        route: '/profile/ao/availablebidders',
+        icon: 'users',
+        roles: [
+          'ao_user',
+          'superuser',
+        ],
+      },
     ],
   } : null,
   {
@@ -312,15 +309,14 @@ export const GET_PROFILE_MENU = () => MenuConfig([
           type: 'all',
         },
       },
-      checkFlag('flags.available_bidders') ?
-        {
-          text: 'Available Bidders',
-          route: '/profile/cdo/availablebidders',
-          icon: 'users',
-          roles: [
-            'cdo',
-          ],
-        } : null,
+      {
+        text: 'Available Bidders',
+        route: '/profile/cdo/availablebidders',
+        icon: 'users',
+        roles: [
+          'cdo',
+        ],
+      },
       checkFlag('flags.agenda_search') ?
         {
           text: 'Employee Agendas',


### PR DESCRIPTION
**Feature Flag Part 3 Removal**
[Config File Part 3 Changes PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2197)

When the `available_bidders` flag is set to false, the `Available Bidders` menu option should show when under the Profile Menu options as an AO, Bureau, CDO, or Post user:

<img width="155" alt="image" src="https://user-images.githubusercontent.com/55964163/175620388-06b6d458-2ec4-418c-9ab7-46ac6d65ae30.png">

