### PR TITLE
TM-3731: Client Profiles - Combine Location & Org

### DIFF
--- a/src/Components/BidderPortfolio/BidderPortfolioStatCard/BidderPortfolioStatCard.jsx
+++ b/src/Components/BidderPortfolio/BidderPortfolioStatCard/BidderPortfolioStatCard.jsx
@@ -17,10 +17,8 @@ const BidderPortfolioStatCard = ({ userProfile, classifications }) => {
   const ted = formatDate(get(userProfile, 'current_assignment.end_date'));
   const languages = get(userProfile, 'current_assignment.position.language');
   const bidder = get(userProfile, 'shortened_name') || 'None listed';
+  const orgShortDesc = get(userProfile, 'current_assignment.position.organization');
 
-  const orgShort = get(userProfile, 'current_assignment.position.organization');
-  const orgLong = get(userProfile, 'current_assignment.position.organization_long');
-  const orgDesc = `(${orgShort}) ${orgLong}`;
   return (
     <BoxShadow className="usa-grid-full bidder-portfolio-stat-card">
       <div className="bidder-portfolio-stat-card-top">
@@ -45,7 +43,7 @@ const BidderPortfolioStatCard = ({ userProfile, classifications }) => {
           <dt>TED:</dt><dd>{ted || NO_TOUR_END_DATE}</dd>
         </div>
         <div className="stat-card-data-point">
-          <dt>Location (Org):</dt><dd>{currentAssignmentText || NO_POST} {orgDesc}</dd>
+          <dt className="location-label">Location (Org):</dt><dd>{currentAssignmentText || NO_POST} ({orgShortDesc})</dd>
         </div>
       </div>
       <div className="bidder-portfolio-stat-card-bottom">

--- a/src/Components/BidderPortfolio/BidderPortfolioStatCard/BidderPortfolioStatCard.jsx
+++ b/src/Components/BidderPortfolio/BidderPortfolioStatCard/BidderPortfolioStatCard.jsx
@@ -21,7 +21,6 @@ const BidderPortfolioStatCard = ({ userProfile, classifications }) => {
   const orgShort = get(userProfile, 'current_assignment.position.organization');
   const orgLong = get(userProfile, 'current_assignment.position.organization_long');
   const orgDesc = `(${orgShort}) ${orgLong}`;
-  console.log(userProfile);
   return (
     <BoxShadow className="usa-grid-full bidder-portfolio-stat-card">
       <div className="bidder-portfolio-stat-card-top">

--- a/src/Components/BidderPortfolio/BidderPortfolioStatCard/BidderPortfolioStatCard.jsx
+++ b/src/Components/BidderPortfolio/BidderPortfolioStatCard/BidderPortfolioStatCard.jsx
@@ -17,6 +17,11 @@ const BidderPortfolioStatCard = ({ userProfile, classifications }) => {
   const ted = formatDate(get(userProfile, 'current_assignment.end_date'));
   const languages = get(userProfile, 'current_assignment.position.language');
   const bidder = get(userProfile, 'shortened_name') || 'None listed';
+
+  const orgShort = get(userProfile, 'current_assignment.position.organization');
+  const orgLong = get(userProfile, 'current_assignment.position.organization_long');
+  const orgDesc = `(${orgShort}) ${orgLong}`;
+  console.log(userProfile);
   return (
     <BoxShadow className="usa-grid-full bidder-portfolio-stat-card">
       <div className="bidder-portfolio-stat-card-top">
@@ -41,7 +46,7 @@ const BidderPortfolioStatCard = ({ userProfile, classifications }) => {
           <dt>TED:</dt><dd>{ted || NO_TOUR_END_DATE}</dd>
         </div>
         <div className="stat-card-data-point">
-          <dt>Location:</dt><dd>{currentAssignmentText || NO_POST}</dd>
+          <dt>Location (Org):</dt><dd>{currentAssignmentText || NO_POST} {orgDesc}</dd>
         </div>
       </div>
       <div className="bidder-portfolio-stat-card-bottom">

--- a/src/Components/BidderPortfolio/BidderPortfolioStatCard/__snapshots__/BidderPortfolioStatCard.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidderPortfolioStatCard/__snapshots__/BidderPortfolioStatCard.test.jsx.snap
@@ -87,11 +87,15 @@ exports[`BidderPortfolioStatCard matches snapshot 1`] = `
     <div
       className="stat-card-data-point"
     >
-      <dt>
-        Location:
+      <dt
+        className="location-label"
+      >
+        Location (Org):
       </dt>
       <dd>
         None listed
+         (
+        )
       </dd>
     </div>
   </div>

--- a/src/Components/BidderPortfolio/BidderPortfolioStatRow/BidderPortfolioStatRow.jsx
+++ b/src/Components/BidderPortfolio/BidderPortfolioStatRow/BidderPortfolioStatRow.jsx
@@ -18,10 +18,7 @@ const BidderPortfolioStatRow = ({ userProfile, showEdit, classifications }) => {
   const ted = formatDate(get(userProfile, 'current_assignment.end_date'));
   const languages = get(userProfile, 'current_assignment.position.language');
   const bidder = get(userProfile, 'shortened_name') || 'None listed';
-
-  const orgShort = get(userProfile, 'current_assignment.position.organization');
-  const orgLong = get(userProfile, 'current_assignment.position.organization_long');
-  const orgDesc = `(${orgShort}) ${orgLong}`;
+  const orgShortDesc = get(userProfile, 'current_assignment.position.organization');
 
   return (
     <div className="usa-grid-full bidder-portfolio-stat-row">
@@ -46,7 +43,7 @@ const BidderPortfolioStatRow = ({ userProfile, showEdit, classifications }) => {
             <dt>TED:</dt><dd>{ted || NO_TOUR_END_DATE}</dd>
           </div>
           <div className="stat-card-data-point">
-            <dt>Location (Org):</dt><dd>{currentAssignmentText || NO_POST} {orgDesc}</dd>
+            <dt>Location (Org):</dt><dd>{currentAssignmentText || NO_POST} ({orgShortDesc})</dd>
           </div>
         </div>
         {

--- a/src/Components/BidderPortfolio/BidderPortfolioStatRow/BidderPortfolioStatRow.jsx
+++ b/src/Components/BidderPortfolio/BidderPortfolioStatRow/BidderPortfolioStatRow.jsx
@@ -18,6 +18,11 @@ const BidderPortfolioStatRow = ({ userProfile, showEdit, classifications }) => {
   const ted = formatDate(get(userProfile, 'current_assignment.end_date'));
   const languages = get(userProfile, 'current_assignment.position.language');
   const bidder = get(userProfile, 'shortened_name') || 'None listed';
+
+  const orgShort = get(userProfile, 'current_assignment.position.organization');
+  const orgLong = get(userProfile, 'current_assignment.position.organization_long');
+  const orgDesc = `(${orgShort}) ${orgLong}`;
+
   return (
     <div className="usa-grid-full bidder-portfolio-stat-row">
       <div className="stat-card-data-point stat-card-data-point--name">
@@ -41,7 +46,7 @@ const BidderPortfolioStatRow = ({ userProfile, showEdit, classifications }) => {
             <dt>TED:</dt><dd>{ted || NO_TOUR_END_DATE}</dd>
           </div>
           <div className="stat-card-data-point">
-            <dt>Location:</dt><dd>{currentAssignmentText || NO_POST}</dd>
+            <dt>Location (Org):</dt><dd>{currentAssignmentText || NO_POST} {orgDesc}</dd>
           </div>
         </div>
         {

--- a/src/Components/BidderPortfolio/BidderPortfolioStatRow/__snapshots__/BidderPortfolioStatRow.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidderPortfolioStatRow/__snapshots__/BidderPortfolioStatRow.test.jsx.snap
@@ -79,10 +79,12 @@ exports[`BidderPortfolioStatRow matches snapshot 1`] = `
         className="stat-card-data-point"
       >
         <dt>
-          Location:
+          Location (Org):
         </dt>
         <dd>
           None listed
+           (
+          )
         </dd>
       </div>
     </div>

--- a/src/sass/_bidderPortfolio.scss
+++ b/src/sass/_bidderPortfolio.scss
@@ -269,6 +269,10 @@
     font-weight: bold;
   }
 
+  .location-label {
+    flex-shrink: 0
+  }
+
   dd {
     margin-left: 5px;
   }
@@ -410,7 +414,7 @@ $cdo-search-container-padding: 10px;
     li:last-child {
       margin-bottom: 3px;
     }
-    
+
     .picky--sublabel {
       margin-left: 2em;
     }

--- a/src/sass/_bidderPortfolio.scss
+++ b/src/sass/_bidderPortfolio.scss
@@ -270,7 +270,7 @@
   }
 
   .location-label {
-    flex-shrink: 0
+    flex-shrink: 0;
   }
 
   dd {


### PR DESCRIPTION
Added organization field (pos_org_short_desc) to userProfile payload to display on Client Profile cards/rows. Ticket was originally asking for the long description of organizations as well but after DEV1 investigation, it was determined that different data from a separate table is needed to expose the correct long descriptions, which will be addressed in a future ticket

Dual Merge: 
- [Mock PR](https://github.com/MetaPhase-Consulting/mock-fsbid/pull/326)
