### PR TITLE
edit position details edit TM-3707

### DIFF
--- a/src/Components/EditPositionDetails/PositionDetailsCard/PositionDetailsCard.jsx
+++ b/src/Components/EditPositionDetails/PositionDetailsCard/PositionDetailsCard.jsx
@@ -70,77 +70,79 @@ const PositionDetailsCard = ({ result }) => {
   };
 
   return (
-    <Row fluid className="bureau-results-card">
-      <Row fluid>
-        <Row fluid className="bureau-card--section bureau-card--header">
-          <div><h3>{title}</h3></div>
-          <div className="toggle-edit-position">
-            <ToggleButton
-              labelTextRight="Edit Position"
-              checked={editMode}
-              onChange={() => setEditMode(!editMode)}
-              onColor="#0071BC"
-            />
-          </div>
+    <>
+      <div className="toggle-edit-position">
+        <ToggleButton
+          labelTextRight="Edit Position"
+          checked={editMode}
+          onChange={() => setEditMode(!editMode)}
+          onColor="#0071BC"
+        />
+      </div>
+      <Row fluid className="bureau-results-card">
+        <Row fluid>
+          <Row fluid className="bureau-card--section bureau-card--header">
+            <div><h3>{title}</h3></div>
+          </Row>
+          <Row fluid className="bureau-card--section bureau-card--header">
+            <DefinitionList itemProps={{ excludeColon: false }} items={sections[2]} className="bureau-definition" />
+          </Row>
+          <Row fluid className="bureau-card--section bureau-card--content">
+            <DefinitionList itemProps={{ excludeColon: true }} items={sections[0]} className="bureau-definition" />
+          </Row>
+          <Row fluid className="bureau-card--section bureau-card--footer">
+            <DefinitionList items={sections[1]} className="bureau-definition" />
+            {
+              !editMode &&
+              <div className="usa-grid-full toggle-more-container">
+                <InteractiveElement className="toggle-more" onClick={() => setShowMore(!showMore)}>
+                  <span>View {showMore ? 'less' : 'more'} </span>
+                  <FA name={`chevron-${showMore ? 'up' : 'down'}`} />
+                </InteractiveElement>
+              </div>
+            }
+          </Row>
         </Row>
-        <Row fluid className="bureau-card--section bureau-card--header">
-          <DefinitionList itemProps={{ excludeColon: false }} items={sections[2]} className="bureau-definition" />
-        </Row>
-        <Row fluid className="bureau-card--section bureau-card--content">
-          <DefinitionList itemProps={{ excludeColon: true }} items={sections[0]} className="bureau-definition" />
-        </Row>
-        <Row fluid className="bureau-card--section bureau-card--footer">
-          <DefinitionList items={sections[1]} className="bureau-definition" />
-          { !editMode &&
-            <div className="usa-grid-full toggle-more-container">
-              <InteractiveElement className="toggle-more" onClick={() => setShowMore(!showMore)}>
-                <span>View {showMore ? 'less' : 'more'} </span>
-                <FA name={`chevron-${showMore ? 'up' : 'down'}`} />
-              </InteractiveElement>
-            </div>
-          }
-        </Row>
-      </Row>
-      {
-        showMore && !editMode &&
-        <Row fluid className="bureau-card--description">
-          <Linkify properties={{ target: '_blank' }}>
-            {description}
-          </Linkify>
-        </Row>
-      }
-      {
-        editMode &&
-        <div>
+        {
+          showMore && !editMode &&
           <Row fluid className="bureau-card--description">
             <Linkify properties={{ target: '_blank' }}>
-              <TextareaAutosize
-                maxRows={4}
-                minRows={4}
-                maxlength="255"
-                name="position-description"
-                placeholder="No Description"
-                defaultValue={description}
-                onChange={e => setDescription(e.target.value)}
-                disabled={isDisabled}
-                className={isDisabled ? 'disabled-input' : ''}
-              />
+              {description}
             </Linkify>
           </Row>
-          {
-            !isDisabled &&
-            <div className="edit-pos-details-btns">
-              <button onClick={updatePosition}>
+        }
+        {
+          editMode &&
+          <div>
+            <Row fluid className="bureau-card--description">
+              <Linkify properties={{ target: '_blank' }}>
+                <TextareaAutosize
+                  maxRows={4}
+                  minRows={4}
+                  name="position-description"
+                  placeholder="No Description"
+                  defaultValue={description}
+                  onChange={e => setDescription(e.target.value)}
+                  disabled={isDisabled}
+                  className={isDisabled ? 'disabled-input' : ''}
+                />
+              </Linkify>
+            </Row>
+            {
+              !isDisabled &&
+              <div className="edit-pos-details-btns">
+                <button onClick={updatePosition}>
                   Update
-              </button>
-              <button onClick={cancelInput}>
+                </button>
+                <button onClick={cancelInput}>
                   Cancel
-              </button>
-            </div>
-          }
-        </div>
-      }
-    </Row>
+                </button>
+              </div>
+            }
+          </div>
+        }
+      </Row>
+    </>
   );
 };
 

