### PR TITLE
remove step letters flag TM-3066

### DIFF
--- a/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import Skeleton from 'react-loading-skeleton';
-import { get, keys, omit } from 'lodash';
-import { checkFlag } from 'flags';
+import { get, keys } from 'lodash';
 import { formatDate, getCustomLocation, useCloseSwalOnUnmount } from 'utilities';
 import { availableBidderEditData, availableBiddersToggleUser } from 'actions/availableBidders';
 import { useDispatch } from 'react-redux';
@@ -18,9 +17,6 @@ import { Tooltip } from 'react-tippy';
 import swal from '@sweetalert/with-react';
 import { AVAILABLE_BIDDER_OBJECT, FILTER } from 'Constants/PropTypes';
 import SkillCodeList from '../../SkillCodeList';
-
-const useStepLetter = () => checkFlag('flags.step_letters');
-
 
 const AvailableBidderRow = (props) => {
   const { bidder, internalViewToggle, isLoading, isAO, isPost,
@@ -214,7 +210,7 @@ const AvailableBidderRow = (props) => {
     // $abl-actions-td and $abl-gray-config variables
     const comments$ = isModal ? get(bidder, 'available_bidder_details.comments') || NO_COMMENTS : commentsToolTip;
     const ted$ = isModal ? formattedTedTooltip : tedToolTip;
-    return isInternalCDA ? omit({
+    return isInternalCDA ? {
       name: (<Link to={`/profile/public/${id}${isAO ? '/bureau' : ''}`}>{name}</Link>),
       status: getStatus(),
       step_letters: stepLettersToolTip,
@@ -226,7 +222,7 @@ const AvailableBidderRow = (props) => {
       cdo: cdo ? getCDO() : NO_CDO,
       updated_on: updateTooltip,
       comments: comments$,
-    }, useStepLetter() ? [] : ['step_letters']) : {
+    } : {
       name: (<Link to={`/profile/public/${id}/${isPost ? 'post' : 'bureau'}`}>{name}</Link>),
       skill: <SkillCodeList skillCodes={get(bidder, 'skills')} />,
       grade: get(bidder, 'grade') || NO_GRADE,

--- a/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { checkFlag } from 'flags';
 import { EMPTY_FUNCTION } from 'Constants/PropTypes';
 import { availableBidderExport, availableBiddersFetchData } from 'actions/availableBidders';
 import { filtersFetchData } from 'actions/filters/filters';
@@ -15,8 +14,6 @@ import FA from 'react-fontawesome';
 import { Tooltip } from 'react-tippy';
 import shortid from 'shortid';
 import { useMount, usePrevious } from 'hooks';
-
-const useStepLetter = () => checkFlag('flags.step_letters');
 
 const AvailableBidderTable = props => {
   const { isInternalCDA, isAO, isPost } = props;
@@ -59,7 +56,7 @@ const AvailableBidderTable = props => {
   let tableHeaders = isInternalCDA ? [
     'Name',
     'Status',
-    isInternalCDA && useStepLetter() ? 'Step Letters' : undefined,
+    isInternalCDA ? 'Step Letters' : undefined,
     'Skill',
     'Grade',
     'Languages',

--- a/src/Components/AvailableBidder/EditBidder/EditBidder.jsx
+++ b/src/Components/AvailableBidder/EditBidder/EditBidder.jsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
-import { checkFlag } from 'flags';
 import { AB_EDIT_DETAILS_OBJECT, AB_EDIT_SECTIONS_OBJECT, EMPTY_FUNCTION, FILTER } from 'Constants/PropTypes';
 import { find, forEach, get, uniqBy } from 'lodash';
 import swal from '@sweetalert/with-react';
@@ -10,8 +9,6 @@ import InteractiveElement from 'Components/InteractiveElement';
 import DatePicker from 'react-datepicker';
 import TextareaAutosize from 'react-textarea-autosize';
 import { format } from 'date-fns-v2';
-
-const useStepLetter = () => checkFlag('flags.step_letters');
 
 const DATE_FORMAT = 'MMMM d, yyyy';
 
@@ -224,7 +221,6 @@ const EditBidder = (props) => {
           </span>
         </div>
         {
-          useStepLetter() &&
           <>
             <div>
               <dt>*Step Letter 1:</dt>


### PR DESCRIPTION
**Feature Flag Part 3 Removal**
[Config File Part 3 Changes PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2197)

When the `step_letters` flag is set to false, the `Step Letters` header should appear in the `ABL Table` and `Step Letters` should appear in the `Edit Bidder` view.

ABL Table
<img width="1348" alt="image" src="https://user-images.githubusercontent.com/55964163/175667091-d0c2f56a-4e2e-4891-84cc-afef6886241f.png">

Edit Bidder
<img width="459" alt="image" src="https://user-images.githubusercontent.com/55964163/175667124-1a244164-f127-44c0-8ba1-56e86b4c2f37.png">




