### PR TITLE
Panel Meeting - Search Results Controls

### DIFF
--- a/src/Components/Panel/PanelMeetingSearch/PanelMeetingSearch.jsx
+++ b/src/Components/Panel/PanelMeetingSearch/PanelMeetingSearch.jsx
@@ -1,15 +1,71 @@
 import PropTypes from 'prop-types';
+import SelectForm from 'Components/SelectForm';
+import { PANEL_MEETINGS_PAGE_SIZES, PANEL_MEETINGS_SORT } from 'Constants/Sort';
+import ExportButton from 'Components/ExportButton';
+import { useState } from 'react';
+import { panelMeetingsExport } from 'actions/availableBidders';
 
 const PanelMeetingSearch = ({ isCDO }) => {
   const text = isCDO ? 'yes CDO' : 'no AO';
+  // const exportDisabled = true;
+  const [exportIsLoading, setExportIsLoading] = useState(false);
+  const [limit, setLimit] = useState(PANEL_MEETINGS_PAGE_SIZES.defaultSize);
+  const [ordering, setOrdering] = useState(PANEL_MEETINGS_PAGE_SIZES.defaultSort);
+
+  const pageSizes = PANEL_MEETINGS_PAGE_SIZES;
+  const sorts = PANEL_MEETINGS_SORT;
+
+  const getQuery = () => ({
+    limit,
+    ordering,
+  });
+
+  const exportPanelMeetings = () => {
+    if (!exportIsLoading) {
+      setExportIsLoading(true);
+      panelMeetingsExport(getQuery())
+        .then(() => {
+          setExportIsLoading(false);
+        })
+        .catch(() => {
+          setExportIsLoading(false);
+        });
+    }
+  };
+
   return (
     <div>
       Panel Meeting Search Page
       <div>
         Headers/Filters TBD
-      </div>
-      <div>
         isCDO: {text}
+      </div>
+      <div className="panel-results-controls-right">
+        <div className="panel-results-controls">
+          <SelectForm
+            id="panel-search-num-results"
+            options={sorts.options}
+            label="Sort by:"
+            defaultSort={ordering}
+            onSelectOption={value => setOrdering(value.target.value)}
+            // disabled={isLoading}
+          />
+          <SelectForm
+            id="panel-search-num-results"
+            options={pageSizes.options}
+            label="Results:"
+            defaultSort={limit}
+            onSelectOption={value => setLimit(value.target.value)}
+            // disabled={isLoading}
+          />
+          <div className="export-button-container">
+            <ExportButton
+              onClick={exportPanelMeetings}
+              isLoading={exportIsLoading}
+              // disabled={exportDisabled}
+            />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/Components/Panel/PanelMeetingSearch/PanelMeetingSearch.jsx
+++ b/src/Components/Panel/PanelMeetingSearch/PanelMeetingSearch.jsx
@@ -7,7 +7,6 @@ import { panelMeetingsExport } from 'actions/availableBidders'; // Replace with 
 
 const PanelMeetingSearch = ({ isCDO }) => {
   const text = isCDO ? 'yes CDO' : 'no AO';
-  // const exportDisabled = true;
   const [exportIsLoading, setExportIsLoading] = useState(false);
   const [limit, setLimit] = useState(PANEL_MEETINGS_PAGE_SIZES.defaultSize);
   const [ordering, setOrdering] = useState(PANEL_MEETINGS_SORT.defaultSort);
@@ -40,33 +39,28 @@ const PanelMeetingSearch = ({ isCDO }) => {
         Headers/Filters TBD
         isCDO: {text}
       </div>
-      <div className="panel-results-controls-right">
-        <div className="panel-results-controls">
-          <SelectForm
-            className="panel-results-select"
-            id="panel-search-results-sort"
-            options={sorts.options}
-            label="Sort by:"
-            defaultSort={ordering}
-            onSelectOption={value => setOrdering(value.target.value)}
-            // disabled={isLoading}
+      <div className="panel-results-controls">
+        <SelectForm
+          className="panel-results-select"
+          id="panel-search-results-sort"
+          options={sorts.options}
+          label="Sort by:"
+          defaultSort={ordering}
+          onSelectOption={value => setOrdering(value.target.value)}
+        />
+        <SelectForm
+          className="panel-results-select"
+          id="panel-search-num-results"
+          options={pageSizes.options}
+          label="Results:"
+          defaultSort={limit}
+          onSelectOption={value => setLimit(value.target.value)}
+        />
+        <div className="export-button-container">
+          <ExportButton
+            onClick={exportPanelMeetings}
+            isLoading={exportIsLoading}
           />
-          <SelectForm
-            className="panel-results-select"
-            id="panel-search-num-results"
-            options={pageSizes.options}
-            label="Results:"
-            defaultSort={limit}
-            onSelectOption={value => setLimit(value.target.value)}
-            // disabled={isLoading}
-          />
-          <div className="export-button-container">
-            <ExportButton
-              onClick={exportPanelMeetings}
-              isLoading={exportIsLoading}
-              // disabled={exportDisabled}
-            />
-          </div>
         </div>
       </div>
     </div>

--- a/src/Components/Panel/PanelMeetingSearch/PanelMeetingSearch.jsx
+++ b/src/Components/Panel/PanelMeetingSearch/PanelMeetingSearch.jsx
@@ -3,14 +3,14 @@ import SelectForm from 'Components/SelectForm';
 import { PANEL_MEETINGS_PAGE_SIZES, PANEL_MEETINGS_SORT } from 'Constants/Sort';
 import ExportButton from 'Components/ExportButton';
 import { useState } from 'react';
-import { panelMeetingsExport } from 'actions/availableBidders';
+import { panelMeetingsExport } from 'actions/availableBidders'; // Replace with correct Action file later
 
 const PanelMeetingSearch = ({ isCDO }) => {
   const text = isCDO ? 'yes CDO' : 'no AO';
   // const exportDisabled = true;
   const [exportIsLoading, setExportIsLoading] = useState(false);
   const [limit, setLimit] = useState(PANEL_MEETINGS_PAGE_SIZES.defaultSize);
-  const [ordering, setOrdering] = useState(PANEL_MEETINGS_PAGE_SIZES.defaultSort);
+  const [ordering, setOrdering] = useState(PANEL_MEETINGS_SORT.defaultSort);
 
   const pageSizes = PANEL_MEETINGS_PAGE_SIZES;
   const sorts = PANEL_MEETINGS_SORT;
@@ -43,7 +43,8 @@ const PanelMeetingSearch = ({ isCDO }) => {
       <div className="panel-results-controls-right">
         <div className="panel-results-controls">
           <SelectForm
-            id="panel-search-num-results"
+            className="panel-results-select"
+            id="panel-search-results-sort"
             options={sorts.options}
             label="Sort by:"
             defaultSort={ordering}
@@ -51,6 +52,7 @@ const PanelMeetingSearch = ({ isCDO }) => {
             // disabled={isLoading}
           />
           <SelectForm
+            className="panel-results-select"
             id="panel-search-num-results"
             options={pageSizes.options}
             label="Results:"

--- a/src/Components/Panel/PanelMeetingSearch/__snapshots__/PanelMeetingSearch.test.jsx.snap
+++ b/src/Components/Panel/PanelMeetingSearch/__snapshots__/PanelMeetingSearch.test.jsx.snap
@@ -4,11 +4,95 @@ exports[`EmployeeAgendaSearchComponent matches snapshot when CDO 1`] = `
 <div>
   Panel Meeting Search Page
   <div>
-    Headers/Filters TBD
-  </div>
-  <div>
-    isCDO: 
+    Headers/Filters TBD isCDO: 
     yes CDO
+  </div>
+  <div
+    className="panel-results-controls-right"
+  >
+    <div
+      className="panel-results-controls"
+    >
+      <SelectForm
+        className="panel-results-select"
+        defaultSort="meeting_date"
+        disabled={false}
+        emptyOptionText="- Select -"
+        id="panel-search-results-sort"
+        includeFirstEmptyOption={false}
+        label="Sort by:"
+        labelSrOnly={false}
+        onSelectOption={[Function]}
+        options={
+          Array [
+            Object {
+              "text": "Meeting Date Asc.",
+              "value": "meeting_date",
+            },
+            Object {
+              "text": "Meeting Date Desc.",
+              "value": "-meeting_date",
+            },
+            Object {
+              "text": "Meeting Status A-Z",
+              "value": "meeting_status",
+            },
+            Object {
+              "text": "Meeting Status Z-A",
+              "value": "-meeting_status",
+            },
+          ]
+        }
+        transformValue={[Function]}
+      />
+      <SelectForm
+        className="panel-results-select"
+        defaultSort={25}
+        disabled={false}
+        emptyOptionText="- Select -"
+        id="panel-search-num-results"
+        includeFirstEmptyOption={false}
+        label="Results:"
+        labelSrOnly={false}
+        onSelectOption={[Function]}
+        options={
+          Array [
+            Object {
+              "text": "5",
+              "value": 5,
+            },
+            Object {
+              "text": "10",
+              "value": 10,
+            },
+            Object {
+              "text": "25",
+              "value": 25,
+            },
+            Object {
+              "text": "50",
+              "value": 50,
+            },
+            Object {
+              "text": "100",
+              "value": 100,
+            },
+          ]
+        }
+        transformValue={[Function]}
+      />
+      <div
+        className="export-button-container"
+      >
+        <ExportButton
+          className=""
+          isLoading={false}
+          onClick={[Function]}
+          primaryClass="usa-button-secondary"
+          text="Export"
+        />
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -17,11 +101,95 @@ exports[`EmployeeAgendaSearchComponent matches snapshot when not CDO 1`] = `
 <div>
   Panel Meeting Search Page
   <div>
-    Headers/Filters TBD
-  </div>
-  <div>
-    isCDO: 
+    Headers/Filters TBD isCDO: 
     no AO
+  </div>
+  <div
+    className="panel-results-controls-right"
+  >
+    <div
+      className="panel-results-controls"
+    >
+      <SelectForm
+        className="panel-results-select"
+        defaultSort="meeting_date"
+        disabled={false}
+        emptyOptionText="- Select -"
+        id="panel-search-results-sort"
+        includeFirstEmptyOption={false}
+        label="Sort by:"
+        labelSrOnly={false}
+        onSelectOption={[Function]}
+        options={
+          Array [
+            Object {
+              "text": "Meeting Date Asc.",
+              "value": "meeting_date",
+            },
+            Object {
+              "text": "Meeting Date Desc.",
+              "value": "-meeting_date",
+            },
+            Object {
+              "text": "Meeting Status A-Z",
+              "value": "meeting_status",
+            },
+            Object {
+              "text": "Meeting Status Z-A",
+              "value": "-meeting_status",
+            },
+          ]
+        }
+        transformValue={[Function]}
+      />
+      <SelectForm
+        className="panel-results-select"
+        defaultSort={25}
+        disabled={false}
+        emptyOptionText="- Select -"
+        id="panel-search-num-results"
+        includeFirstEmptyOption={false}
+        label="Results:"
+        labelSrOnly={false}
+        onSelectOption={[Function]}
+        options={
+          Array [
+            Object {
+              "text": "5",
+              "value": 5,
+            },
+            Object {
+              "text": "10",
+              "value": 10,
+            },
+            Object {
+              "text": "25",
+              "value": 25,
+            },
+            Object {
+              "text": "50",
+              "value": 50,
+            },
+            Object {
+              "text": "100",
+              "value": 100,
+            },
+          ]
+        }
+        transformValue={[Function]}
+      />
+      <div
+        className="export-button-container"
+      >
+        <ExportButton
+          className=""
+          isLoading={false}
+          onClick={[Function]}
+          primaryClass="usa-button-secondary"
+          text="Export"
+        />
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/src/Components/Panel/PanelMeetingSearch/__snapshots__/PanelMeetingSearch.test.jsx.snap
+++ b/src/Components/Panel/PanelMeetingSearch/__snapshots__/PanelMeetingSearch.test.jsx.snap
@@ -8,90 +8,86 @@ exports[`EmployeeAgendaSearchComponent matches snapshot when CDO 1`] = `
     yes CDO
   </div>
   <div
-    className="panel-results-controls-right"
+    className="panel-results-controls"
   >
+    <SelectForm
+      className="panel-results-select"
+      defaultSort="meeting_date"
+      disabled={false}
+      emptyOptionText="- Select -"
+      id="panel-search-results-sort"
+      includeFirstEmptyOption={false}
+      label="Sort by:"
+      labelSrOnly={false}
+      onSelectOption={[Function]}
+      options={
+        Array [
+          Object {
+            "text": "Meeting Date Asc.",
+            "value": "meeting_date",
+          },
+          Object {
+            "text": "Meeting Date Desc.",
+            "value": "-meeting_date",
+          },
+          Object {
+            "text": "Meeting Status A-Z",
+            "value": "meeting_status",
+          },
+          Object {
+            "text": "Meeting Status Z-A",
+            "value": "-meeting_status",
+          },
+        ]
+      }
+      transformValue={[Function]}
+    />
+    <SelectForm
+      className="panel-results-select"
+      defaultSort={25}
+      disabled={false}
+      emptyOptionText="- Select -"
+      id="panel-search-num-results"
+      includeFirstEmptyOption={false}
+      label="Results:"
+      labelSrOnly={false}
+      onSelectOption={[Function]}
+      options={
+        Array [
+          Object {
+            "text": "5",
+            "value": 5,
+          },
+          Object {
+            "text": "10",
+            "value": 10,
+          },
+          Object {
+            "text": "25",
+            "value": 25,
+          },
+          Object {
+            "text": "50",
+            "value": 50,
+          },
+          Object {
+            "text": "100",
+            "value": 100,
+          },
+        ]
+      }
+      transformValue={[Function]}
+    />
     <div
-      className="panel-results-controls"
+      className="export-button-container"
     >
-      <SelectForm
-        className="panel-results-select"
-        defaultSort="meeting_date"
-        disabled={false}
-        emptyOptionText="- Select -"
-        id="panel-search-results-sort"
-        includeFirstEmptyOption={false}
-        label="Sort by:"
-        labelSrOnly={false}
-        onSelectOption={[Function]}
-        options={
-          Array [
-            Object {
-              "text": "Meeting Date Asc.",
-              "value": "meeting_date",
-            },
-            Object {
-              "text": "Meeting Date Desc.",
-              "value": "-meeting_date",
-            },
-            Object {
-              "text": "Meeting Status A-Z",
-              "value": "meeting_status",
-            },
-            Object {
-              "text": "Meeting Status Z-A",
-              "value": "-meeting_status",
-            },
-          ]
-        }
-        transformValue={[Function]}
+      <ExportButton
+        className=""
+        isLoading={false}
+        onClick={[Function]}
+        primaryClass="usa-button-secondary"
+        text="Export"
       />
-      <SelectForm
-        className="panel-results-select"
-        defaultSort={25}
-        disabled={false}
-        emptyOptionText="- Select -"
-        id="panel-search-num-results"
-        includeFirstEmptyOption={false}
-        label="Results:"
-        labelSrOnly={false}
-        onSelectOption={[Function]}
-        options={
-          Array [
-            Object {
-              "text": "5",
-              "value": 5,
-            },
-            Object {
-              "text": "10",
-              "value": 10,
-            },
-            Object {
-              "text": "25",
-              "value": 25,
-            },
-            Object {
-              "text": "50",
-              "value": 50,
-            },
-            Object {
-              "text": "100",
-              "value": 100,
-            },
-          ]
-        }
-        transformValue={[Function]}
-      />
-      <div
-        className="export-button-container"
-      >
-        <ExportButton
-          className=""
-          isLoading={false}
-          onClick={[Function]}
-          primaryClass="usa-button-secondary"
-          text="Export"
-        />
-      </div>
     </div>
   </div>
 </div>
@@ -105,90 +101,86 @@ exports[`EmployeeAgendaSearchComponent matches snapshot when not CDO 1`] = `
     no AO
   </div>
   <div
-    className="panel-results-controls-right"
+    className="panel-results-controls"
   >
+    <SelectForm
+      className="panel-results-select"
+      defaultSort="meeting_date"
+      disabled={false}
+      emptyOptionText="- Select -"
+      id="panel-search-results-sort"
+      includeFirstEmptyOption={false}
+      label="Sort by:"
+      labelSrOnly={false}
+      onSelectOption={[Function]}
+      options={
+        Array [
+          Object {
+            "text": "Meeting Date Asc.",
+            "value": "meeting_date",
+          },
+          Object {
+            "text": "Meeting Date Desc.",
+            "value": "-meeting_date",
+          },
+          Object {
+            "text": "Meeting Status A-Z",
+            "value": "meeting_status",
+          },
+          Object {
+            "text": "Meeting Status Z-A",
+            "value": "-meeting_status",
+          },
+        ]
+      }
+      transformValue={[Function]}
+    />
+    <SelectForm
+      className="panel-results-select"
+      defaultSort={25}
+      disabled={false}
+      emptyOptionText="- Select -"
+      id="panel-search-num-results"
+      includeFirstEmptyOption={false}
+      label="Results:"
+      labelSrOnly={false}
+      onSelectOption={[Function]}
+      options={
+        Array [
+          Object {
+            "text": "5",
+            "value": 5,
+          },
+          Object {
+            "text": "10",
+            "value": 10,
+          },
+          Object {
+            "text": "25",
+            "value": 25,
+          },
+          Object {
+            "text": "50",
+            "value": 50,
+          },
+          Object {
+            "text": "100",
+            "value": 100,
+          },
+        ]
+      }
+      transformValue={[Function]}
+    />
     <div
-      className="panel-results-controls"
+      className="export-button-container"
     >
-      <SelectForm
-        className="panel-results-select"
-        defaultSort="meeting_date"
-        disabled={false}
-        emptyOptionText="- Select -"
-        id="panel-search-results-sort"
-        includeFirstEmptyOption={false}
-        label="Sort by:"
-        labelSrOnly={false}
-        onSelectOption={[Function]}
-        options={
-          Array [
-            Object {
-              "text": "Meeting Date Asc.",
-              "value": "meeting_date",
-            },
-            Object {
-              "text": "Meeting Date Desc.",
-              "value": "-meeting_date",
-            },
-            Object {
-              "text": "Meeting Status A-Z",
-              "value": "meeting_status",
-            },
-            Object {
-              "text": "Meeting Status Z-A",
-              "value": "-meeting_status",
-            },
-          ]
-        }
-        transformValue={[Function]}
+      <ExportButton
+        className=""
+        isLoading={false}
+        onClick={[Function]}
+        primaryClass="usa-button-secondary"
+        text="Export"
       />
-      <SelectForm
-        className="panel-results-select"
-        defaultSort={25}
-        disabled={false}
-        emptyOptionText="- Select -"
-        id="panel-search-num-results"
-        includeFirstEmptyOption={false}
-        label="Results:"
-        labelSrOnly={false}
-        onSelectOption={[Function]}
-        options={
-          Array [
-            Object {
-              "text": "5",
-              "value": 5,
-            },
-            Object {
-              "text": "10",
-              "value": 10,
-            },
-            Object {
-              "text": "25",
-              "value": 25,
-            },
-            Object {
-              "text": "50",
-              "value": 50,
-            },
-            Object {
-              "text": "100",
-              "value": 100,
-            },
-          ]
-        }
-        transformValue={[Function]}
-      />
-      <div
-        className="export-button-container"
-      >
-        <ExportButton
-          className=""
-          isLoading={false}
-          onClick={[Function]}
-          primaryClass="usa-button-secondary"
-          text="Export"
-        />
-      </div>
     </div>
   </div>
 </div>

--- a/src/Constants/Sort.js
+++ b/src/Constants/Sort.js
@@ -220,3 +220,26 @@ export const AGENDA_EMPLOYEES_SORT = {
 };
 
 AGENDA_EMPLOYEES_SORT.defaultSort = AGENDA_EMPLOYEES_SORT.options[0].value;
+
+export const PANEL_MEETINGS_SORT = {
+  options: [
+    { value: 'meeting_date', text: 'Meeting Date Asc.' },
+    { value: '-meeting_date', text: 'Meeting Date Desc.' },
+    { value: 'meeting_status', text: 'Meeting Status A-Z' },
+    { value: '-meeting_status', text: 'Meeting Status Z-A' },
+  ],
+};
+
+PANEL_MEETINGS_SORT.defaultSort = PANEL_MEETINGS_SORT.options[0].value;
+
+export const PANEL_MEETINGS_PAGE_SIZES = {
+  options: [
+    { value: 5, text: '5' },
+    { value: 10, text: '10' },
+    { value: 25, text: '25' },
+    { value: 50, text: '50' },
+    { value: 100, text: '100' },
+  ],
+};
+
+PANEL_MEETINGS_PAGE_SIZES.defaultSize = PANEL_MEETINGS_PAGE_SIZES.options[2].value;

--- a/src/actions/availableBidders.js
+++ b/src/actions/availableBidders.js
@@ -241,7 +241,7 @@ export function availableBidderExport(isInternalCDAView, isSort = 'Name') {
     });
 }
 
-// Will move following functions to new Panel Meetings action file when it is created
+// Move following functions to new Panel Meetings Action file when it is created
 
 const convertQueryToString = query => {
   let q = pickBy(query, identity);

--- a/src/actions/availableBidders.js
+++ b/src/actions/availableBidders.js
@@ -1,5 +1,5 @@
 import { batch } from 'react-redux';
-import { get } from 'lodash';
+import { get, identity, isArray, isString, pickBy } from 'lodash';
 import { ADD_TO_INTERNAL_LIST_ERROR, ADD_TO_INTERNAL_LIST_SUCCESS,
   ADD_TO_INTERNAL_LIST_SUCCESS_TITLE, GENERIC_SUCCESS,
   INTERNAL_LIST_ERROR_TITLE, REMOVE_FROM_INTERNAL_LIST_ERROR,
@@ -9,6 +9,7 @@ import { ADD_TO_INTERNAL_LIST_ERROR, ADD_TO_INTERNAL_LIST_SUCCESS,
   UPDATE_AVAILABLE_BIDDER_SUCCESS_TITLE,
 } from 'Constants/SystemMessages';
 import { downloadFromResponse, formatDate } from 'utilities';
+import { stringify } from 'query-string';
 import { toastError, toastSuccess } from './toast';
 import api from '../api';
 
@@ -237,5 +238,30 @@ export function availableBidderExport(isInternalCDAView, isSort = 'Name') {
     .get(`${isInternalCDAView ? '/cdo' : '/bureau'}/availablebidders/export/?ordering=${isSort}`)
     .then((response) => {
       downloadFromResponse(response, `Available_Bidders_${formatDate(new Date().getTime(), 'YYYY_M_D_Hms')}`);
+    });
+}
+
+// Will move following functions to new Panel Meetings action file when it is created
+
+const convertQueryToString = query => {
+  let q = pickBy(query, identity);
+  Object.keys(q).forEach(queryk => {
+    if (isArray(q[queryk])) { q[queryk] = q[queryk].join(); }
+    if (isString(q[queryk]) && !q[queryk]) {
+      q[queryk] = undefined;
+    }
+  });
+  q = stringify(q);
+  return q;
+};
+
+export function panelMeetingsExport(query = {}) {
+  const q = convertQueryToString(query);
+  const endpoint = '/fsbid/agenda_employees/export/'; // Replace with correct endpoint when available
+  const ep = `${endpoint}?${q}`;
+  return api()
+    .get(ep)
+    .then((response) => {
+      downloadFromResponse(response, `Panel_Meetings${formatDate(new Date().getTime(), 'YYYY_M_D_Hms')}`);
     });
 }

--- a/src/sass/_panel.scss
+++ b/src/sass/_panel.scss
@@ -12,6 +12,10 @@
     div {
         align-items: baseline;
         display: flex;
+
+        label {
+            margin-right: 5px;
+        }
     }
 }
 
@@ -21,7 +25,7 @@
     background-position-x: calc(100% - 8px);
     border: 1px solid $bg-gray-dark-2;
     border-radius: 3px;
-    font-size: 0.8em;
+    font-size: 0.9em;
     height: 28px;
     overflow: hidden;
     padding: 0 1.5em 0 0.7em;

--- a/src/sass/_panel.scss
+++ b/src/sass/_panel.scss
@@ -1,8 +1,7 @@
 .panel-results-controls {
-    align-items: center;
+    align-items: baseline;
     display: flex;
     justify-content: flex-end;
-    padding: 0 0px;
 
     div:first-child {
         margin-right: 10px;
@@ -11,6 +10,11 @@
     div {
         align-items: baseline;
         display: flex;
+
+        label {
+            min-width: 6rem;
+        }
+
     }
 }
 
@@ -19,20 +23,9 @@
     display: flex;
     justify-content: right;
     padding-right: 15px;
-
-    .results-viewby-container {
-        min-width: 120px;
-    }
 }
 
-// .panel-results-controls {
-//     align-items: baseline;
-//     display: flex;
-//     justify-content: right;
-//     padding-right: 35px;
-//     margin-right: 50px;
-
-//     .results-viewby-container {
-//       min-width: 120px;
-//     }
-// }
+.panel-results-select {
+    height: 38px;
+    font-size: small;
+}

--- a/src/sass/_panel.scss
+++ b/src/sass/_panel.scss
@@ -1,0 +1,38 @@
+.panel-results-controls {
+    align-items: center;
+    display: flex;
+    justify-content: flex-end;
+    padding: 0 0px;
+
+    div:first-child {
+        margin-right: 10px;
+    }
+
+    div {
+        align-items: baseline;
+        display: flex;
+    }
+}
+
+.panel-results-controls-right {
+    align-items: center;
+    display: flex;
+    justify-content: right;
+    padding-right: 15px;
+
+    .results-viewby-container {
+        min-width: 120px;
+    }
+}
+
+// .panel-results-controls {
+//     align-items: baseline;
+//     display: flex;
+//     justify-content: right;
+//     padding-right: 35px;
+//     margin-right: 50px;
+
+//     .results-viewby-container {
+//       min-width: 120px;
+//     }
+// }

--- a/src/sass/_panel.scss
+++ b/src/sass/_panel.scss
@@ -2,6 +2,8 @@
     align-items: baseline;
     display: flex;
     justify-content: flex-end;
+    font-size: 0.8em;
+    margin-right: 10px;
 
     div:first-child {
         margin-right: 10px;
@@ -10,22 +12,20 @@
     div {
         align-items: baseline;
         display: flex;
-
-        label {
-            min-width: 6rem;
-        }
-
     }
 }
 
-.panel-results-controls-right {
-    align-items: center;
-    display: flex;
-    justify-content: right;
-    padding-right: 15px;
-}
-
 .panel-results-select {
-    height: 38px;
-    font-size: small;
+    background-color: $color-white;
+    background-image: url(/assets/img/angle-down-black.svg);
+    background-position-x: calc(100% - 8px);
+    border: 1px solid $bg-gray-dark-2;
+    border-radius: 3px;
+    font-size: 0.8em;
+    height: 28px;
+    overflow: hidden;
+    padding: 0 1.5em 0 0.7em;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    width: 130px;
 }


### PR DESCRIPTION
Current view:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/31417027/179258520-cd400102-cf6e-4d01-8c5e-979e4576c4e8.png">


Also - we discussed handling resolution changes but resizing down to 1000 px seems to be fine as is. The export button is hooked into the availableBidders action file, with the new functions added in at the bottom of the file. I've added some comments for clarity whenever we connect the backend.