### PR TITLE
Fixed to fetch all 4 fav-services

### DIFF
--- a/src/Components/FavoritePositions/FavoritePositions.jsx
+++ b/src/Components/FavoritePositions/FavoritePositions.jsx
@@ -20,7 +20,7 @@ const TYPE_PV_TANDEM = 'pvTandem';
 const TYPE_OPEN_TANDEM = 'openTandem';
 
 const FavoritePositions = props => {
-  const [selected, setSelected] = useState(props.navType === 'all' ? TYPE_OPEN : props.navType);
+  const [selected, setSelected] = useState(props.navType || TYPE_OPEN);
   const [isLoading, setIsLoading] = useState(false);
 
   const { favorites, favoritesTandem, favoritesPV,

--- a/src/Components/FavoritePositions/FavoritePositions.jsx
+++ b/src/Components/FavoritePositions/FavoritePositions.jsx
@@ -20,7 +20,7 @@ const TYPE_PV_TANDEM = 'pvTandem';
 const TYPE_OPEN_TANDEM = 'openTandem';
 
 const FavoritePositions = props => {
-  const [selected, setSelected] = useState(props.navType || TYPE_OPEN);
+  const [selected, setSelected] = useState(props.navType === 'all' ? TYPE_OPEN : props.navType);
   const [isLoading, setIsLoading] = useState(false);
 
   const { favorites, favoritesTandem, favoritesPV,

--- a/src/Containers/Favorites/Favorites.jsx
+++ b/src/Containers/Favorites/Favorites.jsx
@@ -35,16 +35,27 @@ const FavoritePositionsContainer = props => {
   const setNavType$ = e => setQuery({ navType: e, page: 1 });
 
   useEffect(() => {
+    const isNavAll = navType === 'all';
     if (!called ||
       !isEqual(userProfileFavoritePositionIsLoading, prevUserProfileFavoritePositionIsLoading)) {
-      // Only fetch all if counts doesn't exist; otherwise fetch selected navType
-      let type = 'all';
-      if (keys(favoritePositions.counts).length) {
-        type = navType;
+      if (isNavAll) {
+        // on initial page call, grab all favorites
+        setCalled(true);
+        setQuery({ navType: 'open', page: 1 });
+        props.bidListFetchData();
+        getFavorites('pv');
+        getFavorites('pvTandem');
+        getFavorites('openTandem');
+      } else {
+        // Only fetch all if counts doesn't exist; otherwise fetch selected navType
+        let type = 'all';
+        if (keys(favoritePositions.counts).length) {
+          type = navType;
+        }
+        setCalled(true);
+        props.bidListFetchData();
+        getFavorites(type);
       }
-      setCalled(true);
-      props.bidListFetchData();
-      getFavorites(type);
     }
   });
 

--- a/src/Containers/Favorites/Favorites.jsx
+++ b/src/Containers/Favorites/Favorites.jsx
@@ -150,7 +150,7 @@ export default connect(mapStateToProps, mapDispatchToProps)(
   withQueryParams({
     page: withDefault(NumberParam, 1),
     sortType: StringParam,
-    navType: withDefault(StringParam, 'open'),
+    navType: withDefault(StringParam, 'all'),
   }, withRouter(
     FavoritePositionsContainer,
   )),


### PR DESCRIPTION
- Setting default selected nav item to Open Positions if the navType being passed is "all"
- Updated logic to fetch "all" favorite data upon Favorites page load (this fix also addresses Tandem tabs not displayed if they are being favorite for the first time)
