### PR TITLE
TM-3560 Add authn false param to previous authn calls

### DIFF
--- a/src/saml2-config.alt.js
+++ b/src/saml2-config.alt.js
@@ -25,7 +25,7 @@ const serviceProvider = new saml2.ServiceProvider({
   private_key: fs.readFileSync(keyFile),
   certificate: fs.readFileSync(certFile),
   assert_endpoint: ASSERT_ENDPOINT,
-  force_authn: true,
+  force_authn: false,
 });
 
 const serviceProviderPublic = new saml2.ServiceProvider({
@@ -33,7 +33,7 @@ const serviceProviderPublic = new saml2.ServiceProvider({
   private_key: fs.readFileSync(keyFile),
   certificate: fs.readFileSync(certFile),
   assert_endpoint: ASSERT_ENDPOINT_PUBLIC,
-  force_authn: true,
+  force_authn: false,
 });
 
 const identityProvider = new saml2.IdentityProvider({

--- a/src/saml2-config.js
+++ b/src/saml2-config.js
@@ -34,7 +34,7 @@ const serviceProvider = new saml2.ServiceProvider({
   private_key: privateKey,
   certificate: cert,
   assert_endpoint: ASSERT_ENDPOINT,
-  force_authn: true,
+  force_authn: false,
 });
 
 const identityProvider = new saml2.IdentityProvider({


### PR DESCRIPTION
Per Mark S. request - changing authn to false to hopefully prevent override of the existing authentication during login loop.