### PR TITLE
remove updated from external abl

### DIFF
--- a/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderRow/AvailableBidderRow.jsx
@@ -230,7 +230,6 @@ const AvailableBidderRow = (props) => {
       ted: ted$,
       current_post: currentPost,
       cdo: cdo ? getCDO() : NO_CDO,
-      updated_on: updateTooltip,
     };
   };
 

--- a/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
+++ b/src/Components/AvailableBidder/AvailableBidderTable/AvailableBidderTable.jsx
@@ -87,7 +87,6 @@ const AvailableBidderTable = props => {
     'TED',
     'Post',
     'CDO',
-    'Updated',
   ];
 
   tableHeaders = tableHeaders.filter(f => f);

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -232,6 +232,7 @@ $abl-actions-td: 12;
 $abl-gray-config: (
   "Status": 2,
   "Step Letter": 3,
+  "Updated On": 10,
   "Notes": 11
 );
 


### PR DESCRIPTION
Reverting changes from this [PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2345)

Dual Merge: 
- [API PR](https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/723)

To-do
- [x] highlight `Updated` column for External Internal CDA View when viewing the ABL as an Internal CDA User (AO/CDO)
- [x] remove `Updated` column & data when viewing the ABL as an External CDA User (Bureau/Post)
- [x] remove `Updated` column and data when exporting the ABL as an Internal CDA User viewing the External CDA View
- [x] remove `Updated` column and data when exporting the ABL as an External CDA User 

**Note: be sure to test as each individual user and not as an Admin to verify roles don't conflict**
**These changes are being undone per the request of the PO**
