### PR TITLE
TM-3909: Alphabetizing status dropdown on AIM page

### DIFF
--- a/src/Components/Agenda/AgendaItemMaintenancePane/AgendaItemMaintenancePane.jsx
+++ b/src/Components/Agenda/AgendaItemMaintenancePane/AgendaItemMaintenancePane.jsx
@@ -44,6 +44,8 @@ const AgendaItemMaintenancePane = (props) => {
   const pos_results_errored = useSelector(state => state.positionsHasErrored);
 
   const statuses = get(statusData, 'data.results') || [];
+  statuses.sort((a, b) => (a.desc_text > b.desc_text) ? 1 : -1);
+
   const panelCategories = get(panelCatData, 'data.results') || [];
   const panelDates = get(panelDatesData, 'data.results') || [];
 


### PR DESCRIPTION
ACs:
1. Verify that the options in the status dropdown on the AIM page are in alphabetical order