### PR TITLE
adding updated column to external abl view TM-3477

### DIFF
--- a/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
@@ -230,6 +230,7 @@ const AvailableBidderRow = (props) => {
       ted: ted$,
       current_post: currentPost,
       cdo: cdo ? getCDO() : NO_CDO,
+      updated_on: updateTooltip,
     };
   };
 

--- a/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
@@ -87,6 +87,7 @@ const AvailableBidderTable = props => {
     'TED',
     'Post',
     'CDO',
+    'Updated',
   ];
 
   tableHeaders = tableHeaders.filter(f => f);

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -232,7 +232,6 @@ $abl-actions-td: 12;
 $abl-gray-config: (
   "Status": 2,
   "Step Letter": 3,
-  "Updated On": 10,
   "Notes": 11
 );
 


### PR DESCRIPTION
Dual Merge: 
- [API PR](https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/719)

To-do
- [x] unhighlight `Updated` column for External Internal CDA View when viewing the ABL as an Internal CDA User (AO/CDO)
- [x] show `Updated` column & data when viewing the ABL as an External CDA User (Bureau/Post)
- [x] show `Updated` column and data when exporting the ABL as an Internal CDA User viewing the External CDA View
- [x] show `Updated` column and data when exporting the ABL as an External CDA User 

**Note: be sure to test as each individual user and not as an Admin to verify roles don't conflict**