### PR TITLE
update abl error message handling TM-3069

### DIFF
--- a/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
@@ -35,7 +35,7 @@ const AvailableBidderTable = props => {
   const hasErrored = availableBiddersHasErrored;
 
   const alertTitle = !hasErrored ? 'Available Bidders List is Empty' : 'Error loading Available Bidders List';
-  const messagesBody = [
+  const alertBody = [
     !hasErrored ?
       {
         body: isInternalCDA ?
@@ -140,7 +140,7 @@ const AvailableBidderTable = props => {
       <div className="usa-width-two-thirds">
         <Alert
           title={alertTitle}
-          messages={messagesBody}
+          messages={alertBody}
         />
       </div>
       :
@@ -248,7 +248,7 @@ const AvailableBidderTable = props => {
             <Alert
               type={'error'}
               title={alertTitle}
-              messages={messagesBody}
+              messages={alertBody}
             />
           </div>
         }

--- a/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
@@ -148,12 +148,16 @@ const AvailableBidderTable = props => {
         <div className="ab-table-title-row">
           <h3>{title} {getTitleCount()}</h3>
           <div className={isInternalCDA ? 'export-button-container' : ''}>
-            <ExportButton
-              onClick={exportBidders}
-              isLoading={exportIsLoading}
-              disabled={!bidders.length}
-              text={internalViewToggle || !isInternalCDA ? 'Export' : 'Export External View'}
-            />
+            {
+              !hasErrored &&
+              <ExportButton
+                onClick={exportBidders}
+                isLoading={exportIsLoading}
+                disabled={!bidders.length}
+                text={internalViewToggle || !isInternalCDA ? 'Export' : 'Export External View'}
+              />
+
+            }
           </div>
         </div>
         <div className={`usa-width-one-whole bidder-manager-bidders ${isInternalCDA ? 'internal ' : ''}ab-lower-section`}>

--- a/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
@@ -39,7 +39,7 @@ const AvailableBidderTable = props => {
       {
         body: isInternalCDA ?
           'Please navigate to the CDO Client Profiles to begin searching and adding bidders.' :
-          'Please wait for CDOs to share available bidders.',
+          'Please wait for Internal CDAs to share available bidders.',
       } : {
         body: 'Please try again.',
       },

--- a/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
@@ -34,6 +34,7 @@ const AvailableBidderTable = props => {
   const isLoading = availableBiddersIsLoading || filtersIsLoading;
   const hasErrored = availableBiddersHasErrored;
 
+  const alertTitle = !hasErrored ? 'Available Bidders List is Empty' : 'Error loading Available Bidders List';
   const messagesBody = [
     !hasErrored ?
       {
@@ -135,11 +136,10 @@ const AvailableBidderTable = props => {
   };
 
   return (
-    !bidders.length && !isLoading ?
+    !bidders.length && !isLoading && !hasErrored ?
       <div className="usa-width-two-thirds">
         <Alert
-          type={!hasErrored ? 'info' : 'error'}
-          title={!hasErrored ? 'Available Bidders List is Empty' : 'Error loading Available Bidders List'}
+          title={alertTitle}
           messages={messagesBody}
         />
       </div>
@@ -242,6 +242,16 @@ const AvailableBidderTable = props => {
             </table>
           }
         </div>
+        {
+          hasErrored &&
+          <div className="usa-width-one-whole">
+            <Alert
+              type={'error'}
+              title={alertTitle}
+              messages={messagesBody}
+            />
+          </div>
+        }
       </>
   );
 };

--- a/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
@@ -27,10 +27,23 @@ const AvailableBidderTable = props => {
   // App state
   const biddersData = useSelector(state => state.availableBiddersFetchDataSuccess);
   const availableBiddersIsLoading = useSelector(state => state.availableBiddersFetchDataLoading);
+  const availableBiddersHasErrored = useSelector(state => state.availableBiddersFetchDataErrored);
   const filtersIsLoading = useSelector(state => state.filtersIsLoading);
   const filterData = useSelector(state => state.filters);
 
   const isLoading = availableBiddersIsLoading || filtersIsLoading;
+  const hasErrored = availableBiddersHasErrored;
+
+  const messagesBody = [
+    !hasErrored ?
+      {
+        body: isInternalCDA ?
+          'Please navigate to the CDO Client Profiles to begin searching and adding bidders.' :
+          'Please wait for CDOs to share available bidders.',
+      } : {
+        body: 'Please try again.',
+      },
+  ];
 
 
   const bureaus = (get(filterData, 'filters') || []).find(f => f.item.description === 'region');
@@ -125,12 +138,9 @@ const AvailableBidderTable = props => {
     !bidders.length && !isLoading ?
       <div className="usa-width-two-thirds">
         <Alert
-          title="Available Bidders List is Empty"
-          messages={[{
-            body: isInternalCDA ?
-              'Please navigate to the CDO Client Profiles to begin searching and adding bidders.' :
-              'Please wait for CDOs to share available bidders.',
-          }]}
+          type={!hasErrored ? 'info' : 'error'}
+          title={!hasErrored ? 'Available Bidders List is Empty' : 'Error loading Available Bidders List'}
+          messages={messagesBody}
         />
       </div>
       :


### PR DESCRIPTION
To-do

- [x] Showing the site wide red 500 error message
- [x] Updated the text for the info banner to `Internal CDAs` from `CDOs` for the `External CDA View` (need to update JIRA ticket with this for testers)
- [x] Hide Export Button on error

Can currently test by using the `Updated` sort option since it is still not working.

<img width="900" alt="image" src="https://user-images.githubusercontent.com/55964163/176755083-50f3643b-895e-4120-a64e-f4eb163620f5.png">


This info message should show if the ABL is empty

**Internal CDA View (AO/CDO)**
<img width="909" alt="image" src="https://user-images.githubusercontent.com/55964163/176756325-f6989d85-0fd7-4f13-995e-73b53d134bf3.png">

**External CDA View (Bureau/Post)**
<img width="913" alt="image" src="https://user-images.githubusercontent.com/55964163/176756692-f6bf8dc3-da63-45fd-b58c-292112908b11.png">
