### PR TITLE
Edit Panel UI Fix - defaulting to array instead of string

### DIFF
--- a/src/Components/AdministratorPage/EditRemark/EditRemark.jsx
+++ b/src/Components/AdministratorPage/EditRemark/EditRemark.jsx
@@ -21,7 +21,7 @@ const EditRemark = (props) => {
 
   const loadInserts = () => {
     const re = new RegExp('{[^}]*}', 'g');
-    const sortedInserts = longDescription.match(re) || '';
+    const sortedInserts = longDescription.match(re) || [];
     return sortedInserts;
   };
 


### PR DESCRIPTION
Defaulting to empty string was breaking editing remarks with no insertions. Changed to default to empty array