### PR TITLE
TM-3554: Update/panel meeting agenda routes

### DIFF
--- a/src/Components/BureauPage/BureauPage.jsx
+++ b/src/Components/BureauPage/BureauPage.jsx
@@ -4,6 +4,7 @@ import EmployeeAgendaSearch from 'Components/Agenda/EmployeeAgendaSearch/Employe
 import AgendaItemHistory from 'Components/Agenda/AgendaItemHistory/AgendaItemHistory';
 import AgendaItemMaintenanceContainer from 'Components/Agenda/AgendaItemMaintenanceContainer/AgendaItemMaintenanceContainer';
 import PanelMeetingSearch from 'Components/Panel/PanelMeetingSearch/PanelMeetingSearch';
+import PanelMeetingAgenda from 'Components/Panel/PanelMeetingAgenda/PanelMeetingAgenda';
 import Dashboard from './Dashboard';
 import Stats from './Stats';
 import PositionManager from './PositionManager';
@@ -30,6 +31,7 @@ const BureauPage = () => {
         <Route path="/profile/ao/createagendaitem/:id" render={() => <AgendaItemMaintenanceContainer isCDO={false} />} />
         <Route path="/profile/ao/panelmeetings" render={() => <PanelMeetingSearch isCDO={false} />} />
         <Route path="/profile/ao/availablebidders" render={() => <AvailableBidderContainer isCDO={false} isAO />} />
+        <Route path="/profile/ao/panelmeetingagenda" render={() => <PanelMeetingAgenda isCDO={false} isAO />} />
         <Route path="/profile/(bureau|ao)/dashboard" render={() => <Dashboard {...dashboardProps} />} />
         <Route path="/profile/cdo/availablebidders" render={() => <AvailableBidderContainer isCDO isAO={false} />} />
         <Route path="/profile/bureau/stats" render={() => <Stats {...statsProps} />} />

--- a/src/Components/CdoPage/CdoPage.jsx
+++ b/src/Components/CdoPage/CdoPage.jsx
@@ -5,6 +5,7 @@ import EmployeeAgendaSearch from 'Components/Agenda/EmployeeAgendaSearch/Employe
 import AgendaItemHistory from 'Components/Agenda/AgendaItemHistory/AgendaItemHistory';
 import AgendaItemMaintenanceContainer from 'Components/Agenda/AgendaItemMaintenanceContainer/AgendaItemMaintenanceContainer';
 import PanelMeetingSearch from 'Components/Panel/PanelMeetingSearch/PanelMeetingSearch';
+import PanelMeetingAgenda from 'Components/Panel/PanelMeetingAgenda/PanelMeetingAgenda';
 
 const CdoPage = () => (
   <div className="usa-grid-full profile-content-container">
@@ -15,6 +16,7 @@ const CdoPage = () => (
       <Route path="/profile/cdo/agendaitemhistory/:id" render={() => <AgendaItemHistory isCDO viewType="cdo" />} />
       <Route path="/profile/cdo/createagendaitem/:id" render={() => <AgendaItemMaintenanceContainer isCDO />} />
       <Route path="/profile/cdo/panelmeetings" render={() => <PanelMeetingSearch isCDO />} />
+      <Route path="/profile/cdo/panelmeetingagenda" render={() => <PanelMeetingAgenda isCDO />} />
     </Switch>
   </div>
 );

--- a/src/Components/Panel/PanelMeetingAgenda/PanelMeetingAgenda.jsx
+++ b/src/Components/Panel/PanelMeetingAgenda/PanelMeetingAgenda.jsx
@@ -80,8 +80,8 @@ const PanelMeetingAgenda = () => {
   return (
     <div className="panel-meeting-search-page">
       <div className="usa-grid-full panel-meeting-search-upper-section results-search-bar-container">
-        <BackButton />
         <ProfileSectionTitle title="Panel Meeting Agenda" icon="comment" />
+        <BackButton />
         <PositionManagerSearch
           submitSearch={submitSearch}
           onChange={setTextInputThrottled}

--- a/src/Components/Panel/PanelMeetingAgenda/PanelMeetingAgenda.jsx
+++ b/src/Components/Panel/PanelMeetingAgenda/PanelMeetingAgenda.jsx
@@ -80,8 +80,8 @@ const PanelMeetingAgenda = () => {
   return (
     <div className="panel-meeting-search-page">
       <div className="usa-grid-full panel-meeting-search-upper-section results-search-bar-container">
-        <ProfileSectionTitle title="Panel Meeting Agenda" icon="comment" />
         <BackButton />
+        <ProfileSectionTitle title="Panel Meeting Agenda" icon="comment" />
         <PositionManagerSearch
           submitSearch={submitSearch}
           onChange={setTextInputThrottled}

--- a/src/Components/Panel/PanelMeetingAgenda/PanelMeetingAgenda.jsx
+++ b/src/Components/Panel/PanelMeetingAgenda/PanelMeetingAgenda.jsx
@@ -1,0 +1,223 @@
+// import Picky from 'react-picky';
+import FA from 'react-fontawesome';
+import { useDispatch, useSelector } from 'react-redux';
+// import DateRangePicker from '@wojtekmaj/react-daterange-picker';
+import SelectForm from 'Components/SelectForm';
+// import ListItem from 'Components/BidderPortfolio/BidControls/BidCyclePicker/ListItem';
+import { useEffect, useRef, useState } from 'react';
+import { filter, flatten, get, isEmpty, throttle } from 'lodash';
+import { isDate, startOfDay } from 'date-fns-v2';
+import { PANEL_MEETINGS_PAGE_SIZES, PANEL_MEETINGS_SORT } from 'Constants/Sort';
+import { panelMeetingsFetchData, panelMeetingsFiltersFetchData, savePanelMeetingsSelections } from 'actions/panelMeetings';
+import PositionManagerSearch from 'Components/BureauPage/PositionManager/PositionManagerSearch';
+import ProfileSectionTitle from 'Components/ProfileSectionTitle/ProfileSectionTitle';
+import ScrollUpButton from '../../ScrollUpButton';
+import BackButton from '../../BackButton';
+
+const PanelMeetingAgenda = () => {
+  const dispatch = useDispatch();
+  const childRef = useRef();
+
+  const userSelections = useSelector(state => state.panelMeetingsSelections);
+
+  const [limit, setLimit] = useState(get(userSelections, 'limit') || PANEL_MEETINGS_PAGE_SIZES.defaultSize);
+  const [ordering, setOrdering] = useState(get(userSelections, 'ordering') || PANEL_MEETINGS_SORT.defaultSort);
+
+  const [selectedMeetingType, setSelectedMeetingType] = useState(get(userSelections, 'selectedMeetingType') || []);
+  const [selectedMeetingDate, setSelectedMeetingDate] = useState(get(userSelections, 'selectedMeetingDate') || null);
+  const [selectedMeetingStatus, setSelectedMeetingStatus] = useState(get(userSelections, 'selectedMeetingStatus') || []);
+  const [textInput, setTextInput] = useState(get(userSelections, 'textInput') || '');
+  const [textSearch, setTextSearch] = useState(get(userSelections, 'textSearch') || '');
+
+  const [clearFilters, setClearFilters] = useState(false);
+
+  const resetFilters = () => {
+    setSelectedMeetingType([]);
+    setSelectedMeetingDate(null);
+    setSelectedMeetingStatus([]);
+    setTextSearch('');
+    childRef.current.clearText();
+    setClearFilters(false);
+  };
+
+  const pageSizes = PANEL_MEETINGS_PAGE_SIZES;
+  const sorts = PANEL_MEETINGS_SORT;
+
+  // const renderSelectionList = ({ items, selected, ...rest }) => {
+  //   const getSelected = item => !!selected.find(f => f.code === item.code);
+  //   return items.map(item =>
+  //     (<ListItem
+  //       key={item.code}
+  //       item={item}
+  //       {...rest}
+  //       queryProp={'description'}
+  //       getIsSelected={getSelected}
+  //     />),
+  //   );
+  // };
+
+  // const pickyProps = {
+  //   numberDisplayed: 2,
+  //   multiple: true,
+  //   includeFilter: true,
+  //   dropdownHeight: 255,
+  //   renderList: renderSelectionList,
+  //   includeSelectAll: true,
+  // };
+
+  const getQuery = () => ({
+    limit,
+    ordering,
+    // User Filters
+    panelMeetingsTypes: selectedMeetingType.map(meetingObject => (get(meetingObject, 'code'))),
+    panelMeetingsStatus: selectedMeetingStatus.map(meetingObject => (get(meetingObject, 'code'))),
+
+    // need to set to beginning of the day to avoid timezone issues
+    'pmd-start': isDate(get(selectedMeetingDate, '[0]')) ? startOfDay(get(selectedMeetingDate, '[0]')).toJSON() : '',
+    'pmd-end': isDate(get(selectedMeetingDate, '[1]')) ? startOfDay(get(selectedMeetingDate, '[1]')).toJSON() : '',
+
+    // Free Text
+    q: textInput || textSearch,
+  });
+
+  const getCurrentInputs = () => ({
+    limit,
+    ordering,
+    selectedMeetingType,
+    selectedMeetingStatus,
+    selectedMeetingDate,
+    textInput,
+    textSearch,
+  });
+
+  useEffect(() => {
+    dispatch(panelMeetingsFiltersFetchData());
+  }, []);
+
+  const fetchAndSet = () => {
+    const filters = [
+      selectedMeetingType,
+      selectedMeetingDate,
+      selectedMeetingStatus,
+    ];
+    if (isEmpty(filter(flatten(filters))) && isEmpty(textSearch)) {
+      setClearFilters(false);
+    } else {
+      setClearFilters(true);
+    }
+    dispatch(panelMeetingsFetchData(getQuery()));
+    dispatch(savePanelMeetingsSelections(getCurrentInputs()));
+  };
+
+  useEffect(() => {
+    fetchAndSet();
+  }, [
+    limit,
+    ordering,
+    selectedMeetingType,
+    selectedMeetingDate,
+    selectedMeetingStatus,
+    textSearch,
+  ]);
+
+  function submitSearch(text) {
+    setTextSearch(text);
+  }
+
+  const throttledTextInput = () =>
+    throttle(q => setTextInput(q), 300, { leading: false, trailing: true });
+
+  const setTextInputThrottled = (q) => {
+    throttledTextInput(q);
+  };
+
+  return (
+    <div className="panel-meeting-search-page">
+      <div className="usa-grid-full panel-meeting-search-upper-section results-search-bar-container">
+        <BackButton />
+        <ProfileSectionTitle title="Panel Meeting Agenda" icon="comment" />
+        <PositionManagerSearch
+          submitSearch={submitSearch}
+          onChange={setTextInputThrottled}
+          ref={childRef}
+          textSearch={textSearch}
+          label="Search for a Panel Meeting"
+          placeHolder="Search using Panel ID"
+        />
+        <div className="filterby-container">
+          <div className="filterby-label">Filter by:</div>
+          <div className="filterby-clear">
+            {clearFilters &&
+                <button className="unstyled-button" onClick={resetFilters}>
+                  <FA name="times" />
+                Clear Filters
+                </button>
+            }
+          </div>
+        </div>
+        <div className="usa-width-one-whole panel-meeting-search-filters">
+          {/* <div className="filter-div">
+            <div className="label">Type:</div>
+            <Picky
+              {...pickyProps}
+              placeholder="Select Meeting Type"
+              value={selectedMeetingType}
+              options={get(panelMeetingsFilters, 'panelMeetingsTypesOptions', [])}
+              onChange={setSelectedMeetingType}
+              valueKey="code"
+              labelKey="description"
+              disabled={isLoading}
+            />
+          </div>
+          <div className="filter-div">
+            <div className="label label-date">Meeting Date:</div>
+            <DateRangePicker
+              onChange={setSelectedMeetingDate}
+              value={selectedMeetingDate}
+              maxDetail="month"
+              calendarIcon={null}
+              showLeadingZeros
+              disabled={isLoading}
+            />
+          </div>
+          <div className="filter-div">
+            <div className="label">Status:</div>
+            <Picky
+              {...pickyProps}
+              placeholder="Select Meeting Status"
+              value={selectedMeetingStatus}
+              options={get(panelMeetingsFilters, 'panelMeetingsStatusOptions', [])}
+              onChange={setSelectedMeetingStatus}
+              valueKey="code"
+              labelKey="description"
+              disabled={isLoading}
+            />
+          </div> */}
+        </div>
+      </div>
+      {
+        <div className="panel-results-controls">
+          <SelectForm
+            className="panel-results-select"
+            id="panel-search-results-sort"
+            options={sorts.options}
+            label="Sort by:"
+            defaultSort={ordering}
+            onSelectOption={value => setOrdering(value.target.value)}
+          />
+          <SelectForm
+            className="panel-results-select"
+            id="panel-search-num-results"
+            options={pageSizes.options}
+            label="Results:"
+            defaultSort={limit}
+            onSelectOption={value => setLimit(value.target.value)}
+          />
+          <ScrollUpButton />
+        </div>
+      }
+    </div>
+  );
+};
+
+export default PanelMeetingAgenda;

--- a/src/Components/Panel/PanelMeetingAgenda/PanelMeetingAgenda.jsx
+++ b/src/Components/Panel/PanelMeetingAgenda/PanelMeetingAgenda.jsx
@@ -1,14 +1,10 @@
-// import Picky from 'react-picky';
 import FA from 'react-fontawesome';
 import { useDispatch, useSelector } from 'react-redux';
-// import DateRangePicker from '@wojtekmaj/react-daterange-picker';
 import SelectForm from 'Components/SelectForm';
-// import ListItem from 'Components/BidderPortfolio/BidControls/BidCyclePicker/ListItem';
 import { useEffect, useRef, useState } from 'react';
-import { filter, flatten, get, isEmpty, throttle } from 'lodash';
-import { isDate, startOfDay } from 'date-fns-v2';
+import { get, throttle } from 'lodash';
 import { PANEL_MEETINGS_PAGE_SIZES, PANEL_MEETINGS_SORT } from 'Constants/Sort';
-import { panelMeetingsFetchData, panelMeetingsFiltersFetchData, savePanelMeetingsSelections } from 'actions/panelMeetings';
+import { panelMeetingsFetchData, savePanelMeetingsSelections } from 'actions/panelMeetings';
 import PositionManagerSearch from 'Components/BureauPage/PositionManager/PositionManagerSearch';
 import ProfileSectionTitle from 'Components/ProfileSectionTitle/ProfileSectionTitle';
 import ScrollUpButton from '../../ScrollUpButton';
@@ -23,58 +19,25 @@ const PanelMeetingAgenda = () => {
   const [limit, setLimit] = useState(get(userSelections, 'limit') || PANEL_MEETINGS_PAGE_SIZES.defaultSize);
   const [ordering, setOrdering] = useState(get(userSelections, 'ordering') || PANEL_MEETINGS_SORT.defaultSort);
 
-  const [selectedMeetingType, setSelectedMeetingType] = useState(get(userSelections, 'selectedMeetingType') || []);
-  const [selectedMeetingDate, setSelectedMeetingDate] = useState(get(userSelections, 'selectedMeetingDate') || null);
-  const [selectedMeetingStatus, setSelectedMeetingStatus] = useState(get(userSelections, 'selectedMeetingStatus') || []);
+  const [selectedMeetingType] = useState(get(userSelections, 'selectedMeetingType') || []);
+  const [selectedMeetingDate] = useState(get(userSelections, 'selectedMeetingDate') || null);
+  const [selectedMeetingStatus] = useState(get(userSelections, 'selectedMeetingStatus') || []);
   const [textInput, setTextInput] = useState(get(userSelections, 'textInput') || '');
   const [textSearch, setTextSearch] = useState(get(userSelections, 'textSearch') || '');
 
   const [clearFilters, setClearFilters] = useState(false);
 
   const resetFilters = () => {
-    setSelectedMeetingType([]);
-    setSelectedMeetingDate(null);
-    setSelectedMeetingStatus([]);
-    setTextSearch('');
-    childRef.current.clearText();
     setClearFilters(false);
   };
 
   const pageSizes = PANEL_MEETINGS_PAGE_SIZES;
   const sorts = PANEL_MEETINGS_SORT;
 
-  // const renderSelectionList = ({ items, selected, ...rest }) => {
-  //   const getSelected = item => !!selected.find(f => f.code === item.code);
-  //   return items.map(item =>
-  //     (<ListItem
-  //       key={item.code}
-  //       item={item}
-  //       {...rest}
-  //       queryProp={'description'}
-  //       getIsSelected={getSelected}
-  //     />),
-  //   );
-  // };
-
-  // const pickyProps = {
-  //   numberDisplayed: 2,
-  //   multiple: true,
-  //   includeFilter: true,
-  //   dropdownHeight: 255,
-  //   renderList: renderSelectionList,
-  //   includeSelectAll: true,
-  // };
-
   const getQuery = () => ({
     limit,
     ordering,
     // User Filters
-    panelMeetingsTypes: selectedMeetingType.map(meetingObject => (get(meetingObject, 'code'))),
-    panelMeetingsStatus: selectedMeetingStatus.map(meetingObject => (get(meetingObject, 'code'))),
-
-    // need to set to beginning of the day to avoid timezone issues
-    'pmd-start': isDate(get(selectedMeetingDate, '[0]')) ? startOfDay(get(selectedMeetingDate, '[0]')).toJSON() : '',
-    'pmd-end': isDate(get(selectedMeetingDate, '[1]')) ? startOfDay(get(selectedMeetingDate, '[1]')).toJSON() : '',
 
     // Free Text
     q: textInput || textSearch,
@@ -90,21 +53,7 @@ const PanelMeetingAgenda = () => {
     textSearch,
   });
 
-  useEffect(() => {
-    dispatch(panelMeetingsFiltersFetchData());
-  }, []);
-
   const fetchAndSet = () => {
-    const filters = [
-      selectedMeetingType,
-      selectedMeetingDate,
-      selectedMeetingStatus,
-    ];
-    if (isEmpty(filter(flatten(filters))) && isEmpty(textSearch)) {
-      setClearFilters(false);
-    } else {
-      setClearFilters(true);
-    }
     dispatch(panelMeetingsFetchData(getQuery()));
     dispatch(savePanelMeetingsSelections(getCurrentInputs()));
   };
@@ -114,9 +63,6 @@ const PanelMeetingAgenda = () => {
   }, [
     limit,
     ordering,
-    selectedMeetingType,
-    selectedMeetingDate,
-    selectedMeetingStatus,
     textSearch,
   ]);
 
@@ -155,45 +101,7 @@ const PanelMeetingAgenda = () => {
             }
           </div>
         </div>
-        <div className="usa-width-one-whole panel-meeting-search-filters">
-          {/* <div className="filter-div">
-            <div className="label">Type:</div>
-            <Picky
-              {...pickyProps}
-              placeholder="Select Meeting Type"
-              value={selectedMeetingType}
-              options={get(panelMeetingsFilters, 'panelMeetingsTypesOptions', [])}
-              onChange={setSelectedMeetingType}
-              valueKey="code"
-              labelKey="description"
-              disabled={isLoading}
-            />
-          </div>
-          <div className="filter-div">
-            <div className="label label-date">Meeting Date:</div>
-            <DateRangePicker
-              onChange={setSelectedMeetingDate}
-              value={selectedMeetingDate}
-              maxDetail="month"
-              calendarIcon={null}
-              showLeadingZeros
-              disabled={isLoading}
-            />
-          </div>
-          <div className="filter-div">
-            <div className="label">Status:</div>
-            <Picky
-              {...pickyProps}
-              placeholder="Select Meeting Status"
-              value={selectedMeetingStatus}
-              options={get(panelMeetingsFilters, 'panelMeetingsStatusOptions', [])}
-              onChange={setSelectedMeetingStatus}
-              valueKey="code"
-              labelKey="description"
-              disabled={isLoading}
-            />
-          </div> */}
-        </div>
+        <div className="usa-width-one-whole panel-meeting-search-filters" />
       </div>
       {
         <div className="panel-results-controls">

--- a/src/Components/Panel/PanelMeetingAgenda/PanelMeetingAgenda.test.jsx
+++ b/src/Components/Panel/PanelMeetingAgenda/PanelMeetingAgenda.test.jsx
@@ -1,15 +1,46 @@
+import TestUtils from 'react-dom/test-utils';
 import { shallow } from 'enzyme';
 import toJSON from 'enzyme-to-json';
+import { MemoryRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
 import PanelMeetingAgenda from './PanelMeetingAgenda';
 
-describe('PanelMeetingSearchRow', () => {
+const middlewares = [thunk];
+const mockStore = configureStore(middlewares);
+
+describe('PanelMeetingAgenda', () => {
   it('is defined', () => {
-    const wrapper = shallow(<PanelMeetingAgenda />);
+    const wrapper = TestUtils.renderIntoDocument(
+      <Provider store={mockStore({})}>
+        <MemoryRouter>
+          <PanelMeetingAgenda isCDO />
+        </MemoryRouter>
+      </Provider>,
+    );
     expect(wrapper).toBeDefined();
   });
 
-  it('matches snapshot', () => {
-    const wrapper = shallow(<PanelMeetingAgenda />);
+  it('matches snapshot when CDO', () => {
+    const wrapper = shallow(
+      <Provider store={mockStore({})}>
+        <MemoryRouter>
+          <PanelMeetingAgenda isCDO />
+        </MemoryRouter>
+      </Provider>,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
+  it('matches snapshot when not CDO', () => {
+    const wrapper = shallow(
+      <Provider store={mockStore({})}>
+        <MemoryRouter>
+          <PanelMeetingAgenda isCDO={false} />
+        </MemoryRouter>
+      </Provider>,
+    );
     expect(toJSON(wrapper)).toMatchSnapshot();
   });
 });

--- a/src/Components/Panel/PanelMeetingAgenda/PanelMeetingAgenda.test.jsx
+++ b/src/Components/Panel/PanelMeetingAgenda/PanelMeetingAgenda.test.jsx
@@ -1,0 +1,15 @@
+import { shallow } from 'enzyme';
+import toJSON from 'enzyme-to-json';
+import PanelMeetingAgenda from './PanelMeetingAgenda';
+
+describe('PanelMeetingSearchRow', () => {
+  it('is defined', () => {
+    const wrapper = shallow(<PanelMeetingAgenda />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(<PanelMeetingAgenda />);
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/Panel/PanelMeetingAgenda/__snapshots__/PanelMeetingAgenda.test.jsx.snap
+++ b/src/Components/Panel/PanelMeetingAgenda/__snapshots__/PanelMeetingAgenda.test.jsx.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PanelMeetingAgenda matches snapshot when CDO 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "subscription": Object {
+        "addNestedSub": [Function],
+        "getListeners": [Function],
+        "handleChangeWrapper": [Function],
+        "isSubscribed": [Function],
+        "notifyNestedSubs": [Function],
+        "trySubscribe": [Function],
+        "tryUnsubscribe": [Function],
+      },
+    }
+  }
+>
+  <MemoryRouter>
+    <PanelMeetingAgenda
+      isCDO={true}
+    />
+  </MemoryRouter>
+</ContextProvider>
+`;
+
+exports[`PanelMeetingAgenda matches snapshot when not CDO 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "subscription": Object {
+        "addNestedSub": [Function],
+        "getListeners": [Function],
+        "handleChangeWrapper": [Function],
+        "isSubscribed": [Function],
+        "notifyNestedSubs": [Function],
+        "trySubscribe": [Function],
+        "tryUnsubscribe": [Function],
+      },
+    }
+  }
+>
+  <MemoryRouter>
+    <PanelMeetingAgenda
+      isCDO={false}
+    />
+  </MemoryRouter>
+</ContextProvider>
+`;

--- a/src/Components/Panel/PanelMeetingAgenda/index.js
+++ b/src/Components/Panel/PanelMeetingAgenda/index.js
@@ -1,0 +1,1 @@
+export { default } from './PanelMeetingAgenda';

--- a/src/Components/Panel/PanelMeetingSearchRow/PanelMeetingSearchRow.jsx
+++ b/src/Components/Panel/PanelMeetingSearchRow/PanelMeetingSearchRow.jsx
@@ -50,7 +50,7 @@ const PanelMeetingSearchRow = ({ isCDO, result, showCreate }) => {
           {
             !!showCreate &&
             <div className="button-box-container">
-              <LinkButton className="button-box" toLink={`/profile/${userRole}/panel/`}>Go to Panel</LinkButton>
+              <LinkButton className="button-box" toLink={`/profile/${userRole}/panelmeetingagenda/`}>Go to Panel</LinkButton>
             </div>
           }
         </div>

--- a/src/Components/Panel/PanelMeetingSearchRow/__snapshots__/PanelMeetingSearchRow.test.jsx.snap
+++ b/src/Components/Panel/PanelMeetingSearchRow/__snapshots__/PanelMeetingSearchRow.test.jsx.snap
@@ -77,7 +77,7 @@ exports[`PanelMeetingSearchRow matches snapshot 1`] = `
       >
         <LinkButton
           className="button-box"
-          toLink="/profile/ao/panel/"
+          toLink="/profile/ao/panelmeetingagenda/"
         >
           Go to Panel
         </LinkButton>

--- a/src/sass/_panel.scss
+++ b/src/sass/_panel.scss
@@ -133,7 +133,7 @@
 
 .panel-meeting-row {
   margin-top: 1rem;
-  
+
   .panel-meeting-stat-row {
     border: 1px solid $color-gray-light;
     border-left: 11px solid $primary-blue;
@@ -166,7 +166,7 @@
       font-size: 1.2em;
       line-height: 1.3em;
       margin: 8px 0 .3rem 15rem;
-      
+
       .row-name {
         color: $primary-blue;
         font-size: .9em;
@@ -186,7 +186,7 @@
     .button-container {
       float: right;
       padding-bottom: 30px;
-      
+
       @media screen and (max-width: 1250px) {
         padding-bottom: 0px;
         padding-top: 20px;
@@ -215,4 +215,9 @@
       }
     }
   }
+}
+
+.panel-meeting-agenda-back-btn {
+  margin-bottom: 0px;
+  margin-top: 0px;
 }

--- a/src/sass/_panel.scss
+++ b/src/sass/_panel.scss
@@ -217,7 +217,3 @@
   }
 }
 
-.panel-meeting-agenda-back-btn {
-  margin-bottom: 0px;
-  margin-top: 0px;
-}


### PR DESCRIPTION
ACs:
1. Go Back button displays in new Panel Meeting Agenda page and returns user to Panel Meeting Search page
2. Using the Go Back button, make sure that filters on the Panel Meeting Search page persist (meeting type, status, etc.)
3. Verify URLs are correct for AO and CDO:
    
    profile/{cdo | ao}/panelmeetingagenda

Cory - I obviously used Panel Meeting Search as a template, and tried to remove the unnecessary code for the new page (mainly the filters). Let me know if I left any 'bloat' in there that's not applicable to the page