### PR TITLE
Update/pm filter sort default TM-4131

### DIFF
--- a/src/Components/BureauPage/PositionManager/PositionManager.jsx
+++ b/src/Components/BureauPage/PositionManager/PositionManager.jsx
@@ -556,7 +556,7 @@ const PositionManager = props => {
           {
             getOverlay() ||
               <>
-                <div className="usa-width-one-whole results-dropdown bureau-controls-container">
+                <div className="usa-width-one-whole results-dropdown controls-container">
                   <TotalResults
                     total={bureauPositions.count}
                     pageNumber={page}

--- a/src/Components/Panel/PanelMeetingSearch/PanelMeetingSearch.jsx
+++ b/src/Components/Panel/PanelMeetingSearch/PanelMeetingSearch.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import FA from 'react-fontawesome';
 import Picky from 'react-picky';
@@ -20,7 +20,6 @@ import TotalResults from 'Components/TotalResults';
 import ScrollUpButton from '../../ScrollUpButton';
 
 const PanelMeetingSearch = ({ isCDO }) => {
-  const childRef = useRef();
   const dispatch = useDispatch();
 
   const panelMeetingsFilters = useSelector(state => state.panelMeetingsFilters);
@@ -148,7 +147,6 @@ const PanelMeetingSearch = ({ isCDO }) => {
     setSelectedMeetingType([]);
     setSelectedMeetingStatus([]);
     setSelectedPanelMeetDate(null);
-    childRef.current.clearText();
     setClearFilters(false);
   };
 
@@ -229,7 +227,7 @@ const PanelMeetingSearch = ({ isCDO }) => {
         </div>
         {
           !groupLoading &&
-          <div className="usa-width-one-whole results-dropdown bureau-controls-container">
+          <div className="usa-width-one-whole results-dropdown controls-container">
             <TotalResults
               total={count}
               pageNumber={page}

--- a/src/Components/Panel/PanelMeetingSearch/PanelMeetingSearch.jsx
+++ b/src/Components/Panel/PanelMeetingSearch/PanelMeetingSearch.jsx
@@ -5,7 +5,6 @@ import FA from 'react-fontawesome';
 import Picky from 'react-picky';
 import { filter, flatten, get, isEmpty } from 'lodash';
 import { panelMeetingsExport, panelMeetingsFetchData, panelMeetingsFiltersFetchData, savePanelMeetingsSelections } from 'actions/panelMeetings';
-import PositionManagerSearch from 'Components/BureauPage/PositionManager/PositionManagerSearch';
 import ProfileSectionTitle from 'Components/ProfileSectionTitle/ProfileSectionTitle';
 import ListItem from 'Components/BidderPortfolio/BidControls/BidCyclePicker/ListItem';
 import SelectForm from 'Components/SelectForm';
@@ -105,10 +104,6 @@ const PanelMeetingSearch = ({ isCDO }) => {
     textSearch,
   ]);
 
-  function submitSearch(text) {
-    setTextSearch(text);
-  }
-
   const exportPanelMeetings = () => {
     if (!exportIsLoading) {
       setExportIsLoading(true);
@@ -176,14 +171,7 @@ const PanelMeetingSearch = ({ isCDO }) => {
       <Spinner type="bureau-results" class="homepage-position-results" size="big" /> :
       <div className="panel-meeting-search-page">
         <div className="usa-grid-full panel-meeting-search-upper-section search-bar-container">
-          <ProfileSectionTitle title="Panel Meeting Search" icon="comment" />
-          <PositionManagerSearch
-            submitSearch={submitSearch}
-            ref={childRef}
-            textSearch={textSearch}
-            label="Search for a Panel Meeting"
-            placeHolder="Search using Panel ID"
-          />
+          <ProfileSectionTitle title="Panel Meeting Search" icon="calendar" />
           <div className="filterby-container">
             <div className="filterby-label">Filter by:</div>
             <div className="filterby-clear">

--- a/src/Components/Panel/PanelMeetingSearch/PanelMeetingSearch.jsx
+++ b/src/Components/Panel/PanelMeetingSearch/PanelMeetingSearch.jsx
@@ -44,7 +44,7 @@ const PanelMeetingSearch = ({ isCDO }) => {
 
   const [selectedMeetingType, setSelectedMeetingType] = useState(get(userSelections, 'selectedMeetingType') || []);
   const [selectedMeetingStatus, setSelectedMeetingStatus] = useState(get(userSelections, 'selectedMeetingStatus') || []);
-  const [selectedPanelMeetDate, setSelectedPanelMeetDate] = useState(get(userSelections, 'selectedPanelMeetDate') || null);
+  const [selectedPanelMeetDate, setSelectedPanelMeetDate] = useState(get(userSelections, 'selectedPanelMeetDate') || []);
 
   const meetingStatusFilterErrored = get(panelMeetingsFilters, 'panelStatuses') ? get(panelMeetingsFilters, 'panelStatuses').length === 0 : true;
   const meetingTypeFilterErrored = get(panelMeetingsFilters, 'panelTypes') ? get(panelMeetingsFilters, 'panelTypes').length === 0 : true;
@@ -159,7 +159,7 @@ const PanelMeetingSearch = ({ isCDO }) => {
   const resetFilters = () => {
     setSelectedMeetingType([]);
     setSelectedMeetingStatus([]);
-    setSelectedPanelMeetDate(null);
+    setSelectedPanelMeetDate([]);
     setClearFilters(false);
   };
 
@@ -227,7 +227,7 @@ const PanelMeetingSearch = ({ isCDO }) => {
               />
             </div>
             <div className="filter-div">
-              <div className="label">Panel Meet Date:</div>
+              <div className="label">Panel Date:</div>
               <DateRangePicker
                 onChange={setSelectedPanelMeetDate}
                 value={selectedPanelMeetDate}

--- a/src/Components/Panel/PanelMeetingSearch/PanelMeetingSearch.jsx
+++ b/src/Components/Panel/PanelMeetingSearch/PanelMeetingSearch.jsx
@@ -121,10 +121,6 @@ const PanelMeetingSearch = ({ isCDO }) => {
     page,
   ]);
 
-  function submitSearch(text) {
-    setTextSearch(text);
-  }
-
   const exportPanelMeetings = () => {
     if (!exportIsLoading) {
       setExportIsLoading(true);

--- a/src/Components/Panel/PanelMeetingSearch/PanelMeetingSearch.jsx
+++ b/src/Components/Panel/PanelMeetingSearch/PanelMeetingSearch.jsx
@@ -44,7 +44,7 @@ const PanelMeetingSearch = ({ isCDO }) => {
 
   const [selectedMeetingType, setSelectedMeetingType] = useState(get(userSelections, 'selectedMeetingType') || []);
   const [selectedMeetingStatus, setSelectedMeetingStatus] = useState(get(userSelections, 'selectedMeetingStatus') || []);
-  const [selectedPanelMeetDate, setSelectedPanelMeetDate] = useState(get(userSelections, 'selectedPanelMeetDate') || []);
+  const [selectedPanelMeetDate, setSelectedPanelMeetDate] = useState(get(userSelections, 'selectedPanelMeetDate') || null);
 
   const meetingStatusFilterErrored = get(panelMeetingsFilters, 'panelStatuses') ? get(panelMeetingsFilters, 'panelStatuses').length === 0 : true;
   const meetingTypeFilterErrored = get(panelMeetingsFilters, 'panelTypes') ? get(panelMeetingsFilters, 'panelTypes').length === 0 : true;
@@ -159,7 +159,7 @@ const PanelMeetingSearch = ({ isCDO }) => {
   const resetFilters = () => {
     setSelectedMeetingType([]);
     setSelectedMeetingStatus([]);
-    setSelectedPanelMeetDate([]);
+    setSelectedPanelMeetDate(null);
     setClearFilters(false);
   };
 

--- a/src/Constants/Sort.js
+++ b/src/Constants/Sort.js
@@ -223,8 +223,8 @@ AGENDA_EMPLOYEES_SORT.defaultSort = AGENDA_EMPLOYEES_SORT.options[0].value;
 
 export const PANEL_MEETINGS_SORT = {
   options: [
-    { value: 'meeting_status', text: 'Meeting Status A-Z' },
-    { value: '-meeting_status', text: 'Meeting Status Z-A' },
+    { value: '-panel_date', text: 'Panel Meet Date: Newest' },
+    { value: 'panel_date', text: 'Panel Meet Date: Oldest' },
   ],
 };
 

--- a/src/sass/_bureau.scss
+++ b/src/sass/_bureau.scss
@@ -338,17 +338,6 @@
   }
 }
 
-.bureau-controls-container {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  padding-top: 15px;
-
-  div:first-child {
-    padding-left: 35px;
-  }
-}
-
 .bureau-results-controls {
   align-items: center;
   display: flex;

--- a/src/sass/_filters.scss
+++ b/src/sass/_filters.scss
@@ -17,3 +17,18 @@
       }
     }
 }
+
+.controls-container {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding-top: 15px;
+
+  div:first-child {
+    padding-left: 35px;
+  }
+
+  @media screen and (max-width: 1200px) {
+    display: block;
+  }
+}

--- a/src/sass/_inputs.scss
+++ b/src/sass/_inputs.scss
@@ -15,17 +15,17 @@ select .select-small {
   padding: 0 1.5em 0 .7em;
 }
 
-.panel-select-box {
+.panel-select {
   background-color: $color-white;
   background-image: url(/assets/img/angle-down-black.svg);
   background-position-x: calc(100% - 8px);
   border: 1px solid $bg-gray-dark-2;
   border-radius: 3px;
-  font-size: 0.9em;
+  font-size: 15px;
   height: 28px;
   overflow: hidden;
   padding: 0 1.5em 0 0.7em;
   text-overflow: ellipsis;
   white-space: nowrap;
-  width: 130px;
+  width: 75px;
 }

--- a/src/sass/_panelSearch.scss
+++ b/src/sass/_panelSearch.scss
@@ -9,7 +9,7 @@
 
   .panel-meeting-search-filters {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(365px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
 
     .filter-div {
       align-items: center;
@@ -18,7 +18,7 @@
 
       .label {
         margin: 0 10px;
-        min-width: 122px;
+        min-width: 85px;
         text-align: end;
       }
 
@@ -27,6 +27,9 @@
         width: 220px;
       }
 
+      .react-daterange-picker__clear-button {
+        padding: 2px 4px;
+      }
       .react-daterange-picker__clear-button:hover {
         background-color: $color-white;
       }
@@ -39,12 +42,13 @@
     .react-daterange-picker {
       align-items: center;
       background: $color-white;
-      font-size: 1.5rem;
-      height: 28px;
-      width: 240px;
+      font-size: 13px;
+      height: 26px;
+      margin: 7px 0;
 
       .react-daterange-picker__wrapper {
         border: none;
+        width: 220px;
       }
 
       .react-daterange-picker__inputGroup {
@@ -83,7 +87,6 @@
   }
 
   div {
-    align-items: stretch;
     display: flex;
 
     label {

--- a/src/sass/_panelSearch.scss
+++ b/src/sass/_panelSearch.scss
@@ -77,12 +77,21 @@
   font-size: 14px;
   margin: 0 35px 5px 0;
 
+  label {
+    font-size: 15px;
+  }
+
+  .panel-sort {
+    width: 160px;
+  }
+
+
   div:first-child {
     margin-right: 10px;
   }
 
   div {
-    align-items: baseline;
+    align-items: stretch;
     display: flex;
 
     label {

--- a/src/sass/_panelSearch.scss
+++ b/src/sass/_panelSearch.scss
@@ -9,7 +9,7 @@
 
   .panel-meeting-search-filters {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(365px, 1fr));
 
     .filter-div {
       align-items: center;
@@ -17,20 +17,18 @@
       margin-right: 10px;
 
       .label {
-        margin-right: 10px;
-        min-width: 90px;
+        margin: 0 10px;
+        min-width: 122px;
         text-align: end;
       }
 
-      @media screen and (max-width: 1025px) {
-        .label {
-          min-width: 100px;
-        }
+      .picky, .picky__input {
+        color: $color-black;
+        width: 220px;
       }
 
-      .picky {
-        color: $color-black;
-        width: 240px;
+      .react-daterange-picker__clear-button:hover {
+        background-color: $color-white;
       }
     }
 
@@ -59,12 +57,6 @@
       .react-daterange-picker__inputGroup__leadingZero,
       .react-date-picker__inputGroup__divider {
         color: $color-black;
-      }
-    }
-
-    @media screen and (max-width: $screen-md-max) {
-      .react-daterange-picker {
-        margin-left: 9px;
       }
     }
   }

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -121,6 +121,6 @@
 @import 'panelMeetingAgendas';
 @import 'editPositionDetails';
 @import 'borderColor';
-@import 'filterBy';
+@import 'filters';
 @import 'tracker';
 @import 'panelMeetingTracker';


### PR DESCRIPTION
Dual Merge: 
- [API PR](https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/769)
- [Mock PR](https://github.com/MetaPhase-Consulting/mock-fsbid/pull/352)

---

1. Ability to sort by Panel Meeting Date - Default to most recent
2. Date picker to filter by a range (Based on panel meeting panel date)  
3. Verify that the tracker dates always display if available            
4. Remove search bar (currently only searching on Panel Meeting ID, which is not viewable) 

