### PR TITLE
removing arrow row highlighting for aim legs TM-3304

### DIFF
--- a/src/Components/Agenda/AgendaItemLegsForm/AgendaItemLegsForm.jsx
+++ b/src/Components/Agenda/AgendaItemLegsForm/AgendaItemLegsForm.jsx
@@ -33,7 +33,11 @@ const AgendaItemLegsForm = props => {
   const [rowHoverNum, setRowHoverNum] = useState();
 
   const onHover = row => {
-    setRowHoverNum(row);
+    // this should check the row number of the
+    // Arrow Header '' to avoid highlighting the arrow row
+    if (row !== 8) {
+      setRowHoverNum(row);
+    }
   };
 
   const onClose$ = leg => {


### PR DESCRIPTION
Removed the highlighting for the row data, but not the header column.

This is no longer showing when you hover over header section for the arrow column (in between ETA and TED)
<img width="992" alt="image" src="https://user-images.githubusercontent.com/55964163/191592824-b4fc164e-a676-4514-815a-695d922143c0.png">
