### PR TITLE
TM-3958: Fixing results controls spacing at lower resolutions

### DIFF
--- a/src/sass/_employeeSearch.scss
+++ b/src/sass/_employeeSearch.scss
@@ -185,6 +185,10 @@
     margin-top: -10px;
     margin-bottom: 20px;
   }
+
+  @media screen and (max-width: 1193px) {
+    display: block;
+  }
 }
 
 .empl-search-pagination-controls {


### PR DESCRIPTION
Reformatting of results controls happens at 1192px.

---

ACs:
1. Verify results controls look pretty at lower resolutions down to 1100px
