### PR TITLE
remove post flag TM-3066

### DIFF
--- a/src/Components/ProfileMenu/ProfileMenuCollapsed/__snapshots__/ProfileMenuCollapsed.test.jsx.snap
+++ b/src/Components/ProfileMenu/ProfileMenuCollapsed/__snapshots__/ProfileMenuCollapsed.test.jsx.snap
@@ -39,6 +39,13 @@ exports[`ProfileMenuCollapsedComponent matches snapshot 1`] = `
       link="/profile/cdo/bidderportfolio"
       search=""
     />
+    <withRouter(NavLink)
+      hidden={true}
+      iconName="building"
+      key="Post"
+      link="/profile/post/dashboard/"
+      search=""
+    />
   </NavLinksContainer>
 </div>
 `;
@@ -80,6 +87,13 @@ exports[`ProfileMenuCollapsedComponent matches snapshot when isGlossaryEditor is
       iconName="street-view"
       key="CDO"
       link="/profile/cdo/bidderportfolio"
+      search=""
+    />
+    <withRouter(NavLink)
+      hidden={true}
+      iconName="building"
+      key="Post"
+      link="/profile/post/dashboard/"
       search=""
     />
   </NavLinksContainer>

--- a/src/Constants/Menu.js
+++ b/src/Constants/Menu.js
@@ -204,7 +204,7 @@ export const GET_PROFILE_MENU = () => MenuConfig([
           ],
         } : null,
     ],
-  } : null,
+  },
   {
     text: 'Post',
     route: '/profile/post/dashboard/',

--- a/src/Constants/Menu.js
+++ b/src/Constants/Menu.js
@@ -205,7 +205,7 @@ export const GET_PROFILE_MENU = () => MenuConfig([
         } : null,
     ],
   } : null,
-  checkFlag('flags.post') ? {
+  {
     text: 'Post',
     route: '/profile/post/dashboard/',
     icon: 'building',
@@ -246,7 +246,7 @@ export const GET_PROFILE_MENU = () => MenuConfig([
           ],
         } : null,
     ],
-  } : null,
+  },
   checkFlag('flags.ao') ? {
     text: 'AO',
     route: '/profile/ao/dashboard/',


### PR DESCRIPTION
**Feature Flag Part 3 Removal**
[Config File Part 3 Changes PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2197)

When the `post` flag is set to false, this should show when under the Profile Menu options (expanded/collapsed views) as an Admin or Post user:

**Expanded**
<img width="155" alt="image" src="https://user-images.githubusercontent.com/55964163/175659624-9e6aab77-24cd-4b7f-acc8-4b42a47c058a.png">

**Collapsed**
<img width="64" alt="image" src="https://user-images.githubusercontent.com/55964163/175659649-e8a19cf2-6589-489c-9abf-edc17b79552a.png">

