### PR TITLE
TM-4048: Remarks Glossary Wrap Up

### DIFF
--- a/src/Components/Agenda/AgendaItemMaintenanceContainer/AgendaItemMaintenanceContainer.jsx
+++ b/src/Components/Agenda/AgendaItemMaintenanceContainer/AgendaItemMaintenanceContainer.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { useEffect, useRef, useState } from 'react';
 import FontAwesome from 'react-fontawesome';
 import { useDispatch } from 'react-redux';
@@ -73,12 +74,6 @@ const AgendaItemMaintenanceContainer = (props) => {
     if (!found) {
       const remark$ = { ...remark };
 
-      /* eslint-disable no-console */
-      console.log('👾👾👾👾👾👾👾👾👾👾👾👾');
-      console.log('👾 current: remark$:', remark$);
-      console.log('👾👾👾👾👾👾👾👾👾👾👾👾');
-
-
       if (has(remark$, 'remark_inserts')) {
         const tempKey = (remark$.seq_num).toString();
         if (!remark$.ari_insertions) {
@@ -87,15 +82,18 @@ const AgendaItemMaintenanceContainer = (props) => {
         remark$.ari_insertions = textInputs[tempKey];
       }
 
+      remark$['user_remark_inserts'] = [];
+      remark$?.remark_inserts.forEach(ri => (remark$['user_remark_inserts'].push({
+        'airiinsertiontext': textInputs[ri.rirmrkseqnum][ri.riseqnum],
+        'airirmrkseqnum': ri.rirmrkseqnum,
+        'aiririseqnum': ri.riseqnum,
+      })));
+
       userRemarks$.push(remark$);
       setUserRemarks(userRemarks$);
     } else {
       setUserRemarks(filter(userRemarks$, (r) => r.seq_num !== remark.seq_num));
     }
-    /* eslint-disable no-console */
-    console.log('👾👾👾👾👾👾👾👾👾👾👾👾');
-    console.log('👾 current: userRemarks$', userRemarks$);
-    console.log('👾👾👾👾👾👾👾👾👾👾👾👾');
   };
 
   const submitAI = () => {

--- a/src/Components/Agenda/AgendaItemMaintenanceContainer/AgendaItemMaintenanceContainer.jsx
+++ b/src/Components/Agenda/AgendaItemMaintenanceContainer/AgendaItemMaintenanceContainer.jsx
@@ -86,6 +86,10 @@ const AgendaItemMaintenanceContainer = (props) => {
     } else {
       setUserRemarks(filter(userRemarks$, (r) => r.seq_num !== remark.seq_num));
     }
+    /* eslint-disable no-console */
+    console.log('👾👾👾👾👾👾👾👾👾👾👾👾');
+    console.log('👾 current: userRemarks$', userRemarks$);
+    console.log('👾👾👾👾👾👾👾👾👾👾👾👾');
   };
 
   const submitAI = () => {

--- a/src/Components/Agenda/AgendaItemMaintenanceContainer/AgendaItemMaintenanceContainer.jsx
+++ b/src/Components/Agenda/AgendaItemMaintenanceContainer/AgendaItemMaintenanceContainer.jsx
@@ -1,12 +1,10 @@
-/* eslint-disable */
 import { useEffect, useRef, useState } from 'react';
 import FontAwesome from 'react-fontawesome';
 import { useDispatch } from 'react-redux';
 import { Tooltip } from 'react-tippy';
 import { withRouter } from 'react-router';
 import InteractiveElement from 'Components/InteractiveElement';
-import { drop, filter, find, get, has } from 'lodash';
-// import { drop, filter, find, get, has, isEmpty } from 'lodash';
+import { drop, filter, find, get, has, isEmpty } from 'lodash';
 import MediaQuery from 'Components/MediaQuery';
 import Spinner from 'Components/Spinner';
 import { Link } from 'react-router-dom';
@@ -28,8 +26,7 @@ const AgendaItemMaintenanceContainer = (props) => {
   const { data: agendaItemData, error: agendaItemError, loading: agendaItemLoading } = useDataLoader(api().get, `/fsbid/agenda/agenda_items/${agendaID}/`);
   const agendaItem = get(agendaItemData, 'data') || {};
   // temporary until business logic is added for readOnly items
-  const isReadOnly = false;
-  // const isReadOnly = !isEmpty(agendaItemData);
+  const isReadOnly = !isEmpty(agendaItemData);
 
   const id = get(props, 'match.params.id');
   const isCDO = get(props, 'isCDO');
@@ -82,11 +79,11 @@ const AgendaItemMaintenanceContainer = (props) => {
         remark$.ari_insertions = textInputs[tempKey];
       }
 
-      remark$['user_remark_inserts'] = [];
-      remark$?.remark_inserts.forEach(ri => (remark$['user_remark_inserts'].push({
-        'airiinsertiontext': textInputs[ri.rirmrkseqnum][ri.riseqnum],
-        'airirmrkseqnum': ri.rirmrkseqnum,
-        'aiririseqnum': ri.riseqnum,
+      remark$.user_remark_inserts = [];
+      remark$.remark_inserts.forEach(ri => (remark$.user_remark_inserts.push({
+        airiinsertiontext: textInputs[ri.rirmrkseqnum][ri.riseqnum],
+        airirmrkseqnum: ri.rirmrkseqnum,
+        aiririseqnum: ri.riseqnum,
       })));
 
       userRemarks$.push(remark$);

--- a/src/Components/Agenda/AgendaItemMaintenanceContainer/AgendaItemMaintenanceContainer.jsx
+++ b/src/Components/Agenda/AgendaItemMaintenanceContainer/AgendaItemMaintenanceContainer.jsx
@@ -4,7 +4,8 @@ import { useDispatch } from 'react-redux';
 import { Tooltip } from 'react-tippy';
 import { withRouter } from 'react-router';
 import InteractiveElement from 'Components/InteractiveElement';
-import { drop, filter, find, get, has, isEmpty } from 'lodash';
+import { drop, filter, find, get, has } from 'lodash';
+// import { drop, filter, find, get, has, isEmpty } from 'lodash';
 import MediaQuery from 'Components/MediaQuery';
 import Spinner from 'Components/Spinner';
 import { Link } from 'react-router-dom';
@@ -26,7 +27,8 @@ const AgendaItemMaintenanceContainer = (props) => {
   const { data: agendaItemData, error: agendaItemError, loading: agendaItemLoading } = useDataLoader(api().get, `/fsbid/agenda/agenda_items/${agendaID}/`);
   const agendaItem = get(agendaItemData, 'data') || {};
   // temporary until business logic is added for readOnly items
-  const isReadOnly = !isEmpty(agendaItemData);
+  const isReadOnly = false;
+  // const isReadOnly = !isEmpty(agendaItemData);
 
   const id = get(props, 'match.params.id'); // client's perdet
   const isCDO = get(props, 'isCDO');

--- a/src/Components/Agenda/AgendaItemMaintenanceContainer/AgendaItemMaintenanceContainer.jsx
+++ b/src/Components/Agenda/AgendaItemMaintenanceContainer/AgendaItemMaintenanceContainer.jsx
@@ -73,6 +73,12 @@ const AgendaItemMaintenanceContainer = (props) => {
     if (!found) {
       const remark$ = { ...remark };
 
+      /* eslint-disable no-console */
+      console.log('👾👾👾👾👾👾👾👾👾👾👾👾');
+      console.log('👾 current: remark$:', remark$);
+      console.log('👾👾👾👾👾👾👾👾👾👾👾👾');
+
+
       if (has(remark$, 'remark_inserts')) {
         const tempKey = (remark$.seq_num).toString();
         if (!remark$.ari_insertions) {

--- a/src/Components/Agenda/AgendaItemResearchPane/AgendaItemResearchPane.jsx
+++ b/src/Components/Agenda/AgendaItemResearchPane/AgendaItemResearchPane.jsx
@@ -134,6 +134,7 @@ const AgendaItemResearchPane = forwardRef((props = { perdet: '', clientData: {},
         }
         return (<RemarksGlossary
           remarks={remarks$}
+          isReadOnly={isReadOnly}
           remarkCategories={rmrkCategories$}
           userSelections={userSelections}
           updateSelection={updateSelection}

--- a/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
+++ b/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
@@ -7,7 +7,9 @@ import TextInput from 'Components/TextInput';
 import { EMPTY_FUNCTION } from 'Constants/PropTypes';
 import Fuse from 'fuse.js';
 
-const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSelection }) => {
+// eslint-disable-next-line no-unused-vars
+const RemarksGlossary = ({ isReadOnly, remarks, remarkCategories,
+  userSelections, updateSelection }) => {
   const [textInputs, setTextInputs] = useState({});
   const [exclusiveCats, setExclusiveCats] = useState({});
 
@@ -43,7 +45,7 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
     }
   };
 
-  const getTextInputValue = (rSeq, riSeq) => textInputs[rSeq][riSeq] || '';
+  const getTextInputValue = (rSeq, riSeq) => textInputs?.[rSeq]?.[riSeq] || '';
 
   const renderText = (r, interactiveTypeRender, disabled) => {
     const rText = r?.text?.split(/(\s+)/) || '';
@@ -112,7 +114,7 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
 
   const getInteractiveTypeAndText = (r) => {
     let interactiveType = '';
-    let disabled = false;
+    let disabled = isReadOnly;
 
     if (find(userSelections, { seq_num: r.seq_num })) {
       interactiveType = 'selectedEnabled';
@@ -225,6 +227,7 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
 };
 
 RemarksGlossary.propTypes = {
+  isReadOnly: PropTypes.bool,
   userSelections: PropTypes.arrayOf(
     PropTypes.shape({
       seq_num: PropTypes.number,
@@ -263,9 +266,10 @@ RemarksGlossary.propTypes = {
 };
 
 RemarksGlossary.defaultProps = {
-  userSelections: [],
+  isReadOnly: false,
   remarks: [],
   remarkCategories: [],
+  userSelections: [],
   updateSelection: EMPTY_FUNCTION,
 };
 

--- a/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
+++ b/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useEffect, useState } from 'react';
 import { find, get, isEqual, orderBy, uniqBy } from 'lodash';
 import PropTypes from 'prop-types';
@@ -14,11 +13,6 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
 
   const setTextInput = (rSeq, riSeq, value) => {
     const textInputs$ = { ...textInputs };
-    /* eslint-disable no-console */
-    console.log('🐥🐥🐥🐥🐥🐥🐥🐥🐥🐥️');
-    console.log('🐥 current: textInputs$:',textInputs$);
-    console.log('🐥🐥🐥🐥🐥🐥🐥🐥🐥🐥️');
-
 
     if (!textInputs$[rSeq.toString()]) {
       textInputs$[rSeq.toString()] = {};
@@ -43,12 +37,6 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
       });
     });
     if (!isEqual(textInputs$, textInputs)) {
-      /* eslint-disable no-console */
-      console.log('🥹🥹🥹🥹🥹🥹🥹🥹🥹🥹');
-      console.log('🥹 current: textInputs$', textInputs$);
-      console.log('🥹 current: userSelections', userSelections);
-      console.log('🥹🥹🥹🥹🥹🥹🥹🥹🥹🥹');
-
       setTextInputs(textInputs$);
     }
   };
@@ -60,11 +48,6 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
     const rInserts = r?.remark_inserts || [];
 
     rInserts.forEach((a) => {
-      /* eslint-disable no-console */
-      console.log('🐙🐙🐙🐙🐙🐙🐙🐙🐙🐙');
-      console.log('🐙 current: getTextInputValue(get(a, \'rirmrkseqnum\'), get(a, \'riseqnum\')):',a?.rirmrkseqnum, a?.riseqnum);
-      console.log('🐙 current: textInputs:',textInputs);
-      console.log('🐙🐙🐙🐙🐙🐙🐙🐙🐙🐙');
       const rInsertionText = a?.riinsertiontext;
       const rTextI = rText.indexOf(rInsertionText);
       if (rTextI > -1) {
@@ -75,60 +58,46 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
           placeholder={rInsertionText.replace(/[{}\d]/g, '').replace(/#/g, 'number')}
           id="remarks-custom-input"
           key={a.riseqnum}
-          inputProps={{autoComplete: 'off'}}
+          inputProps={{ autoComplete: 'off' }}
           disabled={disabled}
         />);
       }
     });
     return (<>
-        {interactiveTypeRender}
-        <div className="remark-input-container">{rText}</div>
-      </>);
-
+      {interactiveTypeRender}
+      <div className="remark-input-container">{rText}</div>
+    </>);
   };
 
   const renderExclusiveCats = () => {
-    const rCatCodes = uniqBy(remarkCategories, 'code');
-    let exclusiveCategories = { exlusiveSeqs: [] };
+    const exclusiveCategories = { };
     // unfortunately we have to loop twice bc we can't trust all remarks in a category
     // to be consistent in their mutually_exclusive_ind status
     remarks.forEach(r => {
-      if(r?.mutually_exclusive_ind === 'Y') {
-        exclusiveCategories[r?.rc_code] = { remarkCatSelected: false }
+      if (r?.mutually_exclusive_ind === 'Y') {
+        exclusiveCategories[r?.rc_code] = { remarkCatSelected: false };
       }
     });
     remarks.forEach(r => {
       const exlusiveRCatCodes = Object.keys(exclusiveCategories);
-      if(exlusiveRCatCodes.includes(r?.rc_code)) {
-        // i thought having an array of the seqnums would help with optimization
-        // but since our remarks usually have the rc_code in them, we can just look up on that
-        // to prevent looping on all 😾 to find
-        // pending: remove seqNums [] before opening PR for review
-        exclusiveCategories[r?.rc_code]['seqNums'] ??= [];
-        exclusiveCategories[r?.rc_code]['seqNums'].push(r?.seq_num);
-        exclusiveCategories?.exlusiveSeqs.push(r?.seq_num);
+      if (exlusiveRCatCodes.includes(r?.rc_code)) {
+        exclusiveCategories[r?.rc_code].seqNums ??= [];
+        exclusiveCategories[r?.rc_code].seqNums.push(r?.seq_num);
       }
     });
-    /* eslint-disable no-console */
-    console.log('🧁🧁🧁🧁🧁🧁🧁🧁🧁🧁');
-    console.log('🧁 current: exclusiveCategories', exclusiveCategories);
-
     setExclusiveCats(exclusiveCategories);
   };
 
   const updateExclusiveCats = () => {
-    let exclusiveCats$ = {...exclusiveCats};
+    const exclusiveCats$ = { ...exclusiveCats };
 
     // reset cats
     Object.keys(exclusiveCats$).forEach(c => {
-      // pending: remove if removing exlusiveSeqs
-      if(c !== 'exlusiveSeqs') {
-        exclusiveCats$[c].remarkCatSelected = false;
-      }
-    })
+      exclusiveCats$[c].remarkCatSelected = false;
+    });
 
     userSelections.forEach(r => {
-      if(exclusiveCats$[r.rc_code]){
+      if (exclusiveCats$[r.rc_code]) {
         exclusiveCats$[r.rc_code].remarkCatSelected = true;
       }
     });
@@ -136,36 +105,36 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
     setExclusiveCats(exclusiveCats$);
   };
 
-  const getInteractiveTypeAndText = (r, textInputs) => {
+  const getInteractiveTypeAndText = (r) => {
     let interactiveType = '';
     let disabled = false;
 
-    if(find(userSelections, { seq_num: r.seq_num })) {
-      interactiveType = 'selectedEnabled'
+    if (find(userSelections, { seq_num: r.seq_num })) {
+      interactiveType = 'selectedEnabled';
       disabled = true;
-    } else if(exclusiveCats?.[r.rc_code]?.remarkCatSelected) {
-      interactiveType = 'notSelectedDisabled'
+    } else if (exclusiveCats?.[r.rc_code]?.remarkCatSelected) {
+      interactiveType = 'notSelectedDisabled';
       disabled = true;
     } else {
-      interactiveType = 'notSelectedEnabled'
+      interactiveType = 'notSelectedEnabled';
     }
 
     const returnTypes = {
       selectedEnabled: (<InteractiveElement onClick={() => updateSelection(r, textInputs)}>
-        <FA name='minus-circle' />
+        <FA name="minus-circle" />
       </InteractiveElement>),
       notSelectedDisabled: (<InteractiveElement onClick={() => {}}>
         <FA
-          name='plus-circle'
-          className='fa-disabled'
+          name="plus-circle"
+          className="fa-disabled"
         />
       </InteractiveElement>),
       notSelectedEnabled: (<InteractiveElement onClick={() => updateSelection(r, textInputs)}>
-        <FA name='plus-circle' />
+        <FA name="plus-circle" />
       </InteractiveElement>),
     };
 
-    return renderText(r, returnTypes[interactiveType], disabled)
+    return renderText(r, returnTypes[interactiveType], disabled);
   };
 
   const [remarks$, setRemarks$] = useState(remarks);
@@ -193,16 +162,12 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
   const remarks$$ = term ? remarks$ : remarks;
 
   const remarkCategoriesCodes = uniqBy(remarkCategories, 'code');
-  let remarkCategories$ = orderBy(remarkCategoriesCodes, 'desc_text');
+  const remarkCategories$ = orderBy(remarkCategoriesCodes, 'desc_text');
 
   const processClick = remark => {
     const el = document.getElementById(`remark-category-${remark.code}`);
     el.scrollIntoView();
   };
-
-  // useEffect(() => {
-  //   setTextInputBulk(remarks);
-  // }, [remarks]);
 
   useEffect(() => {
     updateExclusiveCats();
@@ -232,7 +197,7 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
         </div>
         {remarkCategories$.map(category => {
           const remarksInCategory = orderBy(remarks$$.filter(f => f.rc_code === category.code), 'order_num');
-          const isExclusiveCatText = exclusiveCats.hasOwnProperty(category.code) ? ' (one remark per this category)' : '';
+          const isExclusiveCatText = exclusiveCats?.[category.code] ? ' (one remark per this category)' : '';
 
           return (
             <div key={category.code}>
@@ -242,7 +207,7 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
               <ul>
                 {remarksInCategory.map(r => (
                   (<li key={r.seq_num}>
-                    {getInteractiveTypeAndText(r, textInputs)}
+                    {getInteractiveTypeAndText(r)}
                   </li>)
                 ))}
               </ul>

--- a/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
+++ b/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
@@ -73,40 +73,40 @@ const RemarksGlossary = ({ isReadOnly, remarks, remarkCategories,
     </>);
   };
 
-  const renderExclusiveCats = () => {
-    const localExclusiveCategories = { };
+  const renderExclusiveCategories = () => {
+    const exclusiveCats = { };
     // unfortunately we have to loop twice bc we can't trust all remarks in a category
     // to be consistent in their mutually_exclusive_ind status
     remarks.forEach(r => {
       if (r?.mutually_exclusive_ind === 'Y') {
-        localExclusiveCategories[r?.rc_code] = { remarkCatSelected: false };
+        exclusiveCats[r?.rc_code] = { remarkCatSelected: false };
       }
     });
     remarks.forEach(r => {
-      const exlusiveRCatCodes = Object.keys(localExclusiveCategories);
+      const exlusiveRCatCodes = Object.keys(exclusiveCats);
       if (exlusiveRCatCodes.includes(r?.rc_code)) {
-        localExclusiveCategories[r?.rc_code].seqNums ??= [];
-        localExclusiveCategories[r?.rc_code].seqNums.push(r?.seq_num);
+        exclusiveCats[r?.rc_code].seqNums ??= [];
+        exclusiveCats[r?.rc_code].seqNums.push(r?.seq_num);
       }
     });
-    setExclusiveCategories(localExclusiveCategories);
+    setExclusiveCategories(exclusiveCats);
   };
 
-  const updateExclusiveCats = () => {
-    const exclusiveCats$ = { ...exclusiveCategories };
+  const updateExclusiveCategories = () => {
+    const exclusiveCats = { ...exclusiveCategories };
 
-    // reset cats
-    Object.keys(exclusiveCats$).forEach(c => {
-      exclusiveCats$[c].remarkCatSelected = false;
+    // reset exclusive categories
+    Object.keys(exclusiveCats).forEach(c => {
+      exclusiveCats[c].remarkCatSelected = false;
     });
 
     userSelections.forEach(r => {
-      if (exclusiveCats$[r.rc_code]) {
-        exclusiveCats$[r.rc_code].remarkCatSelected = true;
+      if (exclusiveCats[r.rc_code]) {
+        exclusiveCats[r.rc_code].remarkCatSelected = true;
       }
     });
 
-    setExclusiveCategories(exclusiveCats$);
+    setExclusiveCategories(exclusiveCats);
   };
 
   const remarkStatus = (r) => {
@@ -156,11 +156,11 @@ const RemarksGlossary = ({ isReadOnly, remarks, remarkCategories,
   };
 
   useEffect(() => {
-    updateExclusiveCats();
+    updateExclusiveCategories();
   }, [userSelections]);
 
   useEffect(() => {
-    renderExclusiveCats();
+    renderExclusiveCategories();
     setTextInputBulk();
   }, []);
 

--- a/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
+++ b/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
@@ -26,22 +26,24 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
   const setTextInputBulk = () => {
     const remarksArr = remarks;
     const textInputs$ = {};
+
     remarksArr.forEach(r => {
+      const userRemark = find(userSelections, { seq_num: r.seq_num });
       r.remark_inserts.forEach(ri => {
-        if (!textInputs$[(r.seq_num).toString()]) {
-          textInputs$[(r.seq_num).toString()] = {};
-          textInputs$[(r.seq_num).toString()][(ri.riseqnum).toString()] = ri.riinsertiontext;
-        } else {
-          textInputs$[(r.seq_num).toString()][(ri.riseqnum).toString()] = ri.riinsertiontext;
-        }
+        const userRemarkInsert = find(userRemark?.user_remark_inserts,
+          { aiririseqnum: ri.riseqnum });
+        textInputs$[(r.seq_num).toString()] ??= {};
+        textInputs$[(r.seq_num).toString()][(ri.riseqnum).toString()] =
+          userRemarkInsert?.airiinsertiontext || ri.riinsertiontext;
       });
     });
+
     if (!isEqual(textInputs$, textInputs)) {
       setTextInputs(textInputs$);
     }
   };
 
-  const getTextInputValue = (rSeq, riSeq) => get(textInputs, rSeq[riSeq]) || '';
+  const getTextInputValue = (rSeq, riSeq) => textInputs[rSeq][riSeq] || '';
 
   const renderText = (r, interactiveTypeRender, disabled) => {
     const rText = r?.text?.split(/(\s+)/) || '';
@@ -51,8 +53,11 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
       const rInsertionText = a?.riinsertiontext;
       const rTextI = rText.indexOf(rInsertionText);
       if (rTextI > -1) {
+        let remarkInsertValue = getTextInputValue(get(a, 'rirmrkseqnum'), get(a, 'riseqnum'));
+        remarkInsertValue = remarkInsertValue[0] === '{' ? '' : remarkInsertValue;
+
         rText.splice(rTextI, 1, <TextInput
-          value={getTextInputValue(get(a, 'rirmrkseqnum'), get(a, 'riseqnum'))}
+          value={remarkInsertValue}
           changeText={v => setTextInput(get(a, 'rirmrkseqnum'), get(a, 'riseqnum'), v)}
           customContainerClass="remark-input"
           placeholder={rInsertionText.replace(/[{}\d]/g, '').replace(/#/g, 'number')}

--- a/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
+++ b/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
@@ -60,6 +60,11 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
     const rInserts = r?.remark_inserts || [];
 
     rInserts.forEach((a) => {
+      /* eslint-disable no-console */
+      console.log('🐙🐙🐙🐙🐙🐙🐙🐙🐙🐙');
+      console.log('🐙 current: getTextInputValue(get(a, \'rirmrkseqnum\'), get(a, \'riseqnum\')):',a?.rirmrkseqnum, a?.riseqnum);
+      console.log('🐙 current: textInputs:',textInputs);
+      console.log('🐙🐙🐙🐙🐙🐙🐙🐙🐙🐙');
       const rInsertionText = a?.riinsertiontext;
       const rTextI = rText.indexOf(rInsertionText);
       if (rTextI > -1) {

--- a/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
+++ b/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
@@ -11,7 +11,7 @@ import Fuse from 'fuse.js';
 const RemarksGlossary = ({ isReadOnly, remarks, remarkCategories,
   userSelections, updateSelection }) => {
   const [textInputs, setTextInputs] = useState({});
-  const [exclusiveCats, setExclusiveCats] = useState({});
+  const [exclusiveCategories, setExclusiveCategories] = useState({});
 
   const setTextInput = (rSeq, riSeq, value) => {
     const textInputs$ = { ...textInputs };
@@ -76,26 +76,26 @@ const RemarksGlossary = ({ isReadOnly, remarks, remarkCategories,
   };
 
   const renderExclusiveCats = () => {
-    const exclusiveCategories = { };
+    const localExclusiveCategories = { };
     // unfortunately we have to loop twice bc we can't trust all remarks in a category
     // to be consistent in their mutually_exclusive_ind status
     remarks.forEach(r => {
       if (r?.mutually_exclusive_ind === 'Y') {
-        exclusiveCategories[r?.rc_code] = { remarkCatSelected: false };
+        localExclusiveCategories[r?.rc_code] = { remarkCatSelected: false };
       }
     });
     remarks.forEach(r => {
-      const exlusiveRCatCodes = Object.keys(exclusiveCategories);
+      const exlusiveRCatCodes = Object.keys(localExclusiveCategories);
       if (exlusiveRCatCodes.includes(r?.rc_code)) {
         exclusiveCategories[r?.rc_code].seqNums ??= [];
-        exclusiveCategories[r?.rc_code].seqNums.push(r?.seq_num);
+        localExclusiveCategories[r?.rc_code].seqNums.push(r?.seq_num);
       }
     });
-    setExclusiveCats(exclusiveCategories);
+    setExclusiveCategories(localExclusiveCategories);
   };
 
   const updateExclusiveCats = () => {
-    const exclusiveCats$ = { ...exclusiveCats };
+    const exclusiveCats$ = { ...exclusiveCategories };
 
     // reset cats
     Object.keys(exclusiveCats$).forEach(c => {
@@ -108,7 +108,7 @@ const RemarksGlossary = ({ isReadOnly, remarks, remarkCategories,
       }
     });
 
-    setExclusiveCats(exclusiveCats$);
+    setExclusiveCategories(exclusiveCats$);
   };
 
   const remarkStatus = (r) => {
@@ -117,7 +117,7 @@ const RemarksGlossary = ({ isReadOnly, remarks, remarkCategories,
 
     if (find(userSelections, { seq_num: r.seq_num })) {
       selected = true;
-    } else if (exclusiveCats?.[r.rc_code]?.remarkCatSelected) {
+    } else if (exclusiveCategories?.[r.rc_code]?.remarkCatSelected) {
       selected = false;
       disabled = true;
     }
@@ -185,7 +185,7 @@ const RemarksGlossary = ({ isReadOnly, remarks, remarkCategories,
         </div>
         {remarkCategories$.map(category => {
           const remarksInCategory = orderBy(remarks$$.filter(f => f.rc_code === category.code), 'order_num');
-          const isExclusiveCatText = exclusiveCats?.[category.code] ? ' (one remark per this category)' : '';
+          const isExclusiveCatText = exclusiveCategories?.[category.code] ? ' (one remark per this category)' : '';
 
           return (
             <div key={category.code}>

--- a/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
+++ b/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
@@ -140,14 +140,6 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
     let interactiveType = '';
     let disabled = false;
 
-    //for this category go through the user remarks and if they already
-    // have a selection in that category, disable the adding of more than one per category
-    /* eslint-disable no-console */
-    console.log('🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄');
-    console.log('🦄 current: r', r);
-    console.log('🦄 current: userSelections', userSelections);
-    console.log('🦄 current: find(userSelections, { seq_num: r.seq_num })', find(userSelections, { seq_num: r.seq_num }));
-
     if(find(userSelections, { seq_num: r.seq_num })) {
       interactiveType = 'selectedEnabled'
       disabled = true;
@@ -157,9 +149,6 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
     } else {
       interactiveType = 'notSelectedEnabled'
     }
-
-    console.log('🦄 current: interactiveType', interactiveType);
-    console.log('🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄');
 
     const returnTypes = {
       selectedEnabled: (<InteractiveElement onClick={() => updateSelection(r, textInputs)}>
@@ -295,6 +284,7 @@ RemarksGlossary.propTypes = {
       ),
       mutually_exclusive_ind: PropTypes.string,
       text: PropTypes.string,
+      ref_text: PropTypes.string,
       active_ind: PropTypes.string,
     }),
   ),

--- a/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
+++ b/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
@@ -112,7 +112,8 @@ const RemarksGlossary = ({ isReadOnly, remarks, remarkCategories,
     setExclusiveCats(exclusiveCats$);
   };
 
-  const getInteractiveTypeAndText = (r) => {
+  // eslint-disable-next-line no-unused-vars
+  const getInteractiveTypeAndTextOLD = (r) => {
     let interactiveType = '';
     let disabled = isReadOnly;
 
@@ -143,6 +144,36 @@ const RemarksGlossary = ({ isReadOnly, remarks, remarkCategories,
 
     return renderText(r, returnTypes[interactiveType], disabled);
   };
+
+  const helpMe = (r) => {
+    let disabled = isReadOnly;
+    let selected = false;
+
+    if (find(userSelections, { seq_num: r.seq_num })) {
+      selected = true;
+    } else if (exclusiveCats?.[r.rc_code]?.remarkCatSelected) {
+      selected = false;
+      disabled = true;
+    }
+
+    return { selected, disabled };
+  };
+
+  const getInteractiveTypeAndText = (r) => {
+    const elsa = helpMe(r);
+
+    const returnType = (<InteractiveElement
+      onClick={() => elsa?.disabled ? {} : updateSelection(r, textInputs)}
+    >
+      <FA
+        name={`${elsa?.selected ? 'minus-circle' : 'plus-circle'}`}
+        className={`${elsa?.disabled ? 'fa-disabled' : ''}`}
+      />
+    </InteractiveElement>);
+
+    return renderText(r, returnType, elsa?.disabled || elsa?.selected);
+  };
+
 
   const [remarks$, setRemarks$] = useState(remarks);
 

--- a/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
+++ b/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
@@ -7,7 +7,6 @@ import TextInput from 'Components/TextInput';
 import { EMPTY_FUNCTION } from 'Constants/PropTypes';
 import Fuse from 'fuse.js';
 
-// eslint-disable-next-line no-unused-vars
 const RemarksGlossary = ({ isReadOnly, remarks, remarkCategories,
   userSelections, updateSelection }) => {
   const [textInputs, setTextInputs] = useState({});
@@ -26,10 +25,9 @@ const RemarksGlossary = ({ isReadOnly, remarks, remarkCategories,
   };
 
   const setTextInputBulk = () => {
-    const remarksArr = remarks;
     const textInputs$ = {};
 
-    remarksArr.forEach(r => {
+    remarks.forEach(r => {
       const userRemark = find(userSelections, { seq_num: r.seq_num });
       r.remark_inserts.forEach(ri => {
         const userRemarkInsert = find(userRemark?.user_remark_inserts,
@@ -87,7 +85,7 @@ const RemarksGlossary = ({ isReadOnly, remarks, remarkCategories,
     remarks.forEach(r => {
       const exlusiveRCatCodes = Object.keys(localExclusiveCategories);
       if (exlusiveRCatCodes.includes(r?.rc_code)) {
-        exclusiveCategories[r?.rc_code].seqNums ??= [];
+        localExclusiveCategories[r?.rc_code].seqNums ??= [];
         localExclusiveCategories[r?.rc_code].seqNums.push(r?.seq_num);
       }
     });
@@ -197,14 +195,14 @@ const RemarksGlossary = ({ isReadOnly, remarks, remarkCategories,
                   const rStatus = remarkStatus(r);
                   return (<li key={r.seq_num}>
                     <InteractiveElement
-                      onClick={() => rStatus.disabled ? {} : updateSelection(r, textInputs)}
+                      onClick={() => rStatus?.disabled ? {} : updateSelection(r, textInputs)}
                     >
                       <FA
-                        name={`${rStatus.selected ? 'minus-circle' : 'plus-circle'}`}
-                        className={`${rStatus.disabled ? 'fa-disabled' : ''}`}
+                        name={`${rStatus?.selected ? 'minus-circle' : 'plus-circle'}`}
+                        className={`${rStatus?.disabled ? 'fa-disabled' : ''}`}
                       />
                     </InteractiveElement>
-                    {renderText(r, rStatus.disabled || rStatus.selected)}
+                    {renderText(r, rStatus?.disabled || rStatus?.selected)}
                   </li>);
                 })}
               </ul>

--- a/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
+++ b/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
@@ -84,6 +84,10 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
     remarks.forEach(r => {
       const exlusiveRCatCodes = Object.keys(exclusiveCategories);
       if(exlusiveRCatCodes.includes(r?.rc_code)) {
+        // i thought having an array of the seqnums would help with optimization
+        // but since our remarks usually have the rc_code in them, we can just look up on that
+        // to prevent looping on all 😾 to find
+        // pending: remove seqNums [] before opening PR for review
         exclusiveCategories[r?.rc_code]['seqNums'] ??= [];
         exclusiveCategories[r?.rc_code]['seqNums'].push(r?.seq_num);
         exclusiveCategories?.exlusiveSeqs.push(r?.seq_num);
@@ -92,23 +96,26 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
     /* eslint-disable no-console */
     console.log('🧁🧁🧁🧁🧁🧁🧁🧁🧁🧁');
     console.log('🧁 current: exclusiveCategories', exclusiveCategories);
-    console.log('🧁🧁🧁🧁🧁🧁🧁🧁🧁🧁');
 
     setExclusiveCats(exclusiveCategories);
   };
 
   const updateExclusiveCats = () => {
-    const exclusiveCats$ = {...exclusiveCats};
+    let exclusiveCats$ = {...exclusiveCats};
+
+    // reset cats
+    Object.keys(exclusiveCats$).forEach(c => {
+      // pending: remove if removing exlusiveSeqs
+      if(c !== 'exlusiveSeqs') {
+        exclusiveCats$[c].remarkCatSelected = false;
+      }
+    })
 
     userSelections.forEach(r => {
-      if((exclusiveCats$?.exlusiveSeqs)?.includes(r?.seq_num)){
+      if(exclusiveCats$[r.rc_code]){
         exclusiveCats$[r.rc_code].remarkCatSelected = true;
       }
     });
-    /* eslint-disable no-console */
-    console.log('👻👻👻👻👻👻👻👻👻👻👻');
-    console.log('👻 current: exclusiveCats$', exclusiveCats$);
-    console.log('👻👻👻👻👻👻👻👻👻👻👻');
 
     setExclusiveCats(exclusiveCats$);
   };
@@ -121,7 +128,8 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
     /* eslint-disable no-console */
     console.log('🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄');
     console.log('🦄 current: r', r);
-    console.log('🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄');
+    console.log('🦄 current: userSelections', userSelections);
+    console.log('🦄 current: find(userSelections, { seq_num: r.seq_num })', find(userSelections, { seq_num: r.seq_num }));
 
     if(find(userSelections, { seq_num: r.seq_num })) {
       interactiveType = 'selectedEnabled'
@@ -131,6 +139,8 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
       interactiveType = 'notSelectedEnabled'
     }
 
+    console.log('🦄 current: interactiveType', interactiveType);
+    console.log('🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄');
 
     const returnTypes = {
       selectedEnabled: (<InteractiveElement onClick={() => updateSelection(r, textInputs)}>

--- a/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
+++ b/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
@@ -14,6 +14,12 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
 
   const setTextInput = (rSeq, riSeq, value) => {
     const textInputs$ = { ...textInputs };
+    /* eslint-disable no-console */
+    console.log('🐥🐥🐥🐥🐥🐥🐥🐥🐥🐥️');
+    console.log('🐥 current: textInputs$:',textInputs$);
+    console.log('🐥🐥🐥🐥🐥🐥🐥🐥🐥🐥️');
+
+
     if (!textInputs$[rSeq.toString()]) {
       textInputs$[rSeq.toString()] = {};
       textInputs$[rSeq.toString()][riSeq.toString()] = value;
@@ -23,7 +29,8 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
     setTextInputs(textInputs$);
   };
 
-  const setTextInputBulk = (remarksArr = []) => {
+  const setTextInputBulk = () => {
+    const remarksArr = remarks;
     const textInputs$ = {};
     remarksArr.forEach(r => {
       r.remark_inserts.forEach(ri => {
@@ -39,6 +46,7 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
       /* eslint-disable no-console */
       console.log('🥹🥹🥹🥹🥹🥹🥹🥹🥹🥹');
       console.log('🥹 current: textInputs$', textInputs$);
+      console.log('🥹 current: userSelections', userSelections);
       console.log('🥹🥹🥹🥹🥹🥹🥹🥹🥹🥹');
 
       setTextInputs(textInputs$);
@@ -47,7 +55,7 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
 
   const getTextInputValue = (rSeq, riSeq) => get(textInputs, rSeq[riSeq]) || '';
 
-  const renderText = r => {
+  const renderText = (r, interactiveTypeRender, disabled) => {
     const rText = r?.text?.split(/(\s+)/) || '';
     const rInserts = r?.remark_inserts || [];
 
@@ -62,13 +70,16 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
           placeholder={rInsertionText.replace(/[{}\d]/g, '').replace(/#/g, 'number')}
           id="remarks-custom-input"
           key={a.riseqnum}
-          inputProps={{ autoComplete: 'off' }}
+          inputProps={{autoComplete: 'off'}}
+          disabled={disabled}
         />);
       }
     });
-    return (
-      <div className="remark-input-container">{rText}</div>
-    );
+    return (<>
+        {interactiveTypeRender}
+        <div className="remark-input-container">{rText}</div>
+      </>);
+
   };
 
   const renderExclusiveCats = () => {
@@ -120,8 +131,9 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
     setExclusiveCats(exclusiveCats$);
   };
 
-  const getInteractiveType = (r, textInputs) => {
+  const getInteractiveTypeAndText = (r, textInputs) => {
     let interactiveType = '';
+    let disabled = false;
 
     //for this category go through the user remarks and if they already
     // have a selection in that category, disable the adding of more than one per category
@@ -133,8 +145,10 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
 
     if(find(userSelections, { seq_num: r.seq_num })) {
       interactiveType = 'selectedEnabled'
+      disabled = true;
     } else if(exclusiveCats?.[r.rc_code]?.remarkCatSelected) {
       interactiveType = 'notSelectedDisabled'
+      disabled = true;
     } else {
       interactiveType = 'notSelectedEnabled'
     }
@@ -157,7 +171,7 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
       </InteractiveElement>),
     };
 
-    return returnTypes[interactiveType];
+    return renderText(r, returnTypes[interactiveType], disabled)
   };
 
   const [remarks$, setRemarks$] = useState(remarks);
@@ -192,9 +206,9 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
     el.scrollIntoView();
   };
 
-  useEffect(() => {
-    setTextInputBulk(remarks);
-  }, [remarks]);
+  // useEffect(() => {
+  //   setTextInputBulk(remarks);
+  // }, [remarks]);
 
   useEffect(() => {
     updateExclusiveCats();
@@ -202,6 +216,7 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
 
   useEffect(() => {
     renderExclusiveCats();
+    setTextInputBulk();
   }, []);
 
   return (
@@ -233,8 +248,7 @@ const RemarksGlossary = ({ remarks, remarkCategories, userSelections, updateSele
               <ul>
                 {remarksInCategory.map(r => (
                   (<li key={r.seq_num}>
-                    {getInteractiveType(r, textInputs)}
-                    {renderText(r)}
+                    {getInteractiveTypeAndText(r, textInputs)}
                   </li>)
                 ))}
               </ul>

--- a/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
+++ b/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/RemarksGlossary.jsx
@@ -47,7 +47,7 @@ const RemarksGlossary = ({ isReadOnly, remarks, remarkCategories,
 
   const getTextInputValue = (rSeq, riSeq) => textInputs?.[rSeq]?.[riSeq] || '';
 
-  const renderText = (r, interactiveTypeRender, disabled) => {
+  const renderText = (r, disabled) => {
     const rText = r?.text?.split(/(\s+)/) || '';
     const rInserts = r?.remark_inserts || [];
 
@@ -71,7 +71,6 @@ const RemarksGlossary = ({ isReadOnly, remarks, remarkCategories,
       }
     });
     return (<>
-      {interactiveTypeRender}
       <div className="remark-input-container">{rText}</div>
     </>);
   };
@@ -112,40 +111,7 @@ const RemarksGlossary = ({ isReadOnly, remarks, remarkCategories,
     setExclusiveCats(exclusiveCats$);
   };
 
-  // eslint-disable-next-line no-unused-vars
-  const getInteractiveTypeAndTextOLD = (r) => {
-    let interactiveType = '';
-    let disabled = isReadOnly;
-
-    if (find(userSelections, { seq_num: r.seq_num })) {
-      interactiveType = 'selectedEnabled';
-      disabled = true;
-    } else if (exclusiveCats?.[r.rc_code]?.remarkCatSelected) {
-      interactiveType = 'notSelectedDisabled';
-      disabled = true;
-    } else {
-      interactiveType = 'notSelectedEnabled';
-    }
-
-    const returnTypes = {
-      selectedEnabled: (<InteractiveElement onClick={() => updateSelection(r, textInputs)}>
-        <FA name="minus-circle" />
-      </InteractiveElement>),
-      notSelectedDisabled: (<InteractiveElement onClick={() => {}}>
-        <FA
-          name="plus-circle"
-          className="fa-disabled"
-        />
-      </InteractiveElement>),
-      notSelectedEnabled: (<InteractiveElement onClick={() => updateSelection(r, textInputs)}>
-        <FA name="plus-circle" />
-      </InteractiveElement>),
-    };
-
-    return renderText(r, returnTypes[interactiveType], disabled);
-  };
-
-  const helpMe = (r) => {
+  const remarkStatus = (r) => {
     let disabled = isReadOnly;
     let selected = false;
 
@@ -158,22 +124,6 @@ const RemarksGlossary = ({ isReadOnly, remarks, remarkCategories,
 
     return { selected, disabled };
   };
-
-  const getInteractiveTypeAndText = (r) => {
-    const elsa = helpMe(r);
-
-    const returnType = (<InteractiveElement
-      onClick={() => elsa?.disabled ? {} : updateSelection(r, textInputs)}
-    >
-      <FA
-        name={`${elsa?.selected ? 'minus-circle' : 'plus-circle'}`}
-        className={`${elsa?.disabled ? 'fa-disabled' : ''}`}
-      />
-    </InteractiveElement>);
-
-    return renderText(r, returnType, elsa?.disabled || elsa?.selected);
-  };
-
 
   const [remarks$, setRemarks$] = useState(remarks);
 
@@ -243,11 +193,20 @@ const RemarksGlossary = ({ isReadOnly, remarks, remarkCategories,
                 {category.desc_text}{isExclusiveCatText}
               </div>
               <ul>
-                {remarksInCategory.map(r => (
-                  (<li key={r.seq_num}>
-                    {getInteractiveTypeAndText(r)}
-                  </li>)
-                ))}
+                {remarksInCategory.map(r => {
+                  const rStatus = remarkStatus(r);
+                  return (<li key={r.seq_num}>
+                    <InteractiveElement
+                      onClick={() => rStatus.disabled ? {} : updateSelection(r, textInputs)}
+                    >
+                      <FA
+                        name={`${rStatus.selected ? 'minus-circle' : 'plus-circle'}`}
+                        className={`${rStatus.disabled ? 'fa-disabled' : ''}`}
+                      />
+                    </InteractiveElement>
+                    {renderText(r, rStatus.disabled || rStatus.selected)}
+                  </li>);
+                })}
               </ul>
             </div>
           );

--- a/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/__snapshots__/RemarksGlossary.test.jsx.snap
+++ b/src/Components/Agenda/AgendaItemResearchPane/RemarksGlossary/__snapshots__/RemarksGlossary.test.jsx.snap
@@ -8,6 +8,7 @@ exports[`RemarksGlossary Component matches snapshot 1`] = `
     changeText={[Function]}
     containerProps={Object {}}
     customContainerClass=""
+    disabled={false}
     id="remarks-search"
     inputProps={
       Object {

--- a/src/Components/Agenda/RemarksPill/RemarksPill.jsx
+++ b/src/Components/Agenda/RemarksPill/RemarksPill.jsx
@@ -12,69 +12,12 @@ const RemarksPill = props => {
     const refInserts = r?.remark_inserts || [];
     let remarkText = r?.ref_text || '';
 
-    /* eslint-disable no-console */
-    console.log('👻👻👻👻👻👻👻👻👻👻👻');
-    console.log('👻 current: r:', r);
-    console.log('👻 current: remarkText:', remarkText);
-    // this r works
-    // {
-    //     "seq_num": 88,
-    //     "rc_code": "B",
-    //     "order_num": 3,
-    //     "short_desc_text": "Spec class no.",
-    //     "mutually_exclusive_ind": "N",
-    //     "text": "{#} Specialist Orientation Class",
-    //     "active_ind": "Y",
-    //     "remark_inserts": [
-    //         {
-    //             "riseqnum": 127,
-    //             "rirmrkseqnum": 88,
-    //             "riinsertiontext": "{#}"
-    //         }
-    //     ],
-    //     "ref_text": null,
-    //     "ari_insertions": {
-    //         "127": "666"
-    //     }
-    // }
-    // this one does not:
-    // {
-    //     "seq_num": 225,
-    //     "rc_code": "P",
-    //     "order_num": 11,
-    //     "short_desc_text": "Senior cede",
-    //     "mutually_exclusive_ind": "N",
-    //     "text": "LWOP Committee approved on  09/29/04, criterion 5",
-    //     "active_ind": "Y",
-    //     "remark_inserts": [
-    //         {
-    //             "riseqnum": 192,
-    //             "rirmrkseqnum": 225,
-    //             "riinsertiontext": "{number}"
-    //         },
-    //         {
-    //             "riseqnum": 193,
-    //             "rirmrkseqnum": 225,
-    //             "riinsertiontext": "{date}"
-    //         }
-    //     ],
-    //     "ref_text": "LWOP Committee approved on {date}, criterion {number}"
-    // }
-
-    console.log('👻 current: r?.user_remark_inserts:', r?.user_remark_inserts);
     refInserts.forEach(refInsert => {
-      console.log('👻 current: refInsert:', refInsert);
-      console.log('👻 current: find(r?.user_remark_inserts, { aiririseqnum: refInsert?.riseqnum }):', find(r?.user_remark_inserts, { aiririseqnum: refInsert?.riseqnum }));
-
-      // eslint-disable-next-line max-len
-      remarkText = remarkText.replace(refInsert?.riinsertiontext, find(r?.user_remark_inserts, { aiririseqnum: refInsert?.riseqnum })?.airiinsertiontext);
-      // if (r.ari_insertions[refInsert?.riseqnum]) {
-      //   remarkText =
-      //     remarkText.replace(refInsert?.riinsertiontext, r.ari_insertions[refInsert?.riseqnum]);
-      // }
+      remarkText = remarkText.replace(
+        refInsert?.riinsertiontext,
+        find(r?.user_remark_inserts, { aiririseqnum: refInsert?.riseqnum })?.airiinsertiontext);
     });
 
-    console.log('👻👻👻👻👻👻👻👻👻👻👻');
     return remarkText;
   };
 

--- a/src/Components/Agenda/RemarksPill/RemarksPill.jsx
+++ b/src/Components/Agenda/RemarksPill/RemarksPill.jsx
@@ -1,21 +1,80 @@
 import PropTypes from 'prop-types';
 import FA from 'react-fontawesome';
+import { find } from 'lodash';
 import { EMPTY_FUNCTION } from 'Constants/PropTypes';
 
 const RemarksPill = props => {
   const { remark, isEditable, updateSelection, fromAIM } = props;
 
   const getRemarkText = (r) => {
+    // we can just grab the already merged text from the BE, but it would mean
+    // we have to distinguish from the read/create RemarksGlossary renders
     const refInserts = r?.remark_inserts || [];
-    let remarkText = r?.text || '';
+    let remarkText = r?.ref_text || '';
 
+    /* eslint-disable no-console */
+    console.log('👻👻👻👻👻👻👻👻👻👻👻');
+    console.log('👻 current: r:', r);
+    console.log('👻 current: remarkText:', remarkText);
+    // this r works
+    // {
+    //     "seq_num": 88,
+    //     "rc_code": "B",
+    //     "order_num": 3,
+    //     "short_desc_text": "Spec class no.",
+    //     "mutually_exclusive_ind": "N",
+    //     "text": "{#} Specialist Orientation Class",
+    //     "active_ind": "Y",
+    //     "remark_inserts": [
+    //         {
+    //             "riseqnum": 127,
+    //             "rirmrkseqnum": 88,
+    //             "riinsertiontext": "{#}"
+    //         }
+    //     ],
+    //     "ref_text": null,
+    //     "ari_insertions": {
+    //         "127": "666"
+    //     }
+    // }
+    // this one does not:
+    // {
+    //     "seq_num": 225,
+    //     "rc_code": "P",
+    //     "order_num": 11,
+    //     "short_desc_text": "Senior cede",
+    //     "mutually_exclusive_ind": "N",
+    //     "text": "LWOP Committee approved on  09/29/04, criterion 5",
+    //     "active_ind": "Y",
+    //     "remark_inserts": [
+    //         {
+    //             "riseqnum": 192,
+    //             "rirmrkseqnum": 225,
+    //             "riinsertiontext": "{number}"
+    //         },
+    //         {
+    //             "riseqnum": 193,
+    //             "rirmrkseqnum": 225,
+    //             "riinsertiontext": "{date}"
+    //         }
+    //     ],
+    //     "ref_text": "LWOP Committee approved on {date}, criterion {number}"
+    // }
+
+    console.log('👻 current: r?.user_remark_inserts:', r?.user_remark_inserts);
     refInserts.forEach(refInsert => {
-      if (r.ari_insertions[refInsert?.riseqnum]) {
-        remarkText =
-          remarkText.replace(refInsert?.riinsertiontext, r.ari_insertions[refInsert?.riseqnum]);
-      }
+      console.log('👻 current: refInsert:', refInsert);
+      console.log('👻 current: find(r?.user_remark_inserts, { aiririseqnum: refInsert?.riseqnum }):', find(r?.user_remark_inserts, { aiririseqnum: refInsert?.riseqnum }));
+
+      // eslint-disable-next-line max-len
+      remarkText = remarkText.replace(refInsert?.riinsertiontext, find(r?.user_remark_inserts, { aiririseqnum: refInsert?.riseqnum })?.airiinsertiontext);
+      // if (r.ari_insertions[refInsert?.riseqnum]) {
+      //   remarkText =
+      //     remarkText.replace(refInsert?.riinsertiontext, r.ari_insertions[refInsert?.riseqnum]);
+      // }
     });
 
+    console.log('👻👻👻👻👻👻👻👻👻👻👻');
     return remarkText;
   };
 

--- a/src/Components/Glossary/GlossarySearch/__snapshots__/GlossarySearch.test.jsx.snap
+++ b/src/Components/Glossary/GlossarySearch/__snapshots__/GlossarySearch.test.jsx.snap
@@ -10,6 +10,7 @@ exports[`GlossaryComponent matches snapshot 1`] = `
     changeText={[Function]}
     containerProps={Object {}}
     customContainerClass=""
+    disabled={false}
     id="glossary-search"
     inputProps={
       Object {

--- a/src/Components/SaveNewSearchDialog/__snapshots__/SaveNewSearchDialog.test.jsx.snap
+++ b/src/Components/SaveNewSearchDialog/__snapshots__/SaveNewSearchDialog.test.jsx.snap
@@ -14,6 +14,7 @@ exports[`SaveNewSearchDialogComponent matches snapshot 1`] = `
       changeText={[Function]}
       containerProps={Object {}}
       customContainerClass=""
+      disabled={false}
       id="saved-search"
       inputProps={Object {}}
       label="Name"

--- a/src/Components/TextInput/TextInput.jsx
+++ b/src/Components/TextInput/TextInput.jsx
@@ -27,7 +27,7 @@ const TextInput = props => {
   }, [props.value]);
 
   const { id, labelSrOnly, type, label, labelMessage, placeholder, inputProps,
-    containerProps, customContainerClass } = props;
+    containerProps, customContainerClass, disabled } = props;
   let labelClass;
   // set the input class based on "type" prop
   let inputClass;
@@ -64,6 +64,7 @@ const TextInput = props => {
       <label htmlFor={id} className={labelSrOnly ? 'usa-sr-only' : ''}>{label}</label>
       <input
         id={id}
+        disabled={disabled}
         name="input-type-text"
         type="text"
         value={input}
@@ -80,6 +81,7 @@ const TextInput = props => {
 TextInput.propTypes = {
   id: PropTypes.string.isRequired,
   labelSrOnly: PropTypes.bool,
+  disabled: PropTypes.bool,
   changeText: PropTypes.func,
   type: PropTypes.oneOf(['success', 'error', 'focus']),
   label: PropTypes.string,
@@ -93,6 +95,7 @@ TextInput.propTypes = {
 
 TextInput.defaultProps = {
   labelSrOnly: false,
+  disabled: false,
   changeText: () => {},
   type: undefined,
   label: '',

--- a/src/Components/TextInput/__snapshots__/TextInput.test.jsx.snap
+++ b/src/Components/TextInput/__snapshots__/TextInput.test.jsx.snap
@@ -10,6 +10,7 @@ exports[`TextInputComponent matches snapshot 1`] = `
   />
   <input
     className=""
+    disabled={false}
     id="1"
     name="input-type-text"
     onChange={[Function]}

--- a/src/sass/_agendaItemMaintenance.scss
+++ b/src/sass/_agendaItemMaintenance.scss
@@ -41,10 +41,19 @@
   }
 
   .ai-research-pane {
-    .fa, .fa-disabled, .fa-disabled:hover {
-      color: $color-gray;
-      cursor: not-allowed;
+    .frequent-positions-table, .remarks-glossary-container {
+      .fa, .fa-disabled, .fa-disabled:hover {
+        color: $color-gray;
+        cursor: not-allowed;
+      }
     }
+  }
+}
+
+.remarks-glossary-container {
+  .fa, .fa-disabled, .fa-disabled:hover {
+    color: $color-gray!important;
+    cursor: not-allowed;
   }
 }
 

--- a/src/sass/_agendaItemMaintenance.scss
+++ b/src/sass/_agendaItemMaintenance.scss
@@ -51,7 +51,7 @@
 }
 
 .remarks-glossary-container {
-  .fa, .fa-disabled, .fa-disabled:hover {
+  .fa-disabled, .fa-disabled:hover {
     color: $color-gray!important;
     cursor: not-allowed;
   }

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -912,3 +912,5 @@ export const determineEnv = (url) => {
   if (!match) console.log('no valid env found');
   return match[0];
 };
+
+// Search Tags: common.js, helper file, helper functions, common helper file, common file


### PR DESCRIPTION
Dual Merge: 
- [FE PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2551)
- [API PR](https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/798)


---

✅ Glossary Ingest Remarks
ai remarks that are not legacy should populate in the Remarks Glossary
if Read-Mode, the icons and inputs are disabled
If they exist, insertions should populate the inputs
Edge Case: How to handle the ones where there is more than one remark in a category where we only want one - exclusive categories will disable adding when >= one remark in category is selected
	however, removing will still be enabled. Adding will be re-enabled when 0 remarks in the exclusive category are selected.

---

✅ Glossary Exclusive Categories

Set up the functionality for the remark categories that are rmrkmutuallyexclusiveind": “Y”
Exclusive categories are now communicated to the user with a text next to the category name. 
Adding, for exclusive categories, is disabled when one remark is selected within that category.

---

✅ Disable Inputs
After adding a remark, the input box is disabled - this way there is never a discrepancy between a pill and the input. To Edit insertion text, user must remove the remark.
Inputs are also disabled if the exclusive category is disabled.

---

❎ Inputs
After extensive discussion with Scott, this feature(inputs based on insertion 'types') has been put on hold, bc of LOE - updated Victoria
Way forward - Turn all inputs into text ✅

---
