### PR TITLE
bid tracker hs register checkmark TM-3072

### DIFF
--- a/src/Components/BidTracker/BidPhaseConfig/Complete.js
+++ b/src/Components/BidTracker/BidPhaseConfig/Complete.js
@@ -224,6 +224,8 @@ export default function bidClassesFromCurrentStatus(bid = { status: 'draft' }) {
         date: HAND_SHAKE_ACCEPTED_DATE,
         title: HAND_SHAKE_NEEDS_REGISTER_TITLE,
         needsAction: false,
+        isComplete: false,
+        isCurrent: true,
         isPendingLine: true,
         hasBidPreparingTooltip: false,
         number: HAND_SHAKE_ACCEPTED_NUMBER,

--- a/src/Components/BidTracker/BidStep/BidStepIcon/BidStepIcon.jsx
+++ b/src/Components/BidTracker/BidStep/BidStepIcon/BidStepIcon.jsx
@@ -11,18 +11,12 @@ const assignClasses = (isComplete, needsAction, isCurrent, handshakeRegisterWith
     classes.push('number-icon-incomplete');
   }
 
-  if (!needsAction && isCurrent && handshakeRegisterWithAnotherBidder) {
-    classes.push('register-with-another-bidder-number-icon-is-current-no-action');
-  } else if (!needsAction && isCurrent) {
-    classes.push('number-icon-is-current-no-action')
+  if (!needsAction && isCurrent) {
+    classes.push(handshakeRegisterWithAnotherBidder? '' : 'number-icon-is-current-no-action')
   }
 
   if (needsAction && isCurrent) {
     classes.push('number-icon-needs-action');
-  }
-
-  if (handshakeRegisterWithAnotherBidder) {
-    classes.push('register-with-another-bidder-icon')
   }
   return classes.join(' ');
 };

--- a/src/Components/BidTracker/BidStep/BidStepIcon/BidStepIcon.jsx
+++ b/src/Components/BidTracker/BidStep/BidStepIcon/BidStepIcon.jsx
@@ -12,7 +12,7 @@ const assignClasses = (isComplete, needsAction, isCurrent, handshakeRegisterWith
   }
 
   if (!needsAction && isCurrent) {
-    classes.push(handshakeRegisterWithAnotherBidder? '' : 'number-icon-is-current-no-action')
+    classes.push(handshakeRegisterWithAnotherBidder ? '' : 'number-icon-is-current-no-action')
   }
 
   if (needsAction && isCurrent) {

--- a/src/Components/BidTracker/BidStep/BidSteps.jsx
+++ b/src/Components/BidTracker/BidStep/BidSteps.jsx
@@ -30,6 +30,7 @@ const BidSteps = (props, context) => {
   const bidData = bidClassesFromCurrentStatus(bid).stages || {};
   const handshakeRegisterWithAnotherBidder = get(bid, 'position_info.bid_statistics[0].has_handshake_offered')
     && showHandshakeRegsiterWithAnotherBidderOverlay(bid);
+  const handshakeNeedsRegistered = get(bid, 'status') === 'handshake_needs_registered';
   const getIcon = (status) => {
     const bidPropsAfterRegister = [APPROVED_PROP, IN_PANEL_PROP, HAND_SHAKE_ACCEPTED_PROP];
     const tooltipTitle = get(bidData[status.prop], 'tooltip.title');
@@ -81,7 +82,7 @@ const BidSteps = (props, context) => {
           `}
             title={
               <div>
-                <div className="step-title-main-text">{bidData[status.prop].title}</div>
+                <div className={`step-title-main-text${handshakeNeedsRegistered ? ' hs-needs-registered' : ''}`}>{bidData[status.prop].title}</div>
                 <div className="step-title-sub-text">{formatDate(bidData[status.prop].date)}</div>
               </div>
             }

--- a/src/sass/_bidTracker.scss
+++ b/src/sass/_bidTracker.scss
@@ -620,22 +620,6 @@ $register-hide-icon: 95%;
     border-color: $color-green-dark;
   }
 
-  // .register-with-another-bidder-icon {
-  //   span:nth-of-type(1),
-  //   span:nth-of-type(2),
-  //   span:nth-of-type(3),
-  //   span:nth-of-type(4) {
-  //     animation: none;
-  //     background: $color-green-dark-opacity50;
-  //     border-color: $color-green-dark-opacity50;
-  //   }
-  // }
-
-  // .register-with-another-bidder-number-icon-is-current-no-action {
-  //   background: $color-green-dark-opacity50;
-  //   border-color: $color-green-dark-opacity50;
-  // }
-
   .number-icon-is-current-no-action {
     background: $blue-primary;
     border-color: $blue-primary;
@@ -1078,7 +1062,7 @@ $register-hide-icon: 95%;
   .step-in-panel {
     .rc-steps-item-content {
       .step-title-main-text {
-        left: -2px;
+        left: -12px;
       }
     }
   }
@@ -1226,13 +1210,6 @@ $register-hide-icon: 95%;
       }
     }
   }
-
-  // .register-with-another-bidder-bid-steps {
-  //   .register-with-another-bidder-icon {
-  //     background: $color-green-dark-opacity50;
-  //     border-color: $color-green-dark-opacity50;
-  //   }
-  // }
 
   &.bid-tracker--priority-exists.bid-tracker--is-not-priority,
   &.bid-tracker--priority-exists.bid-tracker--is-priority {

--- a/src/sass/_bidTracker.scss
+++ b/src/sass/_bidTracker.scss
@@ -620,21 +620,21 @@ $register-hide-icon: 95%;
     border-color: $color-green-dark;
   }
 
-  .register-with-another-bidder-icon {
-    span:nth-of-type(1),
-    span:nth-of-type(2),
-    span:nth-of-type(3),
-    span:nth-of-type(4) {
-      animation: none;
-      background: $color-green-dark-opacity50;
-      border-color: $color-green-dark-opacity50;
-    }
-  }
+  // .register-with-another-bidder-icon {
+  //   span:nth-of-type(1),
+  //   span:nth-of-type(2),
+  //   span:nth-of-type(3),
+  //   span:nth-of-type(4) {
+  //     animation: none;
+  //     background: $color-green-dark-opacity50;
+  //     border-color: $color-green-dark-opacity50;
+  //   }
+  // }
 
-  .register-with-another-bidder-number-icon-is-current-no-action {
-    background: $color-green-dark-opacity50;
-    border-color: $color-green-dark-opacity50;
-  }
+  // .register-with-another-bidder-number-icon-is-current-no-action {
+  //   background: $color-green-dark-opacity50;
+  //   border-color: $color-green-dark-opacity50;
+  // }
 
   .number-icon-is-current-no-action {
     background: $blue-primary;
@@ -1223,12 +1223,12 @@ $register-hide-icon: 95%;
     }
   }
 
-  .register-with-another-bidder-bid-steps {
-    .register-with-another-bidder-icon {
-      background: $color-green-dark-opacity50;
-      border-color: $color-green-dark-opacity50;
-    }
-  }
+  // .register-with-another-bidder-bid-steps {
+  //   .register-with-another-bidder-icon {
+  //     background: $color-green-dark-opacity50;
+  //     border-color: $color-green-dark-opacity50;
+  //   }
+  // }
 
   &.bid-tracker--priority-exists.bid-tracker--is-not-priority,
   &.bid-tracker--priority-exists.bid-tracker--is-priority {

--- a/src/sass/_bidTracker.scss
+++ b/src/sass/_bidTracker.scss
@@ -1092,6 +1092,10 @@ $register-hide-icon: 95%;
       position: absolute;
       text-align: center;
     }
+    
+    .hs-needs-registered {
+      left: -15px;
+    }
   }
 
   .step-approval {


### PR DESCRIPTION
To-Do

- [x] Show number instead of green checkmark on timeline when HS W/ Another Bidder Overlay displays
- [x] HS Registered Animation should only display when the Bidder has a HS on the position
- [x] Styling for other numbers on the timeline should not be impacted unless stated above

Screenshots are below to see what the styling should show for each point on the timeline.

**Note: Should work for condensed view as well**