### PR TITLE
Fix sort logic for abl icon

### DIFF
--- a/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
@@ -92,9 +92,11 @@ const AvailableBidderTable = props => {
   tableHeaders = tableHeaders.filter(f => f);
 
   const getSortIcon = (header) => {
-    if (header === sort) {
+    let header$ = header;
+    header$ = header$.replace('Updated', 'Update');
+    if (header$ === sort) {
       return 'sort-asc';
-    } else if (`-${header}` === sort) {
+    } else if (`-${header$}` === sort) {
       return 'sort-desc';
     }
     return 'sort';


### PR DESCRIPTION
Make sure the sort icon toggles properly - you can check using the other sorts. 
Note: Sorts aren't functional locally
