### PR TITLE
Add authn to IDP and SP

### DIFF
--- a/src/saml2-config.alt.js
+++ b/src/saml2-config.alt.js
@@ -40,6 +40,7 @@ const identityProvider = new saml2.IdentityProvider({
   sso_login_url: SSO_LOGIN_URL,
   sso_logout_url: SSO_LOGOUT_URL,
   certificates: [fs.readFileSync(SSO_CERT_FILE)],
+  force_authn: false,
 });
 
 // Call metadata to get XML metatadata used in configuration.

--- a/src/saml2-config.js
+++ b/src/saml2-config.js
@@ -41,12 +41,14 @@ const identityProvider = new saml2.IdentityProvider({
   sso_login_url: SSO_LOGIN_URL,
   sso_logout_url: SSO_LOGOUT_URL,
   certificates: [ssoCert],
+  force_authn: false,  
 });
 
 const identityProviderAlt = new saml2.IdentityProvider({
   sso_login_url: SSO_LOGIN_URL_ALT,
   sso_logout_url: SSO_LOGOUT_URL_ALT,
   certificates: [ssoCert],
+  force_authn: false,  
 });
 
 // Example use of service provider.


### PR DESCRIPTION
Adding redundant force_authn fields to see if both IDP and SP config settings are necessary