--- a/src/Components/EditPositionDetails/PositionDetailsCard/PositionDetailsCard.jsx
+++ b/src/Components/EditPositionDetails/PositionDetailsCard/PositionDetailsCard.jsx
@@ -1,6 +1,4 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
-import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import FA from 'react-fontawesome';
 import Linkify from 'react-linkify';
@@ -18,7 +16,7 @@ import {
 import { POSITION_DETAILS } from 'Constants/PropTypes';
 import TextareaAutosize from 'react-textarea-autosize';
 
-const PositionDetailsCard = ({ result, isProjectedVacancy }) => {
+const PositionDetailsCard = ({ result }) => {
   const pos = get(result, 'position') || result;
 
   const title = propOrDefault(pos, 'title');
@@ -29,14 +27,10 @@ const PositionDetailsCard = ({ result, isProjectedVacancy }) => {
 
   const postShort = `${getPostName(get(pos, 'post') || NO_POST)}`;
   const description$ = shortenString(get(pos, 'description.content') || 'No description.', 2000);
-  const id = get(result, 'id') || '';
 
   const [showMore, setShowMore] = useState(false);
   const [editPositionData, setEditPositionData] = useState(false);
   const [description, setDescription] = useState(description$);
-
-  const detailsLink = (<Link to={`/profile/bureau/positionmanager/${isProjectedVacancy ? 'vacancy' : 'available'}/${id}`}>
-    <h3>{title}</h3></Link>);
 
   const sections = [
     /* eslint-disable quote-props */
@@ -94,7 +88,7 @@ const PositionDetailsCard = ({ result, isProjectedVacancy }) => {
     <Row fluid className="bureau-results-card">
       <Row fluid>
         <Row fluid className="bureau-card--section bureau-card--header">
-          <div>{detailsLink}</div>
+          <div><h3>{title}</h3></div>
           <InteractiveElement onClick={() => editPosition()}>
             <FA name="pencil-square-o" className="fa-lg" />
           </InteractiveElement>
@@ -155,11 +149,6 @@ const PositionDetailsCard = ({ result, isProjectedVacancy }) => {
 
 PositionDetailsCard.propTypes = {
   result: POSITION_DETAILS.isRequired,
-  isProjectedVacancy: PropTypes.bool,
-};
-
-PositionDetailsCard.defaultProps = {
-  isProjectedVacancy: false,
 };
 
 export default PositionDetailsCard;

--- a/src/Components/EditPositionDetails/PositionDetailsCard/PositionDetailsCard.jsx
+++ b/src/Components/EditPositionDetails/PositionDetailsCard/PositionDetailsCard.jsx
@@ -72,7 +72,11 @@ const PositionDetailsCard = ({ result, isProjectedVacancy }) => {
   };
 
   const editPosition = () => {
-    setShowMore(!showMore);
+    if (showMore && !editPositionData) {
+      setEditPositionData(true);
+    } else {
+      setShowMore(!showMore);
+    }
     setEditPositionData(!editPositionData);
   };
 
@@ -125,7 +129,6 @@ const PositionDetailsCard = ({ result, isProjectedVacancy }) => {
           <Row fluid className="bureau-card--description">
             <Linkify properties={{ target: '_blank' }}>
               <TextareaAutosize
-                /* make sure this matches height in _availableBidders.scss edit this later */
                 maxRows={4}
                 minRows={4}
                 maxlength="255"

--- a/src/Components/EditPositionDetails/PositionDetailsCard/PositionDetailsCard.jsx
+++ b/src/Components/EditPositionDetails/PositionDetailsCard/PositionDetailsCard.jsx
@@ -30,10 +30,9 @@ const PositionDetailsCard = ({ result }) => {
   const description$ = shortenString(get(pos, 'description.content') || 'No description.', 2000);
 
   const [showMore, setShowMore] = useState(false);
-  const [editPositionData, setEditPositionData] = useState(false);
+  const [editMode, setEditMode] = useState(false);
   const [description, setDescription] = useState(description$);
 
-  // need to integrate with later
   const isDisabled = false;
 
   const sections = [
@@ -62,12 +61,12 @@ const PositionDetailsCard = ({ result }) => {
 
   const updatePosition = () => {
     setDescription(description);
-    setEditPositionData(false);
+    setEditMode(false);
   };
 
   const cancelInput = () => {
     setDescription(description$);
-    setEditPositionData(false);
+    setEditMode(false);
   };
 
   return (
@@ -78,8 +77,8 @@ const PositionDetailsCard = ({ result }) => {
           <div className="toggle-edit-position">
             <ToggleButton
               labelTextRight="Edit Position"
-              checked={editPositionData}
-              onChange={() => setEditPositionData(!editPositionData)}
+              checked={editMode}
+              onChange={() => setEditMode(!editMode)}
               onColor="#0071BC"
             />
           </div>
@@ -92,7 +91,7 @@ const PositionDetailsCard = ({ result }) => {
         </Row>
         <Row fluid className="bureau-card--section bureau-card--footer">
           <DefinitionList items={sections[1]} className="bureau-definition" />
-          { !editPositionData &&
+          { !editMode &&
             <div className="usa-grid-full toggle-more-container">
               <InteractiveElement className="toggle-more" onClick={() => setShowMore(!showMore)}>
                 <span>View {showMore ? 'less' : 'more'} </span>
@@ -103,7 +102,7 @@ const PositionDetailsCard = ({ result }) => {
         </Row>
       </Row>
       {
-        showMore && !editPositionData &&
+        showMore && !editMode &&
         <Row fluid className="bureau-card--description">
           <Linkify properties={{ target: '_blank' }}>
             {description}
@@ -111,7 +110,7 @@ const PositionDetailsCard = ({ result }) => {
         </Row>
       }
       {
-        editPositionData &&
+        editMode &&
         <div>
           <Row fluid className="bureau-card--description">
             <Linkify properties={{ target: '_blank' }}>

--- a/src/Components/EditPositionDetails/PositionDetailsCard/PositionDetailsCard.jsx
+++ b/src/Components/EditPositionDetails/PositionDetailsCard/PositionDetailsCard.jsx
@@ -62,10 +62,28 @@ const PositionDetailsCard = ({ result, isProjectedVacancy }) => {
     /* eslint-enable quote-props */
   ];
 
+  const toggleView = () => {
+    if (showMore && editPositionData) {
+      setShowMore(false);
+      setEditPositionData(false);
+    } else {
+      setShowMore(!showMore);
+    }
+  };
+
   const editPosition = () => {
     setShowMore(!showMore);
     setEditPositionData(!editPositionData);
-    // setDescription()
+  };
+
+  const updatePosition = () => {
+    setDescription(description);
+    setEditPositionData(false);
+  };
+
+  const cancelInput = () => {
+    setShowMore(false);
+    setEditPositionData(false);
   };
 
   return (
@@ -86,7 +104,7 @@ const PositionDetailsCard = ({ result, isProjectedVacancy }) => {
         <Row fluid className="bureau-card--section bureau-card--footer">
           <DefinitionList items={sections[1]} className="bureau-definition" />
           <div className="usa-grid-full toggle-more-container">
-            <InteractiveElement className="toggle-more" onClick={() => setShowMore(!showMore)}>
+            <InteractiveElement className="toggle-more" onClick={toggleView}>
               <span>View {showMore ? 'less' : 'more'} </span>
               <FA name={`chevron-${showMore ? 'up' : 'down'}`} />
             </InteractiveElement>
@@ -94,7 +112,7 @@ const PositionDetailsCard = ({ result, isProjectedVacancy }) => {
         </Row>
       </Row>
       {
-        showMore &&
+        showMore && !editPositionData &&
         <Row fluid className="bureau-card--description">
           <Linkify properties={{ target: '_blank' }}>
             {description}
@@ -102,7 +120,7 @@ const PositionDetailsCard = ({ result, isProjectedVacancy }) => {
         </Row>
       }
       {
-        (showMore && (editPositionData)) &&
+        editPositionData &&
         <div>
           <Row fluid className="bureau-card--description">
             <Linkify properties={{ target: '_blank' }}>
@@ -118,12 +136,14 @@ const PositionDetailsCard = ({ result, isProjectedVacancy }) => {
               />
             </Linkify>
           </Row>
-          <button>
-            Update
-          </button>
-          <button>
-            Cancel
-          </button>
+          <div className="edit-pos-details-btns">
+            <button onClick={updatePosition}>
+              Update
+            </button>
+            <button onClick={cancelInput}>
+              Cancel
+            </button>
+          </div>
         </div>
       }
     </Row>

--- a/src/Components/EditPositionDetails/PositionDetailsCard/PositionDetailsCard.jsx
+++ b/src/Components/EditPositionDetails/PositionDetailsCard/PositionDetailsCard.jsx
@@ -119,6 +119,7 @@ const PositionDetailsCard = ({ result }) => {
                 <TextareaAutosize
                   maxRows={4}
                   minRows={4}
+                  maxlength="4000"
                   name="position-description"
                   placeholder="No Description"
                   defaultValue={description}

--- a/src/Components/EditPositionDetails/PositionDetailsCard/PositionDetailsCard.jsx
+++ b/src/Components/EditPositionDetails/PositionDetailsCard/PositionDetailsCard.jsx
@@ -15,6 +15,7 @@ import {
 } from 'Constants/SystemMessages';
 import { POSITION_DETAILS } from 'Constants/PropTypes';
 import TextareaAutosize from 'react-textarea-autosize';
+import ToggleButton from 'Components/ToggleButton';
 
 const PositionDetailsCard = ({ result }) => {
   const pos = get(result, 'position') || result;
@@ -31,6 +32,9 @@ const PositionDetailsCard = ({ result }) => {
   const [showMore, setShowMore] = useState(false);
   const [editPositionData, setEditPositionData] = useState(false);
   const [description, setDescription] = useState(description$);
+
+  // need to integrate with later
+  const isDisabled = false;
 
   const sections = [
     /* eslint-disable quote-props */
@@ -80,7 +84,7 @@ const PositionDetailsCard = ({ result }) => {
   };
 
   const cancelInput = () => {
-    setShowMore(false);
+    setDescription(description$);
     setEditPositionData(false);
   };
 
@@ -89,9 +93,14 @@ const PositionDetailsCard = ({ result }) => {
       <Row fluid>
         <Row fluid className="bureau-card--section bureau-card--header">
           <div><h3>{title}</h3></div>
-          <InteractiveElement onClick={() => editPosition()}>
-            <FA name="pencil-square-o" className="fa-lg" />
-          </InteractiveElement>
+          <div className="toggle-edit-position">
+            <ToggleButton
+              labelTextRight="Edit Position"
+              checked={editPositionData}
+              onChange={editPosition}
+              onColor="#0071BC"
+            />
+          </div>
         </Row>
         <Row fluid className="bureau-card--section bureau-card--header">
           <DefinitionList itemProps={{ excludeColon: false }} items={sections[2]} className="bureau-definition" />
@@ -101,12 +110,14 @@ const PositionDetailsCard = ({ result }) => {
         </Row>
         <Row fluid className="bureau-card--section bureau-card--footer">
           <DefinitionList items={sections[1]} className="bureau-definition" />
-          <div className="usa-grid-full toggle-more-container">
-            <InteractiveElement className="toggle-more" onClick={toggleView}>
-              <span>View {showMore ? 'less' : 'more'} </span>
-              <FA name={`chevron-${showMore ? 'up' : 'down'}`} />
-            </InteractiveElement>
-          </div>
+          { !editPositionData &&
+            <div className="usa-grid-full toggle-more-container">
+              <InteractiveElement className="toggle-more" onClick={toggleView}>
+                <span>View {showMore ? 'less' : 'more'} </span>
+                <FA name={`chevron-${showMore ? 'up' : 'down'}`} />
+              </InteractiveElement>
+            </div>
+          }
         </Row>
       </Row>
       {
@@ -130,6 +141,8 @@ const PositionDetailsCard = ({ result }) => {
                 placeholder="No Description"
                 defaultValue={description}
                 onChange={e => setDescription(e.target.value)}
+                disabled={isDisabled}
+                className={isDisabled ? 'disabled-input' : ''}
               />
             </Linkify>
           </Row>

--- a/src/Components/EditPositionDetails/PositionDetailsCard/PositionDetailsCard.jsx
+++ b/src/Components/EditPositionDetails/PositionDetailsCard/PositionDetailsCard.jsx
@@ -135,7 +135,7 @@ const PositionDetailsCard = ({ result, isProjectedVacancy }) => {
                 name="position-description"
                 placeholder="No Description"
                 defaultValue={description}
-                onChange={(e) => setDescription(e.target.value)}
+                onChange={e => setDescription(e.target.value)}
               />
             </Linkify>
           </Row>

--- a/src/Components/EditPositionDetails/PositionDetailsCard/PositionDetailsCard.jsx
+++ b/src/Components/EditPositionDetails/PositionDetailsCard/PositionDetailsCard.jsx
@@ -8,7 +8,7 @@ import DefinitionList from 'Components/DefinitionList';
 import InteractiveElement from 'Components/InteractiveElement';
 import { getDifferentials, getResult } from 'Components/ResultsCard/ResultsCard';
 import LanguageList from 'Components/LanguageList';
-import { getPostName, propOrDefault, shortenString } from 'utilities';
+import { getPostName, propOrDefault } from 'utilities';
 import {
   NO_BUREAU, NO_DATE, NO_GRADE,
   NO_POSITION_NUMBER, NO_POST, NO_SKILL, NO_TOUR_OF_DUTY, NO_UPDATE_DATE, NO_USER_LISTED,
@@ -27,7 +27,7 @@ const PositionDetailsCard = ({ result }) => {
   const language = (<LanguageList languages={languages} propToUse="representation" />);
 
   const postShort = `${getPostName(get(pos, 'post') || NO_POST)}`;
-  const description$ = shortenString(get(pos, 'description.content') || 'No description.', 2000);
+  const description$ = get(pos, 'description.content') || 'No description.';
 
   const [showMore, setShowMore] = useState(false);
   const [editMode, setEditMode] = useState(false);

--- a/src/Components/EditPositionDetails/PositionDetailsCard/PositionDetailsCard.jsx
+++ b/src/Components/EditPositionDetails/PositionDetailsCard/PositionDetailsCard.jsx
@@ -60,24 +60,6 @@ const PositionDetailsCard = ({ result }) => {
     /* eslint-enable quote-props */
   ];
 
-  const toggleView = () => {
-    if (showMore && editPositionData) {
-      setShowMore(false);
-      setEditPositionData(false);
-    } else {
-      setShowMore(!showMore);
-    }
-  };
-
-  const editPosition = () => {
-    if (showMore && !editPositionData) {
-      setEditPositionData(true);
-    } else {
-      setShowMore(!showMore);
-    }
-    setEditPositionData(!editPositionData);
-  };
-
   const updatePosition = () => {
     setDescription(description);
     setEditPositionData(false);
@@ -97,7 +79,7 @@ const PositionDetailsCard = ({ result }) => {
             <ToggleButton
               labelTextRight="Edit Position"
               checked={editPositionData}
-              onChange={editPosition}
+              onChange={() => setEditPositionData(!editPositionData)}
               onColor="#0071BC"
             />
           </div>
@@ -112,7 +94,7 @@ const PositionDetailsCard = ({ result }) => {
           <DefinitionList items={sections[1]} className="bureau-definition" />
           { !editPositionData &&
             <div className="usa-grid-full toggle-more-container">
-              <InteractiveElement className="toggle-more" onClick={toggleView}>
+              <InteractiveElement className="toggle-more" onClick={() => setShowMore(!showMore)}>
                 <span>View {showMore ? 'less' : 'more'} </span>
                 <FA name={`chevron-${showMore ? 'up' : 'down'}`} />
               </InteractiveElement>
@@ -146,14 +128,17 @@ const PositionDetailsCard = ({ result }) => {
               />
             </Linkify>
           </Row>
-          <div className="edit-pos-details-btns">
-            <button onClick={updatePosition}>
-              Update
-            </button>
-            <button onClick={cancelInput}>
-              Cancel
-            </button>
-          </div>
+          {
+            !isDisabled &&
+            <div className="edit-pos-details-btns">
+              <button onClick={updatePosition}>
+                  Update
+              </button>
+              <button onClick={cancelInput}>
+                  Cancel
+              </button>
+            </div>
+          }
         </div>
       }
     </Row>

--- a/src/Components/EditPositionDetails/PositionDetailsCard/PositionDetailsCard.jsx
+++ b/src/Components/EditPositionDetails/PositionDetailsCard/PositionDetailsCard.jsx
@@ -16,11 +16,9 @@ import {
   NO_POSITION_NUMBER, NO_POST, NO_SKILL, NO_TOUR_OF_DUTY, NO_UPDATE_DATE, NO_USER_LISTED,
 } from 'Constants/SystemMessages';
 import { POSITION_DETAILS } from 'Constants/PropTypes';
+import TextareaAutosize from 'react-textarea-autosize';
 
 const PositionDetailsCard = ({ result, isProjectedVacancy }) => {
-  const [showMore, setShowMore] = useState(false);
-
-
   const pos = get(result, 'position') || result;
 
   const title = propOrDefault(pos, 'title');
@@ -30,8 +28,12 @@ const PositionDetailsCard = ({ result, isProjectedVacancy }) => {
   const language = (<LanguageList languages={languages} propToUse="representation" />);
 
   const postShort = `${getPostName(get(pos, 'post') || NO_POST)}`;
-  const description = shortenString(get(pos, 'description.content') || 'No description.', 2000);
+  const description$ = shortenString(get(pos, 'description.content') || 'No description.', 2000);
   const id = get(result, 'id') || '';
+
+  const [showMore, setShowMore] = useState(false);
+  const [editPositionData, setEditPositionData] = useState(false);
+  const [description, setDescription] = useState(description$);
 
   const detailsLink = (<Link to={`/profile/bureau/positionmanager/${isProjectedVacancy ? 'vacancy' : 'available'}/${id}`}>
     <h3>{title}</h3></Link>);
@@ -60,11 +62,20 @@ const PositionDetailsCard = ({ result, isProjectedVacancy }) => {
     /* eslint-enable quote-props */
   ];
 
+  const editPosition = () => {
+    setShowMore(!showMore);
+    setEditPositionData(!editPositionData);
+    // setDescription()
+  };
+
   return (
     <Row fluid className="bureau-results-card">
       <Row fluid>
         <Row fluid className="bureau-card--section bureau-card--header">
           <div>{detailsLink}</div>
+          <InteractiveElement onClick={() => editPosition()}>
+            <FA name="pencil-square-o" className="fa-lg" />
+          </InteractiveElement>
         </Row>
         <Row fluid className="bureau-card--section bureau-card--header">
           <DefinitionList itemProps={{ excludeColon: false }} items={sections[2]} className="bureau-definition" />
@@ -84,11 +95,36 @@ const PositionDetailsCard = ({ result, isProjectedVacancy }) => {
       </Row>
       {
         showMore &&
+        <Row fluid className="bureau-card--description">
+          <Linkify properties={{ target: '_blank' }}>
+            {description}
+          </Linkify>
+        </Row>
+      }
+      {
+        (showMore && (editPositionData)) &&
+        <div>
           <Row fluid className="bureau-card--description">
             <Linkify properties={{ target: '_blank' }}>
-              {description}
+              <TextareaAutosize
+                /* make sure this matches height in _availableBidders.scss edit this later */
+                maxRows={4}
+                minRows={4}
+                maxlength="255"
+                name="position-description"
+                placeholder="No Description"
+                defaultValue={description}
+                onChange={(e) => setDescription(e.target.value)}
+              />
             </Linkify>
           </Row>
+          <button>
+            Update
+          </button>
+          <button>
+            Cancel
+          </button>
+        </div>
       }
     </Row>
   );

--- a/src/Components/EditPositionDetails/PositionDetailsCard/__snapshots__/PositionDetailsCard.test.jsx.snap
+++ b/src/Components/EditPositionDetails/PositionDetailsCard/__snapshots__/PositionDetailsCard.test.jsx.snap
@@ -1,131 +1,141 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PositionDetailsCardComponent matches snapshot 1`] = `
-<Row
-  as="div"
-  className="bureau-results-card"
-  fluid={true}
->
+<Fragment>
+  <div
+    className="toggle-edit-position"
+  >
+    <ToggleButton
+      activeBoxShadow=""
+      boxShadow=""
+      checked={false}
+      checkedIcon={false}
+      height={20}
+      labelSameLine={true}
+      labelText=""
+      labelTextLeft=""
+      labelTextRight="Edit Position"
+      labelToLeft={true}
+      offColor="#888888"
+      offHandleColor="#ffffff"
+      onChange={[Function]}
+      onColor="#0071BC"
+      onHandleColor="#ffffff"
+      uncheckedIcon={false}
+      width={40}
+    />
+  </div>
   <Row
     as="div"
-    className=""
+    className="bureau-results-card"
     fluid={true}
   >
     <Row
       as="div"
-      className="bureau-card--section bureau-card--header"
+      className=""
       fluid={true}
     >
-      <div>
-        <Link
-          replace={false}
-          to="/profile/bureau/positionmanager/available/"
-        >
+      <Row
+        as="div"
+        className="bureau-card--section bureau-card--header"
+        fluid={true}
+      >
+        <div>
           <h3 />
-        </Link>
-      </div>
-      <InteractiveElement
-        className=""
-        onClick={[Function]}
-        type="div"
+        </div>
+      </Row>
+      <Row
+        as="div"
+        className="bureau-card--section bureau-card--header"
+        fluid={true}
       >
-        <FontAwesome
-          className="fa-lg"
-          name="pencil-square-o"
+        <DefinitionList
+          className="bureau-definition"
+          itemProps={
+            Object {
+              "excludeColon": false,
+            }
+          }
+          items={
+            Object {
+              "Location": "null",
+            }
+          }
+          truncate={true}
         />
-      </InteractiveElement>
-    </Row>
-    <Row
-      as="div"
-      className="bureau-card--section bureau-card--header"
-      fluid={true}
-    >
-      <DefinitionList
-        className="bureau-definition"
-        itemProps={
-          Object {
-            "excludeColon": false,
-          }
-        }
-        items={
-          Object {
-            "Location": "null",
-          }
-        }
-        truncate={true}
-      />
-    </Row>
-    <Row
-      as="div"
-      className="bureau-card--section bureau-card--content"
-      fluid={true}
-    >
-      <DefinitionList
-        className="bureau-definition"
-        itemProps={
-          Object {
-            "excludeColon": true,
-          }
-        }
-        items={
-          Object {
-            "Bid cycle": "None Listed",
-            "Bureau": "None listed",
-            "Grade": "None listed",
-            "Incumbent": "None listed",
-            "Language": <LanguageList
-              languages={Array []}
-              propToUse="representation"
-            />,
-            "Position number": "",
-            "Post differential | Danger Pay": <DefinitionList
-              dangerPay="None listed"
-              obcUrl={Object {}}
-              postDifferential="None listed"
-            />,
-            "Posted": "Unknown",
-            "Skill": "None listed",
-            "TED": "None listed",
-            "Tour of duty": "None listed",
-          }
-        }
-        truncate={true}
-      />
-    </Row>
-    <Row
-      as="div"
-      className="bureau-card--section bureau-card--footer"
-      fluid={true}
-    >
-      <DefinitionList
-        className="bureau-definition"
-        itemProps={Object {}}
-        items={
-          Object {
-            "Last Updated": "Unknown",
-          }
-        }
-        truncate={true}
-      />
-      <div
-        className="usa-grid-full toggle-more-container"
+      </Row>
+      <Row
+        as="div"
+        className="bureau-card--section bureau-card--content"
+        fluid={true}
       >
-        <InteractiveElement
-          className="toggle-more"
-          onClick={[Function]}
-          type="div"
+        <DefinitionList
+          className="bureau-definition"
+          itemProps={
+            Object {
+              "excludeColon": true,
+            }
+          }
+          items={
+            Object {
+              "Bid cycle": "None Listed",
+              "Bureau": "None listed",
+              "Grade": "None listed",
+              "Incumbent": "None listed",
+              "Language": <LanguageList
+                languages={Array []}
+                propToUse="representation"
+              />,
+              "Position number": "",
+              "Post differential | Danger Pay": <DefinitionList
+                dangerPay="None listed"
+                obcUrl={Object {}}
+                postDifferential="None listed"
+              />,
+              "Posted": "Unknown",
+              "Skill": "None listed",
+              "TED": "None listed",
+              "Tour of duty": "None listed",
+            }
+          }
+          truncate={true}
+        />
+      </Row>
+      <Row
+        as="div"
+        className="bureau-card--section bureau-card--footer"
+        fluid={true}
+      >
+        <DefinitionList
+          className="bureau-definition"
+          itemProps={Object {}}
+          items={
+            Object {
+              "Last Updated": "Unknown",
+            }
+          }
+          truncate={true}
+        />
+        <div
+          className="usa-grid-full toggle-more-container"
         >
-          <span>
-            View 
-            more
-             
-          </span>
-          <FontAwesome
-            name="chevron-down"
-          />
-        </InteractiveElement>
-      </div>
+          <InteractiveElement
+            className="toggle-more"
+            onClick={[Function]}
+            type="div"
+          >
+            <span>
+              View 
+              more
+               
+            </span>
+            <FontAwesome
+              name="chevron-down"
+            />
+          </InteractiveElement>
+        </div>
+      </Row>
     </Row>
   </Row>
-</Row>
+</Fragment>
 `;

--- a/src/Components/EditPositionDetails/PositionDetailsCard/__snapshots__/PositionDetailsCard.test.jsx.snap
+++ b/src/Components/EditPositionDetails/PositionDetailsCard/__snapshots__/PositionDetailsCard.test.jsx.snap
@@ -24,6 +24,16 @@ exports[`PositionDetailsCardComponent matches snapshot 1`] = `
           <h3 />
         </Link>
       </div>
+      <InteractiveElement
+        className=""
+        onClick={[Function]}
+        type="div"
+      >
+        <FontAwesome
+          className="fa-lg"
+          name="pencil-square-o"
+        />
+      </InteractiveElement>
     </Row>
     <Row
       as="div"

--- a/src/sass/_editPositionDetails.scss
+++ b/src/sass/_editPositionDetails.scss
@@ -76,7 +76,11 @@
   width: 130px;
 }
 
+textarea {
+  max-width: 194rem;
+}
 
 .edit-pos-details-btns {
   float: right;
+  margin-right: -7px;
 }

--- a/src/sass/_editPositionDetails.scss
+++ b/src/sass/_editPositionDetails.scss
@@ -82,7 +82,7 @@
 }
 
 textarea {
-  max-width: 194rem;
+  max-width: 100%;
 }
 
 .edit-pos-details-btns {

--- a/src/sass/_editPositionDetails.scss
+++ b/src/sass/_editPositionDetails.scss
@@ -75,3 +75,8 @@
   white-space: nowrap;
   width: 130px;
 }
+
+
+.edit-pos-details-btns {
+  float: right;
+}

--- a/src/sass/_editPositionDetails.scss
+++ b/src/sass/_editPositionDetails.scss
@@ -76,6 +76,12 @@
   width: 130px;
 }
 
+.toggle-edit-position {
+  float: right;
+  padding-top: 15px;
+  padding-right: 5px;
+}
+
 .disabled-input {
   background-color: $bg-gray-dark-3;
   cursor: not-allowed;

--- a/src/sass/_editPositionDetails.scss
+++ b/src/sass/_editPositionDetails.scss
@@ -76,6 +76,11 @@
   width: 130px;
 }
 
+.disabled-input {
+  background-color: $bg-gray-dark-3;
+  cursor: not-allowed;
+}
+
 textarea {
   max-width: 194rem;
 }


### PR DESCRIPTION
To-do
- [x] add pencil icon
- [x] clicking pencil icon allows position details to be editable
- [x] position text is editable


New To-do's
- [x] remove pencil
- [x] add toggle button to top right (similar to op tandem search)
- [x] when toggling to edit, allows editable data to be editable and view more/less goes away (bad grammar I know 😅)
- [x] when toggling to disable edit, card is no longer editable and view more/less reappears
- [x] when toggling edit and a field (capsule description only atm) is disabled, grey out the field 
- [x] capsule description should be editable (there was a 255 max length lol)