### PR TITLE
remove classifications flag TM-3066

### DIFF
--- a/src/Components/ProfileDashboard/Classifications/Classifications.jsx
+++ b/src/Components/ProfileDashboard/Classifications/Classifications.jsx
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 import { updateClassifications } from 'actions/classifications';
 import { CLASSIFICATIONS, CLIENT_CLASSIFICATIONS, EMPTY_FUNCTION } from 'Constants/PropTypes';
 import { orderClassifications } from 'Components/BidderPortfolio/helpers';
-import { checkFlag } from 'flags';
 import SectionTitle from '../SectionTitle';
 import CheckboxList from '../../BidderPortfolio/CheckboxList';
 
@@ -57,9 +56,6 @@ const Classifications = props => {
     }
   };
 
-  const useClassificationsEditor = () => checkFlag('flags.classifications');
-  const displayClassificationsEditor = useClassificationsEditor() && isPublic;
-
   const classifications$ = orderClassifications(classifications);
 
   return (
@@ -83,7 +79,7 @@ const Classifications = props => {
         </div>
       </div>
       {
-        !editView && displayClassificationsEditor &&
+        !editView &&
         <div className="section-padded-inner-container small-link-container view-more-link-centered">
           <button className="unstyled-button classifications-checkbox" onClick={() => setEditView(true)}>
             <FA

--- a/src/Components/ProfileDashboard/Classifications/Classifications.jsx
+++ b/src/Components/ProfileDashboard/Classifications/Classifications.jsx
@@ -79,7 +79,7 @@ const Classifications = props => {
         </div>
       </div>
       {
-        !editView &&
+        !editView && isPublic &&
         <div className="section-padded-inner-container small-link-container view-more-link-centered">
           <button className="unstyled-button classifications-checkbox" onClick={() => setEditView(true)}>
             <FA


### PR DESCRIPTION
**Feature Flag Part 3 Removal**
[Config File Part 3 Changes PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2197)

When the `classifications` flag is set to false, the `Edit Classifications` button should show when viewing a client's public profile.

<img width="482" alt="image" src="https://user-images.githubusercontent.com/55964163/175655880-3fbf7f19-517d-4211-a730-a0d7e8c044d7.png">




