### PR TITLE
TM-3451 - AIM Menu Alignment

### DIFF
--- a/src/Components/Agenda/AgendaItemMaintenancePane/AgendaItemMaintenancePane.jsx
+++ b/src/Components/Agenda/AgendaItemMaintenancePane/AgendaItemMaintenancePane.jsx
@@ -150,7 +150,6 @@ const AgendaItemMaintenancePane = (props) => {
             {
               !asgSepBidLoading && !asgSepBidError &&
                 <select
-                  id="ai-maintenance-dd-asgSepBids"
                   className={`${asgSepBidSelectClass}${legLimit ? ' asg-disabled' : ''}`}
                   defaultValue={asgSepBids}
                   onChange={(e) => addAsgSepBid(get(e, 'target.value'))}
@@ -247,7 +246,7 @@ const AgendaItemMaintenancePane = (props) => {
                     onChange={(e) => setDate(get(e, 'target.value'), true)}
                     value={selectedPanelMLDate}
                   >
-                    <option value={''}>Panel Dates - ML</option>
+                    <option value={''}>ML Dates</option>
                     {
                       panelDatesML.map(a => (
                         <option
@@ -264,7 +263,7 @@ const AgendaItemMaintenancePane = (props) => {
                     onChange={(e) => setDate(get(e, 'target.value'), false)}
                     value={selectedPanelIDDate}
                   >
-                    <option value={''}>Panel Dates - ID</option>
+                    <option value={''}>ID Dates</option>
                     {
                       panelDatesID.map(a => (
                         <option

--- a/src/sass/_agendaItemMaintenance.scss
+++ b/src/sass/_agendaItemMaintenance.scss
@@ -83,7 +83,7 @@
 
     label {
       font-weight: bold;
-      margin: 10px 10px;
+      margin: 10px 10px 10px 0;
       text-align: left;
       min-width: 160px;
     }
@@ -114,7 +114,7 @@
 
     .corrections, .remarks {
       max-width: fit-content;
-      margin: 10px;
+      margin: 10px 0;
 
       label {
         display: inline;
@@ -131,16 +131,9 @@
     }
 
     .ai-maintenance-header-dd {
-      margin-right: 10px;
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: space-between;
-      width: 94%;
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
 
-      #ai-maintenance-dd-asgSepBids {
-        max-width: fit-content;
-        margin-left: 10px;
-      }
       .asg-disabled {
         background-color: $color-gray-lighter;
         border: 1px solid $color-gray-light;
@@ -242,7 +235,13 @@
       position: absolute;
       top: 40%;
     }
-
+    @media screen and (min-width: 4000px) {
+      .ai-maintenance-header label {
+        margin: 10px;
+        min-width: 0;
+        text-align: right;
+      }
+    }
   }
 
   .maintenance-container-left-expanded {
@@ -254,6 +253,13 @@
       left: 55%;
       position: absolute;
       top: 40%;
+    }
+    @media screen and (min-width: 2300px) {
+      .ai-maintenance-header label {
+        margin: 10px;
+        min-width: 0;
+        text-align: right;
+      }
     }
   }
 

--- a/src/sass/_agendaItemMaintenance.scss
+++ b/src/sass/_agendaItemMaintenance.scss
@@ -88,7 +88,8 @@
     label {
       font-weight: bold;
       margin: 10px 10px;
-      text-align: end;
+      text-align: left;
+      min-width: 160px;
     }
 
     .back-save-btns-container {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/31417027/193684646-192ade65-2105-43e3-9919-7fd880874bbc.png)

After:
![image](https://user-images.githubusercontent.com/31417027/193684696-93d28def-2a5f-40c9-872b-153c2dcb41d6.png)

Still checking out a small bug between 1840 and 1890px screen sizes where the panel date - ID menu gets cut off very slightly: 

![image](https://user-images.githubusercontent.com/31417027/193685373-1b517583-e711-4e41-b16d-56ca4104ba9c.png)

Lastly, also still checking out a fix for resolutions above 2600px, styling just starts to look bad