### PR TITLE
panel meeting agenda filter spacing TM-3619

### DIFF
--- a/src/sass/_panelMeetingAgendas.scss
+++ b/src/sass/_panelMeetingAgendas.scss
@@ -69,7 +69,7 @@
       padding-right: 14em;
     }
     
-    @media screen and (min-width: 3188px) {
+    @media screen and (min-width: 3189px) {
       padding-right: 18em;
     }
 

--- a/src/sass/_panelMeetingAgendas.scss
+++ b/src/sass/_panelMeetingAgendas.scss
@@ -60,6 +60,19 @@
   .panel-meeting-agenda-filters {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(335px, 1fr));
+    padding-right: 6em;
+
+    @media screen and (min-width: 2390px) and (max-width: 2780px) {
+      padding-right: 10em;
+    }
+    
+    @media screen and (min-width: 2781px) and (max-width: 3188px) {
+      padding-right: 14em;
+    }
+    
+    @media screen and (min-width: 3188px) {
+      padding-right: 18em;
+    }
 
     .filter-div {
       align-items: center;


### PR DESCRIPTION
To-do:
- [x] Filters should not show past search button, regardless of screen size