### PR TITLE
TM-3700: UI Panel Meeting Link

### DIFF
--- a/src/Components/Agenda/EmployeeAgendaSearchCard/EmployeeAgendaSearchCard.jsx
+++ b/src/Components/Agenda/EmployeeAgendaSearchCard/EmployeeAgendaSearchCard.jsx
@@ -8,7 +8,7 @@ import { get, isNil } from 'lodash';
 import BoxShadow from 'Components/BoxShadow';
 import { formatDate } from 'utilities';
 
-export const FALLBACK = 'None listed';
+export const FALLBACK = 'None Listed';
 
 const EmployeeAgendaSearchCard = ({ isCDO, result, showCreate, viewType }) => {
   // will need to update during integration
@@ -99,7 +99,16 @@ const EmployeeAgendaSearchCard = ({ isCDO, result, showCreate, viewType }) => {
         <div className="employee-card-data-point">
           <FA name="calendar-o" />
           <dt>Panel Meeting Date:</dt>
-          <dd>{panelDate}</dd>
+          {
+            panelDate !== FALLBACK ?
+              <dd>
+                <Link to={`/profile/${userRole}/panelmeetingagendas/`}>
+                  {panelDate}
+                </Link>
+              </dd>
+              :
+              <dd>{panelDate}</dd>
+          }
         </div>
         <div className="employee-card-data-point">
           <FA name="sticky-note-o" />

--- a/src/Components/Agenda/EmployeeAgendaSearchCard/__snapshots__/EmployeeAgendaSearchCard.test.jsx.snap
+++ b/src/Components/Agenda/EmployeeAgendaSearchCard/__snapshots__/EmployeeAgendaSearchCard.test.jsx.snap
@@ -24,7 +24,7 @@ exports[`EmployeeAgendaSearchCards matches snapshot 1`] = `
   >
     <div>
       <h3>
-        None listed
+        None Listed
       </h3>
     </div>
     <div
@@ -37,7 +37,7 @@ exports[`EmployeeAgendaSearchCards matches snapshot 1`] = `
         ID:
       </dt>
       <dd>
-        None listed
+        None Listed
       </dd>
     </div>
     <div
@@ -50,12 +50,12 @@ exports[`EmployeeAgendaSearchCards matches snapshot 1`] = `
         Org:
       </dt>
       <dd>
-        None listed
+        None Listed
         <FontAwesome
           className="org-fa-arrow"
           name="long-arrow-right"
         />
-        None listed
+        None Listed
       </dd>
     </div>
     <div
@@ -68,7 +68,7 @@ exports[`EmployeeAgendaSearchCards matches snapshot 1`] = `
         TED:
       </dt>
       <dd>
-        None listed
+        None Listed
       </dd>
     </div>
     <div
@@ -81,7 +81,7 @@ exports[`EmployeeAgendaSearchCards matches snapshot 1`] = `
         CDO:
       </dt>
       <dd>
-        None listed
+        None Listed
       </dd>
     </div>
     <div
@@ -94,7 +94,7 @@ exports[`EmployeeAgendaSearchCards matches snapshot 1`] = `
         Panel Meeting Date:
       </dt>
       <dd>
-        None listed
+        None Listed
       </dd>
     </div>
     <div
@@ -107,7 +107,7 @@ exports[`EmployeeAgendaSearchCards matches snapshot 1`] = `
         Agenda Status:
       </dt>
       <dd>
-        None listed
+        None Listed
       </dd>
     </div>
   </div>

--- a/src/Components/Agenda/EmployeeAgendaSearchRow/EmployeeAgendaSearchRow.jsx
+++ b/src/Components/Agenda/EmployeeAgendaSearchRow/EmployeeAgendaSearchRow.jsx
@@ -92,7 +92,16 @@ const EmployeeAgendaSearchRow = ({ isCDO, result, showCreate, viewType }) => {
           <div className="employee-agenda-row-data-point">
             <FA name="calendar-o" />
             <dt>Panel Meeting Date:</dt>
-            <dd>{panelDate}</dd>
+            {
+              panelDate !== FALLBACK ?
+                <dd>
+                  <Link to={`/profile/${userRole}/panelmeetingagendas/`}>
+                    {panelDate}
+                  </Link>
+                </dd>
+                :
+                <dd>{panelDate}</dd>
+            }
           </div>
           <div className="employee-agenda-row-data-point">
             <FA name="sticky-note-o" />

--- a/src/Components/Agenda/EmployeeAgendaSearchRow/__snapshots__/EmployeeAgendaSearchRow.test.jsx.snap
+++ b/src/Components/Agenda/EmployeeAgendaSearchRow/__snapshots__/EmployeeAgendaSearchRow.test.jsx.snap
@@ -28,9 +28,9 @@ exports[`EmployeeAgendaSearchRow matches snapshot 1`] = `
     <div
       className="row-name"
     >
-      None listed
+      None Listed
        (
-      None listed
+      None Listed
       )
     </div>
   </div>
@@ -50,12 +50,12 @@ exports[`EmployeeAgendaSearchRow matches snapshot 1`] = `
           Org:
         </dt>
         <dd>
-          None listed
+          None Listed
           <FontAwesome
             className="org-fa-arrow"
             name="long-arrow-right"
           />
-          None listed
+          None Listed
         </dd>
       </div>
       <div
@@ -68,7 +68,7 @@ exports[`EmployeeAgendaSearchRow matches snapshot 1`] = `
           TED:
         </dt>
         <dd>
-          None listed
+          None Listed
         </dd>
       </div>
       <div
@@ -81,7 +81,7 @@ exports[`EmployeeAgendaSearchRow matches snapshot 1`] = `
           CDO:
         </dt>
         <dd>
-          None listed
+          None Listed
         </dd>
       </div>
       <div
@@ -94,7 +94,7 @@ exports[`EmployeeAgendaSearchRow matches snapshot 1`] = `
           Panel Meeting Date:
         </dt>
         <dd>
-          None listed
+          None Listed
         </dd>
       </div>
       <div
@@ -107,7 +107,7 @@ exports[`EmployeeAgendaSearchRow matches snapshot 1`] = `
           Agenda Status:
         </dt>
         <dd>
-          None listed
+          None Listed
         </dd>
       </div>
     </div>


### PR DESCRIPTION
Set up link on employee agenda search cards and rows which takes user to the placeholder Panel Meeting Agendas screen with the dummy agenda data. None of the employees displayed have an actual panel date, so for testing I just flipped the !== to === and checked the 'None Listed' link to see if it took the user to the Panel Meeting Agendas screen (I don't know how to insert a fake panel meeting date into these cards/rows)

Also capitalized the 'L' in 'None listed' lol

ACs
1. Verify link on employee agenda card view
2. Verify link on employee agenda row view

[Mock PR](https://github.com/MetaPhase-Consulting/mock-fsbid/pull/322)