### PR TITLE
TM-4082: Update/admin remarks insertion removal

### DIFF
--- a/src/Components/AdministratorPage/EditRemark/EditRemark.jsx
+++ b/src/Components/AdministratorPage/EditRemark/EditRemark.jsx
@@ -30,7 +30,7 @@ const EditRemark = (props) => {
     const regex = new RegExp('{[^}]*}', 'g');
     let x = 0;
     // eslint-disable-next-line no-plusplus
-    const result = descriptionInput.replace(regex, (match) => (++x === i + 1 ? '' : match));
+    const result = descriptionInput.replace(regex, (match) => (x++ === i ? '' : match));
     setDescriptionInput(result);
   };
 

--- a/src/Components/AdministratorPage/EditRemark/EditRemark.jsx
+++ b/src/Components/AdministratorPage/EditRemark/EditRemark.jsx
@@ -26,7 +26,7 @@ const EditRemark = (props) => {
     const returnArray = [...rmrkInsertionList];
     returnArray.splice(i, 1);
     setRmrkInsertionList(returnArray);
-    
+
     const regex = new RegExp('{[^}]*}', 'g');
     let x = 0;
     // eslint-disable-next-line no-plusplus

--- a/src/Components/AdministratorPage/EditRemark/EditRemark.jsx
+++ b/src/Components/AdministratorPage/EditRemark/EditRemark.jsx
@@ -26,6 +26,12 @@ const EditRemark = (props) => {
     const returnArray = [...rmrkInsertionList];
     returnArray.splice(i, 1);
     setRmrkInsertionList(returnArray);
+    
+    const regex = new RegExp('{[^}]*}', 'g');
+    let x = 0;
+    // eslint-disable-next-line no-plusplus
+    const result = descriptionInput.replace(regex, (match) => (++x === i + 1 ? '' : match));
+    setDescriptionInput(result);
   };
 
   const submitInsertion = () => {


### PR DESCRIPTION
ACs:
1. Removing an insertion from the `Remark Insertions` list below should now remove that specific insertion from the `Remark Description` input box

Only note is me using the `eslint-disable-next-line no-plusplus` - I couldn't get the code to work any other way besides using the increment operator