### PR TITLE
Bids and Assignments Ref Data

### DIFF
--- a/src/Components/Agenda/AgendaItemMaintenancePane/AgendaItemMaintenancePane.jsx
+++ b/src/Components/Agenda/AgendaItemMaintenancePane/AgendaItemMaintenancePane.jsx
@@ -137,7 +137,7 @@ const AgendaItemMaintenancePane = (props) => {
                       <option key={a.pos_num} value={a.pos_num}>
                         {/* eslint-disable-next-line react/no-unescaped-entities */}
                         '{a.status || defaultText}'
-                          in {a.org || defaultText} -
+                          in {a.org || defaultText} -&nbsp;
                         {a.pos_title || defaultText}({a.pos_num || defaultText})
                       </option>
                     ))

--- a/src/Components/Agenda/AgendaItemMaintenancePane/AgendaItemMaintenancePane.jsx
+++ b/src/Components/Agenda/AgendaItemMaintenancePane/AgendaItemMaintenancePane.jsx
@@ -26,7 +26,7 @@ const AgendaItemMaintenancePane = (props) => {
     updateSelection,
   } = props;
 
-  const defaultText = 'Coming Soon';
+  const defaultText = '';
 
   const { data: asgSepBidData, error: asgSepBidError, loading: asgSepBidLoading } = useDataLoader(api().get, `/fsbid/employee/assignments_separations_bids/${perdet}/`);
   const { data: statusData, error: statusError, loading: statusLoading } = useDataLoader(api().get, '/fsbid/agenda/statuses/');
@@ -136,7 +136,7 @@ const AgendaItemMaintenancePane = (props) => {
                     asgSepBids.map(a => (
                       <option key={a.pos_num} value={a.pos_num}>
                         {/* eslint-disable-next-line react/no-unescaped-entities */}
-                        {a.name || defaultText} '{a.status || defaultText}'
+                        '{a.status || defaultText}'
                           in {a.org || defaultText} -
                         {a.pos_title || defaultText}({a.pos_num || defaultText})
                       </option>

--- a/src/Components/Agenda/AgendaLeg/__snapshots__/AgendaLeg.test.jsx.snap
+++ b/src/Components/Agenda/AgendaLeg/__snapshots__/AgendaLeg.test.jsx.snap
@@ -70,7 +70,7 @@ exports[`AgendaLeg Component matches snapshot 1`] = `
   <div
     className="grid-col-3 grid-row-9"
   >
-    08/03/22
+    08/05/22
     <FontAwesome
       name="calendar"
       onClick={[Function]}


### PR DESCRIPTION
- Remove 'Coming Soon' since the data is now _integrated_
- Remove name field portion of the dropdown since its redundant and not included in the api response
- Remove name from assignments, bids, and separations dropdown

To-Do: Match dropdown formatting against FSBID and Story AC to confirm

Dual Merge: 
- [API PR](https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/704)
- [Mock PR](https://github.com/MetaPhase-Consulting/mock-fsbid/pull/299)
