### PR TITLE
TM-3302 Fix: Removing padding from TED AIH modal

### DIFF
--- a/src/Components/Agenda/AgendaLeg/AgendaLeg.jsx
+++ b/src/Components/Agenda/AgendaLeg/AgendaLeg.jsx
@@ -50,6 +50,7 @@ const AgendaLeg = props => {
       title: 'Tour End Date (TED)',
       closeOnEsc: true,
       button: false,
+      className: 'swal-wide',
       content: (
         <div className="ted-modal-content-container">
           <div className="ted-modal-header">

--- a/src/Components/Agenda/AgendaLeg/AgendaLeg.jsx
+++ b/src/Components/Agenda/AgendaLeg/AgendaLeg.jsx
@@ -50,7 +50,7 @@ const AgendaLeg = props => {
       title: 'Tour End Date (TED)',
       closeOnEsc: true,
       button: false,
-      className: 'swal-wide',
+      className: 'swal-no-padding',
       content: (
         <div className="ted-modal-content-container">
           <div className="ted-modal-header">

--- a/src/Components/Agenda/AgendaLeg/AgendaLeg.jsx
+++ b/src/Components/Agenda/AgendaLeg/AgendaLeg.jsx
@@ -50,7 +50,7 @@ const AgendaLeg = props => {
       title: 'Tour End Date (TED)',
       closeOnEsc: true,
       button: false,
-      className: 'swal-no-padding',
+      className: 'swal-aim-ted-calendar',
       content: (
         <div className="ted-modal-content-container">
           <div className="ted-modal-header">

--- a/src/sass/_agendaItemLegsForm.scss
+++ b/src/sass/_agendaItemLegsForm.scss
@@ -17,7 +17,7 @@
       min-height: 80px;
     }
   }
-  
+
   @each $row-num in map-values($aim-legs-sm-height-config) {
     .grid-row-#{$row-num} {
       min-height: 60px;
@@ -122,6 +122,11 @@
     margin-top: 20px;
     font-weight: bold;
     flex-basis: 100%;
+  }
+
+  .swal-wide {
+    padding: 0px;
+    width: 600px;
   }
 
 .leg-dropdown {

--- a/src/sass/_agendaItemLegsForm.scss
+++ b/src/sass/_agendaItemLegsForm.scss
@@ -124,7 +124,7 @@
     flex-basis: 100%;
   }
 
-  .swal-no-padding {
+  .swal-aim-ted-calendar {
     padding: 0px;
     width: 600px;
   }

--- a/src/sass/_agendaItemLegsForm.scss
+++ b/src/sass/_agendaItemLegsForm.scss
@@ -124,7 +124,7 @@
     flex-basis: 100%;
   }
 
-  .swal-wide {
+  .swal-no-padding {
     padding: 0px;
     width: 600px;
   }


### PR DESCRIPTION
Ticket for removing the padding around new TED AIH modal which prevented users from clicking outside the modal to close it. The padding was initially added to sweet alert for the bureau offer handshake modal as a quality of life improvement so that users wouldn't accidentally click slightly outside the modal and close everything they'd been working on. It was determined that the padding was not needed for the TED AIH modal, at least not for now.