### PR TITLE
TM-3609: Add User Data to Panel Meeting Agendas

### DIFF
--- a/src/Components/Agenda/AgendaItemRow/AgendaItemRow.jsx
+++ b/src/Components/Agenda/AgendaItemRow/AgendaItemRow.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { get } from 'lodash';
+import { useSelector } from 'react-redux';
 import FA from 'react-fontawesome';
 import InteractiveElement from 'Components/InteractiveElement';
 import { formatDate } from 'utilities';
@@ -14,10 +15,18 @@ const AgendaItemRow = props => {
     showEdit,
     isCDO,
     perdet,
+    isPanelMeetingView,
   } = props;
 
   const userRole = isCDO ? 'cdo' : 'ao';
   const perdet$ = perdet || get(agenda, 'perdet');
+
+  const panelAgendas = useSelector(state => state.panelMeetingAgendas[0]);
+
+  const userSkill = get(panelAgendas, 'skill');
+  const userLanguage = get(panelAgendas, 'language');
+  const userBureau = get(panelAgendas, 'bureau');
+  const userGrade = get(panelAgendas, 'grade');
 
   // eslint-disable-next-line no-console
   const editAI = () => { console.log('placeholder edit AI'); };
@@ -48,6 +57,20 @@ const AgendaItemRow = props => {
           <div className="ai-history-row-panel-date">
             Panel Date: {agenda.panel_date ? formatDate(agenda.panel_date) : 'N/A'}
           </div>
+          {
+            isPanelMeetingView &&
+            <div className="panel-meeting-agendas-user-info">
+              <div className="panel-meeting-agendas-profile-link">
+                <Link to="/profile/public/4">Townpost, Jenny Y.</Link>
+              </div>
+              <div>
+                <div className="item"><strong>Bureau: </strong> {userBureau}</div>
+                <div className="item"><strong>Grade: </strong> {userGrade}</div>
+                <div className="item"><strong>Language: </strong> {userLanguage}</div>
+                <div className="item"><strong>Skill: </strong> {userSkill}</div>
+              </div>
+            </div>
+          }
           <AgendaItemLegs legs={agenda.legs} remarks={agenda.remarks} />
           {
             showEdit &&
@@ -103,6 +126,7 @@ AgendaItemRow.propTypes = {
   showEdit: PropTypes.bool,
   isCDO: PropTypes.bool,
   perdet: PropTypes.number,
+  isPanelMeetingView: PropTypes.bool,
 };
 
 
@@ -112,6 +136,7 @@ AgendaItemRow.defaultProps = {
   showEdit: false,
   isCDO: false,
   perdet: null,
+  isPanelMeetingView: false,
 };
 
 export default AgendaItemRow;

--- a/src/Components/Agenda/AgendaItemRow/AgendaItemRow.jsx
+++ b/src/Components/Agenda/AgendaItemRow/AgendaItemRow.jsx
@@ -20,10 +20,10 @@ const AgendaItemRow = props => {
   const userRole = isCDO ? 'cdo' : 'ao';
   const perdet$ = perdet || get(agenda, 'perdet');
 
-  const userSkill = get(agenda, 'skill' || 'None Listed');
-  const userLanguage = get(agenda, 'language' || 'None Listed');
-  const userBureau = get(agenda, 'bureau' || 'None Listed');
-  const userGrade = get(agenda, 'grade' || 'None Listed');
+  const userSkill = get(agenda, 'skill') || 'None Listed';
+  const userLanguage = get(agenda, 'language') || 'None Listed';
+  const userBureau = get(agenda, 'bureau') || 'None Listed';
+  const userGrade = get(agenda, 'grade') || 'None Listed';
 
   // eslint-disable-next-line no-console
   const editAI = () => { console.log('placeholder edit AI'); };

--- a/src/Components/Agenda/AgendaItemRow/AgendaItemRow.jsx
+++ b/src/Components/Agenda/AgendaItemRow/AgendaItemRow.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { get } from 'lodash';
-import { useSelector } from 'react-redux';
+// import { useSelector } from 'react-redux';
 import FA from 'react-fontawesome';
 import InteractiveElement from 'Components/InteractiveElement';
 import { formatDate } from 'utilities';
@@ -21,12 +21,12 @@ const AgendaItemRow = props => {
   const userRole = isCDO ? 'cdo' : 'ao';
   const perdet$ = perdet || get(agenda, 'perdet');
 
-  const panelAgendas = useSelector(state => state.panelMeetingAgendas[0]);
+  // const panelAgendas = useSelector(state => state.panelMeetingAgendas[0]);
 
-  const userSkill = get(panelAgendas, 'skill');
-  const userLanguage = get(panelAgendas, 'language');
-  const userBureau = get(panelAgendas, 'bureau');
-  const userGrade = get(panelAgendas, 'grade');
+  const userSkill = get(agenda, 'skill' || 'None Listed');
+  const userLanguage = get(agenda, 'language' || 'None Listed');
+  const userBureau = get(agenda, 'bureau' || 'None Listed');
+  const userGrade = get(agenda, 'grade' || 'None Listed');
 
   // eslint-disable-next-line no-console
   const editAI = () => { console.log('placeholder edit AI'); };
@@ -55,20 +55,23 @@ const AgendaItemRow = props => {
             <div className="poly-slash" style={{ backgroundColor: borderColor, color: borderColor }} >_</div>
           </div>
           <div className="ai-history-row-panel-date">
-            Panel Date: {agenda.panel_date ? formatDate(agenda.panel_date) : 'N/A'}
+            {
+              isPanelMeetingView &&
+              <div className="panel-meeting-agendas-user-info">
+                <div className="item"><span className="label">Bureau: </span> {userBureau}</div>
+                <div className="item"><span className="label">Grade: </span> {userGrade}</div>
+                <div className="item"><span className="label">Language: </span> {userLanguage}</div>
+                <div className="item"><span className="label">Skill: </span> {userSkill}</div>
+              </div>
+            }
+            <div>
+              Panel Date: {agenda.panel_date ? formatDate(agenda.panel_date) : 'N/A'}
+            </div>
           </div>
           {
             isPanelMeetingView &&
-            <div className="panel-meeting-agendas-user-info">
-              <div className="panel-meeting-agendas-profile-link">
-                <Link to="/profile/public/4">Townpost, Jenny Y.</Link>
-              </div>
-              <div>
-                <div className="item"><strong>Bureau: </strong> {userBureau}</div>
-                <div className="item"><strong>Grade: </strong> {userGrade}</div>
-                <div className="item"><strong>Language: </strong> {userLanguage}</div>
-                <div className="item"><strong>Skill: </strong> {userSkill}</div>
-              </div>
+            <div className="panel-meeting-agendas-profile-link">
+              <Link to="/profile/public/4">Townpost, Jenny Y.</Link>
             </div>
           }
           <AgendaItemLegs legs={agenda.legs} remarks={agenda.remarks} />

--- a/src/Components/Agenda/AgendaItemRow/AgendaItemRow.jsx
+++ b/src/Components/Agenda/AgendaItemRow/AgendaItemRow.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { get } from 'lodash';
-// import { useSelector } from 'react-redux';
 import FA from 'react-fontawesome';
 import InteractiveElement from 'Components/InteractiveElement';
 import { formatDate } from 'utilities';
@@ -20,8 +19,6 @@ const AgendaItemRow = props => {
 
   const userRole = isCDO ? 'cdo' : 'ao';
   const perdet$ = perdet || get(agenda, 'perdet');
-
-  // const panelAgendas = useSelector(state => state.panelMeetingAgendas[0]);
 
   const userSkill = get(agenda, 'skill' || 'None Listed');
   const userLanguage = get(agenda, 'language' || 'None Listed');

--- a/src/Components/Panel/PanelMeetingAgendas/PanelMeetingAgendas.jsx
+++ b/src/Components/Panel/PanelMeetingAgendas/PanelMeetingAgendas.jsx
@@ -422,6 +422,7 @@ const PanelMeetingAgendas = ({ isCDO }) => {
                     isCDO={isCDO}
                     isAIHView
                     agenda={result}
+                    isPanelMeetingView
                   />
                 ))
               }

--- a/src/actions/panelMeetingAgendas.js
+++ b/src/actions/panelMeetingAgendas.js
@@ -9,6 +9,10 @@ const dummyAgenda = [
     panel_date: '2015-02-14T00:00:00Z',
     status: 'BR',
     status_full: 'Item Status: Ready',
+    skill: 'CONSULAR AFFAIRS (3001)',
+    bureau: '(DGHR) DIR GEN OF THE FOR SER & DIR OF HUMAN RESOURCES',
+    language: 'Spanish 3/3',
+    grade: '03',
     remarks: [
       {
         active_ind: 'Y',

--- a/src/sass/_panelMeetingAgendas.scss
+++ b/src/sass/_panelMeetingAgendas.scss
@@ -77,7 +77,7 @@
 
       .ai-history-row-panel-date {
         display: flex;
-        justify-content: flex-end;
+        justify-content: space-between;
         font-size: large;
 
         @media screen and (max-width: 1600px) {
@@ -229,19 +229,24 @@
 
   .panel-meeting-agendas-user-info {
     display: flex;
-    justify-content: space-between;
+    flex-wrap: wrap;
     align-items: center;
     width: 750px;
-    margin: 10px 0px 5px 20px;
-
-    .panel-meeting-agendas-profile-link {
-      font-weight: bold;
-      font-size: 1.8rem;
-    }
+    margin-left: 300px;
 
     .item {
       font-size: 1.4rem;
       width: 100%;
+
+      .label {
+        font-weight: bold;
+      }
     }
+  }
+
+  .panel-meeting-agendas-profile-link {
+    font-weight: bold;
+    font-size: 1.8rem;
+    margin: -20px 0px 20px 3rem;
   }
 }

--- a/src/sass/_panelMeetingAgendas.scss
+++ b/src/sass/_panelMeetingAgendas.scss
@@ -226,4 +226,22 @@
     margin-left: 20px;
     font-family: 'Roboto';
   }
+
+  .panel-meeting-agendas-user-info {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 750px;
+    margin: 10px 0px 5px 20px;
+
+    .panel-meeting-agendas-profile-link {
+      font-weight: bold;
+      font-size: 1.8rem;
+    }
+
+    .item {
+      font-size: 1.4rem;
+      width: 100%;
+    }
+  }
 }

--- a/src/sass/_panelMeetingAgendas.scss
+++ b/src/sass/_panelMeetingAgendas.scss
@@ -249,7 +249,6 @@
   .panel-meeting-agendas-user-info {
     display: flex;
     flex-wrap: wrap;
-    align-items: center;
     width: 750px;
     margin-left: 300px;
 


### PR DESCRIPTION
ACs
1. Bureau
2. Skill
3. Language
4. Grade
5. Profile link to Jenny (hard coded)

I went ahead and put a check (isPanelMeetingView) on AgendaItemRows so that this new information doesn't show up on Agenda Item History cards. All data is hard coded (new info is passed in with the dummy agenda from action file)


Ticket Design:
![image](https://user-images.githubusercontent.com/31417027/203089606-0d57b491-c730-44be-b993-e6e8f906f3ea.png)


Implementation:
<img width="1539" alt="image" src="https://user-images.githubusercontent.com/31417027/202787545-5f8ea0e9-45fa-4864-8d77-025328fb7632.png">
