### PR TITLE
[TM-4568] Remaining Typescript Utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,12 +127,15 @@
     "@types/jest": "^26.0.24",
     "@types/lodash": "^4.14.181",
     "@types/node": "^16.4.12",
+    "@types/numeral": "^2.0.2",
     "@types/react": "^17.0.16",
     "@types/react-dom": "^17.0.14",
     "@types/react-fontawesome": "^1.6.5",
     "@types/react-responsive": "^8.0.5",
     "@types/react-router-dom": "^5.3.3",
+    "@types/react-scroll": "^1.8.7",
     "@types/shortid": "^0.0.29",
+    "@types/sinon": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "autoprefixer": "^9.8.8",
@@ -266,7 +269,9 @@
     ],
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.js?(x)",
-      "<rootDir>/src/**/?(*.)(spec|test).js?(x)"
+      "<rootDir>/src/**/?(*.)(spec|test).js?(x)",
+      "<rootDir>/src/**/__tests__/**/*.ts?(x)",
+      "<rootDir>/src/**/?(*.)(spec|test).ts?(x)"
     ],
     "testEnvironment": "node",
     "testURL": "http://localhost",

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,47 @@
+// ================== Global ==================
+
+// declaration merging of navigator to support new typescript version
+declare global {
+  interface Navigator {
+    msSaveBlob?: (blob: any, defaultName?: string) => boolean;
+    msSaveOrOpenBlob?: (blob: any, defaultName?: string) => boolean;
+  }
+}
+
+// ================== Local Types ==================
+
+export type Client = {
+  waivers: Waiver[];
+  bids: Bid[];
+  current_assignment: string;
+}
+
+export type Waiver = {
+  position: string;
+  category: string;
+}
+
+export type Bid = {
+  position: { title: string; position_number: string; };
+  status?: string;
+}
+
+export type Filter = {
+
+}
+
+export type Region = {
+  text: string;
+  value?: string;
+  disabled: boolean;
+  long_description?: string;
+  code?: string;
+}
+
+export type Grade = {
+  code: string;
+  value?: string;
+  text?: string;
+  name?: string;
+}
+

--- a/src/utilities.test.ts
+++ b/src/utilities.test.ts
@@ -1,0 +1,943 @@
+import sinon from 'sinon';
+import { isEqual } from 'lodash';
+import {
+  anyToTitleCase,
+  cleanQueryParams,
+  difference,
+  downloadFromResponse,
+  existsInNestedObject,
+  fetchUserToken,
+  focusByFirstOfHeader,
+  focusById,
+  formExploreRegionDropdown,
+  formQueryString,
+  formatBidTitle,
+  formatDate,
+  formatIdSpacing,
+  formatWaiverTitle,
+  getAccessiblePositionNumber,
+  getApplicationPath,
+  getAriaValue,
+  getAssetPath,
+  getBidCycleName,
+  getBidListStats,
+  getDifferentialPercentage,
+  getItemLabel,
+  getPostName,
+  getScrollDistanceFromBottom,
+  getTimeDistanceInWords,
+  hasValidToken,
+  ifEnter,
+  isUrl,
+  loadImg,
+  localStorageFetchValue,
+  localStorageToggleValue,
+  mapSavedSearchToDescriptions,
+  mapSavedSearchesToSingleQuery,
+  move,
+  numbersToPercentString,
+  propOrDefault,
+  propSort,
+  redirectToLoginRedirect,
+  returnObjectsWherePropMatches,
+  scrollToGlossaryTerm,
+  scrollToTop,
+  shortenString,
+  sortGrades,
+  spliceStringForCSV,
+  splitByLineBreak,
+  stopProp,
+  userHasPermissions,
+  validStateEmail,
+  wrapForMultiSelect,
+} from './utilities';
+import { searchObjectParent } from './__mocks__/searchObject';
+
+describe('local storage', () => {
+  it('should be able to fetch the existence of a value when there is one values in the array', () => {
+    localStorage.setItem('keyName', JSON.stringify(['1']));
+    const retrieved = localStorageFetchValue('keyName', '1');
+    expect(retrieved.exists).toBe(true);
+    localStorage.clear();
+  });
+
+  it('should be able to fetch the existence of a value when there are multiple values in the array', () => {
+    localStorage.setItem('keyName', JSON.stringify(['1', '2']));
+    const retrieved = localStorageFetchValue('keyName', '1');
+    expect(retrieved.exists).toBe(true);
+    localStorage.clear();
+  });
+
+  it('should be able to fetch the existence of a value when that value is not in the array', () => {
+    localStorage.setItem('keyName', JSON.stringify(['2', '3']));
+    const retrieved = localStorageFetchValue('keyName', '1');
+    expect(retrieved.exists).toBe(false);
+    localStorage.clear();
+  });
+
+  it('should be able to fetch the count of an array', () => {
+    localStorage.setItem('keyName', JSON.stringify(['1', '2']));
+    const retrieved = localStorageFetchValue('keyName', '1');
+    expect(retrieved.count).toBe(2);
+    localStorage.clear();
+  });
+
+  it('should be able to toggle a value in the array', () => {
+    localStorage.setItem('keyName', JSON.stringify(['1', '2']));
+    let retrieved = localStorageFetchValue('keyName', '1');
+    expect(retrieved.exists).toBe(true);
+    localStorageToggleValue('keyName', '1');
+    retrieved = localStorageFetchValue('keyName', '1');
+    expect(retrieved.exists).toBe(false);
+    localStorage.clear();
+  });
+});
+
+describe('validStateEmail', () => {
+  it('should return true for a valid State email', () => {
+    const email = 'joe123@state.gov';
+    const output = validStateEmail(email);
+    expect(output).toBe(true);
+  });
+
+  it('should return false for an invalid State email', () => {
+    const email = 'joe123@email.com';
+    const output = validStateEmail(email);
+    expect(output).toBe(false);
+  });
+});
+
+describe('fetchUserToken', () => {
+  it('should be able to fetch the auth token', () => {
+    localStorage.clear();
+    localStorage.setItem('token', '1234');
+    const output = fetchUserToken();
+    expect(output).toBe('Token 1234');
+    localStorage.clear();
+  });
+});
+
+describe('sort functions', () => {
+  const items = [{ title: 'a', description: 'a' }, { title: 'b', description: 'b' }];
+  const grades = [{ code: '01' }, { code: '02' }, { code: 'fake' }, { code: 'MC' }];
+
+  it('can sort by description', () => {
+    expect(propSort('description')(items[0], items[1])).toBe(-1);
+    expect(propSort('description')(items[1], items[0])).toBe(1);
+    expect(propSort('description')(items[0], items[0])).toBe(0);
+  });
+
+  it('can sort by title', () => {
+    expect(propSort('title')(items[0], items[1])).toBe(-1);
+    expect(propSort('title')(items[1], items[0])).toBe(1);
+    expect(propSort('title')(items[0], items[0])).toBe(0);
+  });
+
+  it('can apply custom sorting to grades', () => {
+    expect(sortGrades(grades[0], grades[1])).toBe(-1);
+    expect(sortGrades(grades[1], grades[0])).toBe(1);
+    expect(sortGrades(grades[0], grades[2])).toBe(-1);
+    expect(sortGrades(grades[3], grades[2])).toBe(-1);
+    expect(sortGrades(grades[2], grades[3])).toBe(1);
+    expect(sortGrades(grades[2], grades[2])).toBe(0);
+  });
+});
+
+const filters = [{ item: { title: 'Bureau' }, data: [{ long_description: 'regionA', code: 'code' }] }, { item: { title: 'Language' } }];
+
+describe('formExploreRegionDropdown function', () => {
+  const regions = formExploreRegionDropdown(filters);
+
+  it('can filter for region', () => {
+    if (filters[0].data)
+      expect(regions[1].long_description).toBe(filters[0].data[0].long_description);
+  });
+
+  it('can add new properties', () => {
+    if (filters[0].data)
+      expect(regions[1].text).toBe(filters[0].data[0].long_description);
+  });
+
+  it('adds the placeholder object to the beginning of the array', () => {
+    expect(regions[0].disabled).toBe(true);
+  });
+});
+
+describe('scrollToTop function', () => {
+  it('can call the scrollToTop function', () => {
+    scrollToTop();
+  });
+});
+
+describe('getItemLabel function', () => {
+  it('can can get an item label', () => {
+    if (filters[0].data)
+      expect(getItemLabel(filters[0].data[0])).toBe(filters[0].data[0].long_description);
+    expect(getItemLabel({ description: 'test' })).toBe('test');
+    expect(getItemLabel({ code: '0' })).toBe('0');
+  });
+});
+
+describe('shortenString function', () => {
+  const string = '012345';
+  it('can shorten a string with the default suffix', () => {
+    expect(shortenString(string, 0)).toBe('...');
+    expect(shortenString(string, 2)).toBe('...');
+    expect(shortenString(string, 3)).toBe('...');
+    expect(shortenString(string, 4)).toBe('0...');
+    expect(shortenString(string, 5)).toBe('01...');
+    expect(shortenString(string, 6)).toBe('012345');
+    expect(shortenString(string, 7)).toBe('012345');
+  });
+
+  it('can shorten a string with a null suffix', () => {
+    expect(shortenString(string, 0, null)).toBe('');
+    expect(shortenString(string, 2, null)).toBe('01');
+    expect(shortenString(string, 3, null)).toBe('012');
+    expect(shortenString(string, 4, null)).toBe('0123');
+    expect(shortenString(string, 5, null)).toBe('01234');
+    expect(shortenString(string, 6, null)).toBe('012345');
+    expect(shortenString(string, 7, null)).toBe('012345');
+  });
+});
+
+describe('cleanQueryParams', () => {
+  const query = { q: 'test', fake: 'test' };
+  it('retain only real query params', () => {
+    expect(cleanQueryParams(query).fake).toBe(undefined);
+    expect(cleanQueryParams(query).q).toBe(query.q);
+    expect(Object.keys(cleanQueryParams(query)).length).toBe(1);
+  });
+});
+
+describe('ifEnter', () => {
+  it('only returns true for keyCode of 13', () => {
+    expect(ifEnter({ keyCode: 13 } as React.KeyboardEvent)).toBe(true);
+    expect(ifEnter({ keyCode: 14 } as React.KeyboardEvent)).toBe(false);
+  });
+});
+
+describe('formQueryString', () => {
+  it('can return a string', () => {
+    expect(formQueryString({ q: 'test' })).toBe('q=test');
+  });
+});
+
+describe('existsInNestedObject', () => {
+  it('can return true when something exists in a nested object', () => {
+    const arr = [{ position_info: { id: 1 } }];
+    expect(existsInNestedObject(1, arr)).toEqual(arr[0]);
+  });
+
+  it('can return false when something does not exist in a nested object', () => {
+    expect(existsInNestedObject(1, [{ position: { otherId: 2 } }])).toBe(false);
+  });
+});
+
+describe('distanceInWords', () => {
+  it('returns a defined value containg "ago" in the string', () => {
+    const timeDistanceInWords = getTimeDistanceInWords(new Date());
+    // we won't explicitly test for values since we can expect date-fns to work
+    expect(timeDistanceInWords).toBeDefined();
+    // but we will test that it contains ' ago' since that is custom text we added in
+    expect(timeDistanceInWords).toContain(' ago');
+  });
+});
+
+describe('formatDate', () => {
+  it('returns a properly formatted date', () => {
+    // how we expect the date from the API
+    const unformattedDate = '2017-01-15';
+    // converted date
+    const formattedDate = formatDate(unformattedDate);
+    // should be formatted using the default format
+    expect(formattedDate).toBe('01/15/2017');
+  });
+
+  it('returns a properly formatted date with a custom format', () => {
+    // how we expect the date from the API
+    const unformattedDate = '2017-01-01';
+    // converted date
+    const formattedDate = formatDate(unformattedDate, 'M-D-YYYY');
+    // should be formatted using the custom format
+    expect(formattedDate).toBe('1-1-2017');
+  });
+
+  // Function is type checked in new TS utilities so this unit test may not be needed
+  // In that case, remove null from param types in formatDate
+  it('returns null if no date is provided', () => {
+    expect(formatDate(null)).toBe(null);
+  });
+});
+
+describe('focusById', () => {
+  let focusSpy: sinon.SinonSpy;
+  it('can focus by ID', () => {
+    focusSpy = sinon.spy();
+    const elements: any = {
+      test: {
+        focus: focusSpy,
+      },
+    };
+    global.document.getElementById = id => elements[id];
+    focusById('test');
+    sinon.assert.calledOnce(focusSpy);
+  });
+
+  it('can focus by ID when there is a timeout', (done) => {
+    focusSpy = sinon.spy();
+    const elements: any = {
+      test: {
+        focus: focusSpy,
+      },
+    };
+    global.document.getElementById = id => elements[id];
+    const timeout = 10;
+    focusById('test', timeout);
+    setTimeout(() => {
+      sinon.assert.calledOnce(focusSpy);
+      done();
+    }, timeout);
+  });
+});
+
+describe('focusByFirstOfHeader', () => {
+  let valuesSetBySetAttribute: string[] = [];
+  const setAttribute = (attribute: string, value: string) => { valuesSetBySetAttribute = [attribute, value]; };
+
+  let focusSpy = sinon.spy();
+  let elements: any = {
+    h1: [
+      {},
+      { focus: focusSpy, setAttribute },
+    ],
+    h2: {},
+  };
+  global.document.getElementsByTagName = (tag: string) => elements[tag];
+  it('can focus and set attributes to the first header found', (done) => {
+    focusByFirstOfHeader();
+    const f = () => {
+      setTimeout(() => {
+        sinon.assert.calledOnce(focusSpy);
+        expect(valuesSetBySetAttribute[0]).toBe('tabindex');
+        expect(valuesSetBySetAttribute[1]).toBe('-1');
+        done();
+      }, 10);
+    };
+    f();
+  });
+
+  it('can focus the first h2 if h1 does not exist', (done) => {
+    // reset spy and attribute array
+    valuesSetBySetAttribute = [];
+    focusSpy = sinon.spy();
+    elements = {
+      h2: [
+        { focus: focusSpy, setAttribute },
+      ],
+    };
+    focusByFirstOfHeader();
+    const f = () => {
+      setTimeout(() => {
+        sinon.assert.calledOnce(focusSpy);
+        expect(valuesSetBySetAttribute[0]).toBe('tabindex');
+        expect(valuesSetBySetAttribute[1]).toBe('-1');
+        done();
+      }, 10);
+    };
+    f();
+  });
+});
+
+describe('wrapForMultiSelect', () => {
+  it('can convert properties', () => {
+    const options = [{ code: '100', description: 'one hundred' }, { code: '200', description: 'two hundred' }];
+    const wrappedOptions = wrapForMultiSelect(options, 'code', 'description');
+    expect(wrappedOptions).toBeDefined();
+    expect(wrappedOptions[0].value).toBe(options[0].code);
+    expect(wrappedOptions[0].label).toBe(options[0].description);
+    expect(wrappedOptions[1].value).toBe(options[1].code);
+    expect(wrappedOptions[1].label).toBe(options[1].description);
+  });
+});
+
+describe('returnObjectsWherePropMatches', () => {
+  it('can return objects in two arrays where a property matches in both arrays', () => {
+    const sourceArray = [
+      { code: '1', description: 'one' },
+      { code: '2', description: 'two' },
+    ];
+    const compareArray = [
+      { code: '2', description: 't-w-o', label: 'two' },
+      { code: '4', description: 'four' },
+      { code: '5', description: 'five' },
+    ];
+    const propToCheck = 'code';
+    const newArray = returnObjectsWherePropMatches(sourceArray, compareArray, propToCheck);
+    // only one code matches between the two arrays, the one where code === '2'
+    expect(newArray.length).toBe(1);
+    // the description should be the one from the first array
+    expect(newArray[0].description).toBe(sourceArray[1].description);
+    // no props from the second array should be used
+    expect(newArray[0].label).toBeUndefined();
+  });
+});
+
+describe('numbersToPercentString', () => {
+  let numerator = 2;
+  let denominator = 10;
+
+  it('can return a percent', () => {
+    const percent = numbersToPercentString(numerator, denominator);
+    expect(percent).toBe('20.0%');
+  });
+
+  it('can return a percent with proper format', () => {
+    numerator = 3;
+    denominator = 7;
+    const format = '0.00%';
+    const percent = numbersToPercentString(numerator, denominator, format);
+    expect(percent).toBe('42.86%');
+  });
+});
+
+describe('formatBidTitle', () => {
+  it('can format a bid title', () => {
+    const bid = {
+      position: {
+        position_number: '0AA',
+        title: 'Title',
+      },
+    };
+    const expected = 'Title (0AA)';
+    expect(formatBidTitle(bid)).toBe(expected);
+  });
+});
+
+describe('formatWaiverTitle', () => {
+  it('can format a bid title', () => {
+    const waiver = {
+      position: 'Position',
+      category: 'category',
+    };
+    const expected = 'Position - CATEGORY';
+    expect(formatWaiverTitle(waiver)).toBe(expected);
+  });
+});
+
+describe('propOrDefault', () => {
+  const nestedObject = {
+    a: {
+      b: true,
+      c: {
+        d: {},
+        e: 1,
+        f: 0,
+      },
+    },
+  };
+
+  it('traverses nested objects', () => {
+    expect(propOrDefault(nestedObject, 'a.b')).toBe(true);
+    expect(propOrDefault(nestedObject, 'a.c.d')).toBeDefined();
+    expect(propOrDefault(nestedObject, 'a.c.e')).toBe(1);
+  });
+
+  it('returns the default value when the nested property does not exist', () => {
+    expect(propOrDefault(nestedObject, 'a.b.e.e.e')).toBe(null);
+    expect(propOrDefault(nestedObject, 'a.g')).toBe(null);
+    expect(propOrDefault(nestedObject, 'a.b.c.d.d', 'value')).toBe('value');
+  });
+
+  it('returns the property value when the property value exists, but is 0', () => {
+    expect(propOrDefault(nestedObject, 'a.c.f')).toBe(0);
+  });
+});
+
+describe('formatIdSpacing', () => {
+  it('can format strings', () => {
+    expect(formatIdSpacing('two words')).toBe('two-words');
+    expect(formatIdSpacing('has Three words')).toBe('has-Three-words');
+  });
+
+  it('can format numbers', () => {
+    expect(formatIdSpacing(3)).toBe('3');
+  });
+
+  it('can format undefined values', () => {
+    // these will be randomly generated shortids, so we just check that they have length
+    // greater than 3
+    expect(formatIdSpacing(undefined)).toBeDefined();
+    expect(formatIdSpacing(null)).toBeDefined();
+    // expect(formatIdSpacing(false)).toBeDefined(); // type checked with new TS utility functions
+  });
+});
+
+describe('userHasPermissions', () => {
+  let userPermissions: string[];
+  let permissionsToCheck: string[];
+  beforeEach(() => {
+    userPermissions = ['a', 'b', 'c'];
+    permissionsToCheck = ['a', 'c'];
+  });
+
+  it('returns true if the user has all the needed permissions', () => {
+    expect(userHasPermissions(permissionsToCheck, userPermissions)).toBe(true);
+  });
+
+  it('returns false if the user has some of the needed permissions', () => {
+    userPermissions = ['a'];
+    expect(userHasPermissions(permissionsToCheck, userPermissions)).toBe(false);
+  });
+
+  it('returns true if the user has more than the needed permissions', () => {
+    userPermissions.push('d', 'e');
+    expect(userHasPermissions(permissionsToCheck, userPermissions)).toBe(true);
+  });
+
+  it('returns false if userPermissions are not provided', () => {
+    userPermissions = [];
+    expect(userHasPermissions(permissionsToCheck, userPermissions)).toBe(false);
+  });
+
+  it('returns true if permissionsToCheck are not provided', () => {
+    permissionsToCheck = [];
+    expect(userHasPermissions(permissionsToCheck, userPermissions)).toBe(true);
+  });
+
+  it('returns true if permissionsToCheck and userPermissions are not provided', () => {
+    permissionsToCheck = [];
+    userPermissions = [];
+    expect(userHasPermissions(permissionsToCheck, userPermissions)).toBe(true);
+  });
+});
+
+describe('getAssetPath', () => {
+  it('returns the correct path with no PUBLIC_URL', () => {
+    const assetPath = '/image.png';
+    const result = getAssetPath(assetPath);
+    expect(result).toBe(assetPath);
+  });
+
+  it('returns the correct path with a PUBLIC_URL', () => {
+    process.env.PUBLIC_URL = '/public';
+    const assetPath = '/image.png';
+    const result = getAssetPath(assetPath);
+    expect(result).toBe(`/public${assetPath}`);
+  });
+
+  it('returns the correct path with a PUBLIC_URL with a trailing slash', () => {
+    process.env.PUBLIC_URL = '/public/';
+    const assetPath = '/image.png';
+    const result = getAssetPath(assetPath);
+    expect(result).toBe(`/public${assetPath}`);
+  });
+});
+
+describe('getApplicationPath', () => {
+  it('returns a valid path', () => {
+    // set env
+    process.env.PUBLIC_URL = '/application/';
+
+    const result = getApplicationPath();
+
+    expect(result).toBe('http://localhost/application/');
+  });
+});
+
+describe('getAccessiblePositionNumber', () => {
+  it('adds spaces to a position number', () => {
+    const positionNumber = 'S7001';
+
+    expect(getAccessiblePositionNumber(positionNumber)).toBe('S 7 0 0 1');
+  });
+
+  it('returns null if positionNumber is undefined', () => {
+    const positionNumber = undefined;
+
+    expect(getAccessiblePositionNumber(positionNumber)).toBe(null);
+  });
+});
+
+describe('getPostName', () => {
+  it('returns a domestic post name', () => {
+    const post = { location: { city: 'Arlington', state: 'VA', country: 'United States' } };
+    expect(getPostName(post)).toBe('Arlington, VA');
+  });
+
+  it('returns a domestic post name when country === USA', () => {
+    const post = { location: { city: 'Arlington', state: 'VA', country: 'USA' } };
+    expect(getPostName(post)).toBe('Arlington, VA');
+  });
+
+  it('returns an overseas post name', () => {
+    const post = { location: { city: 'London', state: null, country: 'United Kingdom' } };
+    expect(getPostName(post)).toBe('London, United Kingdom');
+  });
+
+  it('returns the code when location data is not available', () => {
+    const post = { location: null, code: '0AA' };
+    expect(getPostName(post)).toBe('0AA');
+  });
+
+  it('returns the default defaultValue when the code and location data are not available', () => {
+    const post = { location: null };
+    expect(getPostName(post)).toBe(null);
+  });
+
+  it('returns a custom defaultValue when the code and location data are not available', () => {
+    const post = { location: null };
+    expect(getPostName(post, 'default')).toBe('default');
+  });
+});
+
+describe('getDifferentialPercentage', () => {
+  it('returns a percentage for a differential', () => {
+    expect(getDifferentialPercentage(30)).toBe('30%');
+  });
+
+  it('returns a percentage for a differential of 0', () => {
+    expect(getDifferentialPercentage(0)).toBe('0%');
+  });
+
+  it('returns the default value for a differential of null', () => {
+    expect(getDifferentialPercentage(null)).toBe('');
+  });
+
+  it('returns a custom default value for a differential of null', () => {
+    expect(getDifferentialPercentage(null, 'custom')).toBe('custom');
+  });
+});
+
+describe('mapSavedSearchesToSingleQuery', () => {
+  const searches = searchObjectParent;
+  it('maps multiple saved searches to a single query', () => {
+    const mappedSearch = mapSavedSearchesToSingleQuery(searches);
+    const expected = {
+      position__grade__code__in: '02',
+      position__post__tour_of_duty__code__in: 'O',
+      q: 'german',
+      position__skill__code__in: '6080',
+    };
+    expect(isEqual(mappedSearch, expected)).toBe(true);
+  });
+});
+
+describe('mapSavedSearchToDescriptions', () => {
+  const searches = searchObjectParent;
+  const mappedFilters = [{
+    codeRef: '6080',
+    descCode: 'CONSULAR AFFAIRS',
+    description: 'CONSULAR AFFAIRS',
+    hasDuplicateDescription: true,
+    isCommon: undefined,
+    isTandem: true,
+    isToggle: undefined,
+    selectionRef: 'position__skill__code__in'
+  }];
+
+  it('maps saved searches to descriptions', () => {
+    const mappedDescriptions = mapSavedSearchToDescriptions(
+      searches.results[0].filters, mappedFilters);
+    const expected = [
+      { description: 'german', isTandem: undefined, isCommon: true, isToggle: undefined },
+      { description: 'CONSULAR AFFAIRS', isTandem: true, isCommon: undefined, isToggle: undefined },
+    ];
+    expect(isEqual(mappedDescriptions, expected)).toBe(true);
+  });
+});
+
+describe('difference', () => {
+  it('verify diff between 2 - 1 level objects when there ARE differences', () => {
+    const itemA = {
+      boolean: true,
+      array: null,
+    };
+
+    const itemB = {
+      boolean: false,
+      array: [],
+      new: 'I am new!',
+    };
+
+    const diff = difference(itemA, itemB);
+    const expected = {
+      boolean: false,
+      array: [],
+      new: 'I am new!',
+    };
+
+    expect(diff).toEqual(expected);
+  });
+
+  it('verify diff between 2 - 1 level objects when there NO differences', () => {
+    const itemA = {
+      boolean: true,
+      array: [],
+      string: 'string',
+    };
+
+    const itemB = {
+      boolean: true,
+      array: [],
+    };
+
+    const diff = difference(itemA, itemB);
+    const expected = {};
+
+    expect(diff).toEqual(expected);
+  });
+
+  it('verify diff between 2 - deep level objects', () => {
+    const itemA = {
+      data: {
+        boolean: false,
+        number: -1,
+        key: 'key',
+      },
+
+      params: {
+        config: '/var/usr/app',
+        count: 0,
+        data: {
+          boolean: false,
+          page: 1,
+        },
+      },
+    };
+
+    const itemB = {
+      data: {
+        boolean: false,
+        number: -1,
+        key: 'key',
+      },
+
+      params: {
+        config: '/var/usr/app',
+        count: 320,
+        data: {
+          boolean: false,
+          page: 10,
+        },
+      },
+    };
+
+    const diff = difference(itemA, itemB);
+    const expected = {
+      params: {
+        count: 320,
+        data: {
+          page: 10,
+        },
+      },
+    };
+
+    expect(diff).toEqual(expected);
+  });
+});
+
+describe('redirectToLoginRedirect', () => {
+  it('assigns a new window location', () => {
+    let newLocation;
+    process.env.PUBLIC_URL = '/test';
+    // eslint-disable-next-line no-return-assign
+    window.location.assign = loc => newLocation = loc;
+    redirectToLoginRedirect();
+    expect(newLocation).toBe('/test/loginRedirect');
+  });
+});
+
+describe('isUrl', () => {
+  it('returns the expected output for different strings', () => {
+    [
+      ['http', false], ['https', false], ['ftp', false], ['https://www', false], ['http.goo', false], ['goog.com', false],
+      ['http://google.com', true], ['https://www.goo.co', true],
+    ].map((u) => {
+      // assume first item in array is a string from declaration above
+      const output = isUrl(u[0] as string);
+      return u[1] ? expect(output).toBeTruthy() : expect(output).toBeFalsy();
+    });
+  });
+});
+
+describe('hasValidToken', () => {
+  it('removes the localStorage token if it is invalid', () => {
+    localStorage.setItem('token', '{');
+    expect(hasValidToken()).toBe(false);
+    expect(localStorage.getItem('token')).toBe(null);
+  });
+});
+
+describe('getScrollDistanceFromBottom', () => {
+  it('returns the scroll distance from the bottom of the page', () => {
+    window.pageYOffset = 100;
+    window.innerHeight = 800;
+    const z = document.createElement('body');
+    Object.setPrototypeOf(z, { offsetHeight: 3000 });
+    document.body = z;
+    expect(getScrollDistanceFromBottom()).toBe(2100);
+  });
+});
+
+describe('getAriaValue', () => {
+  [[true, 'true'], [false, 'false'], ['true', 'true'], ['false', 'false'], [null, 'false'], [1, 'true']]
+    .map(m => (
+      it(`returns ${m[1]} for ${m[0]}`, () => {
+        expect(getAriaValue(m[0])).toBe(m[1]);
+      })
+    ));
+});
+
+describe('spliceStringForCSV', () => {
+  it('splices the string correctly when index 1 === "="', () => {
+    expect(spliceStringForCSV('"=jjj"')).toBe('="jjj"');
+  });
+
+  it('returns the value unchanged when index 1 !== "="', () => {
+    expect(spliceStringForCSV('"jjj"')).toBe('"jjj"');
+  });
+});
+
+describe('scrollToGlossaryTerm', () => {
+  it("calls element's functions", (done) => {
+    const scrollSpy = sinon.spy();
+    const clickSpy = sinon.spy();
+
+    window.document.getElementById = () => ({
+      scrollIntoView: scrollSpy, 
+      getAttribute: () => '', 
+      click: clickSpy, 
+      focus: () => { },
+    } as unknown as HTMLElement);
+
+    scrollToGlossaryTerm('term');
+
+    setTimeout(() => {
+      sinon.assert.calledOnce(scrollSpy);
+      sinon.assert.calledOnce(clickSpy);
+      done();
+    }, 500);
+  });
+
+  describe('getBidCycleName', () => {
+    const cyclename = 'Summer 2020';
+
+    it('returns the correct value for strings', () => {
+      expect(getBidCycleName(cyclename)).toBe(cyclename);
+    });
+
+    it('returns the correct value for objects', () => {
+      expect(getBidCycleName({ name: cyclename })).toBe(cyclename);
+    });
+
+    it('returns the correct value when it cannot find a name', () => {
+      expect(getBidCycleName({ a: cyclename })).not.toBe(cyclename);
+      expect(getBidCycleName([])).not.toBe(cyclename);
+      expect(getBidCycleName({ cyclename: 1 })).not.toBe(cyclename);
+    });
+  });
+
+  describe('loadImg', () => {
+    it('does not throw an error', () => {
+      expect(loadImg).not.toThrowError();
+    });
+  });
+
+  describe('downloadFromResponse', () => {
+    let blobSpy: sinon.SinonSpy;
+    // let blobSpy: sinon.SinonSpy | ((blob: any, defaultName?: string | undefined) => boolean) | undefined;
+    // let blobSpy: sinon.SinonSpy<any[], any> | sinon.SinonSpy<any, any>;
+    // let blobSpy: sinon.SinonSpy<any[], any> | ((blob: any, defaultName?: string | undefined) => boolean) | sinon.SinonSpy<any, any> | undefined;
+    let response: { headers: { 'content-disposition': string; }; data: string; };
+
+    beforeEach(() => {
+      blobSpy = sinon.spy();
+      response = {
+        headers: { 'content-disposition': 'attachment; filename=test.csv' },
+        data: 'some data',
+      };
+      global.window.navigator.msSaveOrOpenBlob = blobSpy;
+    });
+
+    it('calls msSaveOrOpenBlob if msSaveBlob exists', () => {
+      downloadFromResponse(response);
+      sinon.assert.calledOnce(blobSpy);
+      blobSpy.reset();
+    });
+
+    it('does not call msSaveOrOpenBlob if msSaveBlob does not exist', () => {
+      global.window.navigator.msSaveBlob = undefined;
+      downloadFromResponse(response);
+      sinon.assert.notCalled(blobSpy);
+    });
+  });
+
+  describe('anyToTitleCase', () => {
+    it('converts a string to title case', () => {
+      const result = 'The Quick Dog';
+      ['tHE qUick Dog', 'THE QUICK DOG', 'the quick dog', 'The Quick Dog', 'tHe Quick dOg']
+        .map(m => expect(anyToTitleCase(m)).toBe(result));
+    });
+  });
+
+  describe('stopProp', () => {
+    it('calls stopPropagation on stopProp', () => {
+      const spy = sinon.spy();
+      const e = { stopPropagation: spy };
+      stopProp(e);
+      sinon.assert.calledOnce(spy);
+    });
+  });
+
+  describe('getBidListStats', () => {
+    it('properly counts statuses', () => {
+      const bidList = [{ status: 'a' }, { status: 'b' }, { status: 'c' }, { status: 'd' }, { status: 'e' }];
+      const statuses = ['a', 'b', 'c'];
+      expect(getBidListStats(bidList, statuses, false)).toBe(3);
+      expect(getBidListStats(bidList, ['x', 'y', 'z'])).toBe(0);
+      expect(getBidListStats(bidList, ['d'])).toBe(1);
+    });
+
+    it('properly pads numbers less than 10 when padWithZero', () => {
+      const bidList = [
+        { status: 'a' }, { status: 'a' }, { status: 'a' }, { status: 'a' }, { status: 'a' },
+        { status: 'a' }, { status: 'a' }, { status: 'a' }, { status: 'a' },
+        { status: 'b' }, { status: 'b' }, { status: 'b' }, { status: 'b' }, { status: 'b' },
+        { status: 'b' }, { status: 'b' }, { status: 'b' }, { status: 'b' }, { status: 'b' },
+      ];
+      const statuses = ['a', 'b', 'c'];
+      expect(getBidListStats(bidList, ['x', 'y', 'z'], true)).toBe('00');
+      expect(getBidListStats(bidList, ['a'], true)).toBe('09');
+      expect(getBidListStats(bidList, ['b'], true)).toBe('10');
+      expect(getBidListStats(bidList, statuses, true)).toBe('19');
+    });
+  });
+});
+
+describe('move', () => {
+  it('moves an item in an array', () => {
+    const arr = [1, 2, 3];
+    const exp = move(arr, 0, 1);
+    expect(exp).toEqual([2, 1, 3]);
+  });
+});
+
+describe('splitByLineBreak', () => {
+  // We use 3 line breaks to signal a split
+  it('splits a single message', () => {
+    expect(splitByLineBreak('test')).toEqual(['test']);
+  });
+
+  it('splits no messages', () => {
+    expect(splitByLineBreak(null)).toEqual(['']);
+  });
+
+  it('splits 2 messages', () => {
+    expect(splitByLineBreak('test\n\n\ntest2')).toEqual(['test', 'test2']);
+  });
+
+  it('splits 5 messages', () => {
+    expect(splitByLineBreak('test \n a  \n\n\ntest2 a\n\n\n test 3 \n\n\n test4 4 4 \n\n\ntest5 \n\n').length).toEqual(5);
+  });
+});

--- a/src/utilities.tsx
+++ b/src/utilities.tsx
@@ -1,22 +1,373 @@
-import { useEffect } from 'react';
+import { useEffect, KeyboardEvent } from 'react';
 import {
   cloneDeep, get, has, identity, includes, intersection, isArray, isEmpty, isEqual,
   isFunction, isNumber, isObject, isString, keys, lowerCase, merge as merge$, omit, orderBy,
   padStart, pick, pickBy, split, startCase, take, toLower, toString, transform, uniqBy
 } from 'lodash';
-import { LOGIN_REDIRECT, LOGIN_ROUTE, LOGOUT_ROUTE } from './login/routes';
-import { NO_BID_CYCLE, NO_POST } from './Constants/SystemMessages';
-import FLAG_COLORS from './Constants/FlagColors';
 import queryString from 'query-string'; //upgraded package
 // import swal from '@sweetalert/with-react'; //need to check if this is compatible with typescript
 import Fuse from 'fuse.js';
 import shortid from 'shortid';
 import Bowser from 'bowser';
+import Scroll from 'react-scroll';
+import numeral from 'numeral';
+import { distanceInWords, format } from 'date-fns';
 
-//converted utilities JS file to TS
+import { Bid, Grade, Region, Waiver } from './types';
+import { LOGIN_REDIRECT, LOGIN_ROUTE, LOGOUT_ROUTE } from './login/routes';
+import { NO_BID_CYCLE, NO_POST } from './Constants/SystemMessages';
+import { VALID_PARAMS, VALID_TANDEM_PARAMS } from './Constants/EndpointParams';
+import FLAG_COLORS from './Constants/FlagColors';
+
+const scroll = Scroll.animateScroll;
+
+export function localStorageFetchValue(key: string, value: any): { exists: boolean; count: number } {
+  const saved = { exists: true, count: 0 };
+  const retrievedKey = localStorage.getItem(key);
+  let parsedKey = JSON.parse(retrievedKey ?? '');
+  const arrayExists = Array.isArray(parsedKey);
+  if (!arrayExists) {
+    localStorage.setItem(key, JSON.stringify([]));
+    parsedKey = JSON.parse(localStorage.getItem(key) ?? '');
+  }
+  saved.count = parsedKey.length;
+  const refIsSaved = parsedKey.indexOf(value);
+  if (refIsSaved !== -1) {
+    saved.exists = true;
+  } else {
+    saved.exists = false;
+  }
+  return saved;
+}
+
+const dispatchLs = (key: string): void => {
+  // create, initialize, and dispatch event
+  const event = document.createEvent('Event');
+  event.initEvent(`${key}-ls`, true, true);
+  document.dispatchEvent(event);
+};
+
+export function localStorageSetKey(key: string, value: string): void {
+  localStorage.setItem(key, value);
+  dispatchLs(key);
+}
+
+// toggling a specific value in an array
+// useDispatch: only dispatch an event if true.
+// onlyDelete: don't add, only delete from the array
+export function localStorageToggleValue(key: string, value: any, useDispatch: boolean = true, onlyDelete: boolean = false): void {
+  const existingArray = JSON.parse(localStorage.getItem(key) ?? '') || [];
+  // check if the value matches, either as a string or as a number
+  let indexOfId = existingArray.indexOf(value);
+  if (indexOfId <= -1) {
+    indexOfId = existingArray.indexOf(Number(value));
+  }
+  if (indexOfId <= -1) {
+    indexOfId = existingArray.indexOf(toString(value));
+  }
+  if (indexOfId !== -1) {
+    existingArray.splice(indexOfId, 1);
+    localStorage.setItem(key,
+      JSON.stringify(existingArray));
+    if (useDispatch) {
+      dispatchLs(key);
+    }
+  } else if (!onlyDelete) {
+    existingArray.push(value);
+    localStorage.setItem(key,
+      JSON.stringify(existingArray));
+    if (useDispatch) {
+      dispatchLs(key);
+    }
+  }
+}
+
+export function validStateEmail(email: string): boolean {
+  return /.+@state.gov$/.test(email.trim());
+}
+
+export function hasValidToken(): boolean {
+  try {
+    /* eslint-disable no-unused-vars */
+    const token = JSON.parse(localStorage.getItem('token') ?? '');
+    /* eslint-enable no-unused-vars */
+    return true;
+  } catch (error) {
+    // If token exists and is bad (maybe user injected)
+    // Drop the token anyways just so we can have the container
+    // render login directly
+    localStorage.removeItem('token');
+    return false;
+  }
+}
+
+export function fetchUserToken(): (string | null) {
+  const key = JSON.parse(localStorage.getItem('token') ?? '');
+  if (key) {
+    return `Token ${key}`;
+  }
+  return null;
+}
+
+export function fetchJWT(): (string | null) {
+  const key = sessionStorage.getItem('jwt');
+  if (key) {
+    return key;
+  }
+  return null;
+}
+
+export const sortTods = (data: any): any => {
+  const sortingArray = ['T', 'C', 'H', 'O', 'V', '1', '2', 'U', 'A', 'B', 'E', 'N', 'S', 'G', 'D', 'F', 'R', 'Q', 'J', 'I', 'P', 'W', 'L', 'K', 'M', 'Y', 'Z', 'X'];
+  // eslint-disable-next-line no-confusing-arrow
+  return orderBy(data, o => o ? sortingArray.indexOf(o.code) : sortingArray.length);
+};
+
+export const propSort = (propName: string, nestedPropName?: string) => (a: any, b: any): number => {
+  let A = get(a, `${propName}.${nestedPropName}`) || get(a, propName);
+  A = lowerCase(toString(A));
+  let B = get(b, `${propName}.${nestedPropName}`) || get(b, propName);
+  B = lowerCase(toString(B));
+  if (A < B) { // sort string ascending
+    return -1;
+  }
+  if (A > B) { return 1; }
+  return 0; // default return value (no sorting)
+};
+
+// Custom grade sorting
+export const sortGrades = (a: Grade, b: Grade): number => {
+  const sortingArray = ['01', '02', '03', '04', '05', '06', '07', '08', '09', '00', 'CM', 'MC', 'OC', 'OM'];
+  const A = a.code;
+  const B = b.code;
+
+  // if grade is not in sortingArray, push to bottom of list.
+  const indexOfA = sortingArray.indexOf(A) >= 0 ? sortingArray.indexOf(A) : sortingArray.length;
+  const indexOfB = sortingArray.indexOf(B) >= 0 ? sortingArray.indexOf(B) : sortingArray.length;
+
+  if (indexOfA < indexOfB) {
+    return -1;
+  }
+  if (indexOfA > indexOfB) { return 1; }
+  return 0;
+};
+
+// function to find the Region filters
+export const formExploreRegionDropdown = (filters: any[]): Region[] => {
+  function filterRegion(filterItem: { item: { title: string; }; }) {
+    return (filterItem.item && filterItem.item.title === 'Bureau');
+  }
+  // set an array so we can render in case we don't find Region
+  let regions: Region[] = [];
+  // find the Region filters
+  const foundRegion = filters.find(filterRegion);
+  // if found, set foundRegion to a copy of the data
+  if (foundRegion && foundRegion.data) { regions = foundRegion.data.slice(); }
+  if (regions.length) {
+    regions.forEach((region, i) => {
+      // set up our prop names so that SelectForm can read them
+      regions[i].text = region.long_description ?? '';
+      regions[i].value = region.code;
+    });
+    // also add a placeholder to the top
+    regions.unshift(
+      {
+        text: 'Select a Bureau',
+        value: '',
+        disabled: true,
+      },
+    );
+  }
+  return regions;
+};
+
+// see all props at https://github.com/fisshy/react-scroll#propsoptions
+const defaultScrollConfig = {
+  duration: 900,
+  delay: 270,
+  smooth: 'easeOutQuad',
+};
+
+export const scrollTo = (num: number, config = {}): void => {
+  scroll.scrollTo(num, { ...defaultScrollConfig, ...config });
+};
+
+export const scrollToTop = (config = {}): void => {
+  scroll.scrollToTop({ ...defaultScrollConfig, ...config });
+};
+
+
+export const scrollToId = ({ el, config = {} }: any): void => {
+  // Get an element's distance from the top of the page
+  const getElemDistance = (elem: HTMLElement) => {
+    let location = 0;
+    if (elem.offsetParent) {
+      // eslint-disable-next-line no-loops/no-loops
+      do {
+        location += elem.offsetTop;
+        elem = elem.offsetParent as HTMLElement; // eslint-disable-line
+      } while (elem);
+    }
+    return location >= 0 ? location : 0;
+  };
+  const elem = document.querySelector(el);
+  const location = getElemDistance(elem);
+
+  scrollTo(location, config);
+};
+
+// When we want to grab a label, but aren't sure which one exists.
+// We set custom ones first in the list.
+export const getItemLabel = (itemData: any): string =>
+  itemData.custom_description || itemData.long_description ||
+  itemData.description || itemData.code || itemData.name;
+
+// abcde 4 // a...
+// Shortens strings to varying lengths
+export const shortenString = (string: string, shortenTo: number = 250, suffix: (string | null) = '...'): string => {
+  let newString = string;
+  let newSuffix = suffix;
+  if (!newSuffix) {
+    newSuffix = '';
+  }
+  // return the suffix even if the shortenTo is less than its length, empty string if null
+  if (shortenTo < newSuffix.length) {
+    return suffix ?? '';
+  }
+  if (string && string.length > shortenTo) {
+    // shorten to the shortenTo param, less the length of our suffix
+    newString = string.slice(0, shortenTo - newSuffix.length);
+    // in case the last character(s) was whitespace
+    newString = newString.trim();
+    // append suffix
+    newString += newSuffix;
+  }
+  // return the string
+  return newString;
+};
+
+// TODO: Clarify type of array, is a variety of objects that have the id attribute or only one
+// for checking if a favorite_position exists in the user's profile
+export const existsInArray = (ref: any, array: any[]): boolean => {
+  let found = false;
+  array.forEach((i) => {
+    if (get(i, 'id') && ref && `${i.id}` === `${ref}`) {
+      found = true;
+    }
+  });
+  return found;
+};
+
+// Check if there is an object in the array with a value in the nested prop 
+// strictly equal to the given ref value
+// Used for checking if a position is in the user's bid list
+export const existsInNestedObject = (ref: any, array: any[], prop: string = 'position_info', nestedProp: string = 'id'): boolean => {
+  const array$ = isArray(array) ? array : [];
+  let found = false;
+  array$.some((i) => {
+    if (i[prop] && i[prop][nestedProp] === ref) {
+      found = i;
+      return true;
+    }
+    return false;
+  });
+  return found;
+};
+
+// clean our query object for use with the saved search endpoint
+// make sure query object only uses real parameters (no extras that may have been added to the URL)
+// we also want to get rid of page and limit,
+// since those aren't valid params in the saved search endpoint
+export const cleanQueryParams = (q: any): any => {
+  let object = Object.assign({}, q);
+  object = omit(object, ['count']);
+  Object.keys(object).forEach((key) => {
+    if (VALID_PARAMS.indexOf(key) <= -1) {
+      delete object[key];
+    }
+  });
+  return object;
+};
+
+export const cleanTandemQueryParams = (q: any): any => {
+  const object = Object.assign({}, q);
+  Object.keys(object).forEach((key) => {
+    if (VALID_TANDEM_PARAMS.indexOf(key) <= -1 && VALID_PARAMS.indexOf(key) <= -1) {
+      delete object[key];
+    }
+  });
+  return object;
+};
+
+export const ifEnter = (event: KeyboardEvent): boolean => {
+  if (event.keyCode === 13) {
+    return true;
+  }
+  return false;
+};
+
+// convert a query object to a query string
+export const formQueryString = (queryObject: any): string => queryString.stringify(queryObject);
+
+// remove duplicates from an array by object property
+export const removeDuplicates = (myArr: any[], props: string[] = ['']): any => (
+  uniqBy(myArr, elem => props.map(m => elem[m]).join())
+);
+
+// Format date for notifications.
+// We want to use minutes for recent notifications, but days for older ones.
+export const getTimeDistanceInWords = (dateToCompare: Date, date: Date = new Date(), options = {}): string =>
+  `${distanceInWords(dateToCompare, date, options)} ago`;
+
+// Format the date into our preferred format.
+// We can take any valid date and convert it into M.D.YYYY format, or any
+// format provided with the dateFormat param.
+export const formatDate = (date: string | null, dateFormat: string = 'MM/DD/YYYY'): (string | null) => {
+  if (date) {
+    // then format the date with dateFormat
+    const formattedDate = format(date, dateFormat);
+    // and finally return the formatted date
+    return formattedDate;
+  }
+  return null;
+};
+
+// Prefix asset paths with the PUBLIC_URL
+export const getAssetPath = (strAssetPath: string): string =>
+  `${process.env.PUBLIC_URL}${strAssetPath}`.replace('//', '/');
+
+// Filter by objects that contain a specified prop(s) that match a string.
+// Check if any of "array"'s objects' "props" contain "keyword"
+export const filterByProps = (keyword: string, props: string[] = [], array: any[] = []): any[] => {
+  // keyword should have length
+  if (keyword.length) {
+    // filter the array and return its value
+    return array.filter((data) => {
+      let doesMatch = true;
+      // iterate through props and see if keyword is found in their values
+      keyword.split(' ').filter(f => f.length).forEach((k) => {
+        let doesMatch$ = false;
+        props.forEach((prop) => {
+          if (doesMatch) {
+            // if so, doesMatch = true
+            if (lowerCase(toString(data[prop])).indexOf(lowerCase(toString(k))) !== -1) {
+              doesMatch$ = true;
+            }
+          }
+        });
+        doesMatch = doesMatch$;
+      });
+      // if keyword was found in at least one of the props, doesMatch should be true
+      return doesMatch;
+    });
+  }
+  // if keyword length === 0, return the unfiltered array
+  return array;
+};
+
 // Focus an element on the page based on its ID. Pass an optional, positive timeout number to
 // execute the focus within a timeout.
-export const focusById = (id: string, timeout: number, config: { preventScroll?: boolean } = {}): void => {
+export const focusById = (id: string, timeout?: number, config: { preventScroll?: boolean } = {}): void => {
   const config$ = {
     preventScroll: true,
     ...config,
@@ -34,13 +385,68 @@ export const focusById = (id: string, timeout: number, config: { preventScroll?:
   }
 };
 
+// Determine which header type to focus. We always have a page title h1, so we
+// search for 1. The second h1, 2. the first h2, 3. the first h3, and focus which ever
+// is found first.
+export const focusByFirstOfHeader = (timeout: number = 1): void => {
+  setTimeout(() => {
+    let element: HTMLCollectionOf<HTMLHeadingElement> | HTMLHeadingElement = document.getElementsByTagName('h1');
+    element = (element && element[1]) || document.getElementsByTagName('h2')[0] || document.getElementsByTagName('h3')[0];
+    if (element) {
+      element.setAttribute('tabindex', '-1');
+      element.focus();
+    }
+  }, timeout);
+};
 
+// Give objects in an array the necessary value and label props needed when
+// they're used in a multi-select list.
+export const wrapForMultiSelect = (options: any[], valueProp: string, labelProp: string): any[] => options.slice().map((f) => {
+  const newObj = { ...f };
+  newObj.value = f[valueProp];
+  newObj.label = f[labelProp];
+  return newObj;
+});
+
+// Provide two arrays, a sourceArray and a compareArray, and a property to check (propToCheck),
+// and this function will return objects from the sourceArray where a given propToCheck value exists
+// in at least one object in both arrays.
+export const returnObjectsWherePropMatches = (sourceArray: any[] = [], compareArray: any[] = [], propToCheck: string): any[] =>
+  sourceArray.filter(o1 => compareArray.some(o2 => o1[propToCheck] === o2[propToCheck]));
+
+// Convert a numerator and a denominator to a percentage.
+export const numbersToPercentString = (numerator: number, denominator: number, percentFormat: string = '0.0%'): string => {
+  const fraction = numerator / denominator;
+  const percentage = numeral(fraction).format(percentFormat);
+  return percentage;
+};
+
+export const formatBidTitle = (bid: Bid): string => `${bid.position.title} (${bid.position.position_number})`;
+
+export const formatWaiverTitle = (waiver: Waiver): string => `${waiver.position} - ${waiver.category.toUpperCase()}`;
+
+// for traversing nested objects.
+// obj should be an object, such as { a: { b: 1, c: { d: 2 } } }
+// path should be a string to the desired path - "a.b.c.d"
+// defaultToReturn should be the default value you want to return if the traversal fails
 export const propOrDefault = (obj: any, path: string, defaultToReturn: any = null): any =>
   get(obj, path, defaultToReturn);
 
-export const formatIdSpacing = (id: any): string => {
+// Return the correct object from the bidStatistics array/object.
+// If it doesn't exist, return an empty object.
+export const getBidStatisticsObject = (bidStatistics: any | any[]): any => {
+  if (Array.isArray(bidStatistics) && bidStatistics.length) {
+    return bidStatistics[0];
+  } else if (isObject(bidStatistics)) {
+    return bidStatistics;
+  }
+  return {};
+};
+
+// replace spaces with hyphens so that id attributes are valid
+export const formatIdSpacing = (id?: string | number | null): string => {
   if (id && toString(id)) {
-    let idString: string = toString(id);
+    let idString = toString(id);
     idString = split(idString, ' ').join('-');
     // remove any non-alphanumeric character, excluding hyphen
     idString = idString.replace(/[^a-zA-Z0-9 -]/g, '');
@@ -50,6 +456,13 @@ export const formatIdSpacing = (id: any): string => {
   return shortid.generate();
 };
 
+// provide an array of permissions to check if they all exist in an array of user permissions
+export const userHasPermissions = (permissionsToCheck: string[] = [], userPermissions: string[] = []): boolean =>
+  permissionsToCheck.every(val => userPermissions.indexOf(val) >= 0);
+
+// provide an array of permissions to check if at least one exists in an array of user permissions
+export const userHasSomePermissions = (permissionsToCheck: string[] = [], userPermissions: string[] = []): boolean =>
+  !!intersection(permissionsToCheck, userPermissions).length;
 
 // Takes multiple saved search objects and combines them into one object,
 // where the value for each property is an array of all individual values
@@ -145,7 +558,7 @@ export const getApplicationPath = () => `${window.location.origin}${process.env.
 // the screen reader reads the number as a full-length numeral
 // (i.e., "S. 7 million two hundred thousand ….). This can confuse or disorient the user as
 // they navigate and search for positions.
-export const getAccessiblePositionNumber = (positionNumber: string | null) => {
+export const getAccessiblePositionNumber = (positionNumber?: string | null) => {
   if (positionNumber) {
     return positionNumber.split('').join(' ');
   }
@@ -287,7 +700,7 @@ export const getBrowser = () => Bowser.getParser(window.navigator.userAgent).get
 // Convert values used in aria-* attributes to 'true'/'false' string.
 // Perform a string check, if for some reason the value was already a string.
 // https://github.com/cerner/terra-core/wiki/React-16-Migration-Guide#noted-changes
-export const getAriaValue = (e: string) => {
+export const getAriaValue = (e: string | number | boolean | null) => {
   if (e === 'true') {
     return e;
   } else if (e === 'false') {
@@ -367,10 +780,9 @@ export const downloadPdfStream = (response: any, filename: string = 'employee-pr
 
 
 //Create a tsx file for the constants
-export const getBidCycleName = (bidcycle: {
-  name: any,
-}): string => {
-  let text: string = isObject(bidcycle) && has(bidcycle, 'name') ? bidcycle.name : bidcycle;
+export const getBidCycleName = (bidcycle: string | object): string => {
+  // TODO: Reference bidcycle type once determined instead of any
+  let text: string = isObject(bidcycle) && has(bidcycle, 'name') ? (bidcycle as any).name : bidcycle;
   if (!isString(text) || !text) { text = NO_BID_CYCLE; }
   return text;
 };
@@ -480,15 +892,15 @@ export const getAvatarColor = (str: string, hashAdjuster: number = 0): { backgro
   return null;
 };
 
-export function getBidListStats(bidList: any[], statuses: string, padWithZero: boolean): number | string {
-  let numBids: any = 0;
+export function getBidListStats(bidList: any[], statuses: string[], padWithZero?: boolean): number | string {
+  let numBids: number = 0;
   bidList.forEach((b: any) => {
     if (includes(statuses, b.status)) numBids += 1;
   });
   if (padWithZero) {
-    numBids = padStart(toString(numBids), 2, '0');
+    return padStart(toString(numBids), 2, '0').toString();
   }
-  return padWithZero ? numBids : numBids.toString();
+  return numBids;
 }
 
 export const isOnProxy = (): boolean => !!includes(get(window, 'location.host'), 'msappproxy');
@@ -528,7 +940,7 @@ export function getCustomLocation(loc: any, org: string): string {
 //     closeSwal();
 //   }, []);
 
-export const splitByLineBreak = (text: string) => (text || '').split('\n\n\n');
+export const splitByLineBreak = (text: string | null) => (text || '').split('\n\n\n');
 
 export const convertQueryToString = (query: Record<string, any>): string | Record<string, any> => {
   let q: any = pickBy(query, identity);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2052,6 +2052,11 @@
   version "8.9.5"
   resolved "https://registry.npmjs.org/@types/node/-/node-8.9.5.tgz#162b864bc70be077e6db212b322754917929e976"
 
+"@types/numeral@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/numeral/-/numeral-2.0.2.tgz#8ea2c4f4e64c0cc948ad7da375f6f827778a7912"
+  integrity sha512-A8F30k2gYJ/6e07spSCPpkuZu79LCnkPTvqmIWQzNGcrzwFKpVOydG41lNt5wZXjSI149qjyzC2L1+F2PD/NUA==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -2116,6 +2121,13 @@
     "@types/history" "*"
     "@types/react" "*"
 
+"@types/react-scroll@^1.8.7":
+  version "1.8.7"
+  resolved "https://registry.yarnpkg.com/@types/react-scroll/-/react-scroll-1.8.7.tgz#7241c6ccd47839d79227a23a5184d727245c7324"
+  integrity sha512-BB8g+hQL7OtBPWg/NcES6p5u6vduZonGl1BxrsGUwcefE53pfI0pFDd1lRFndgEUE6whYdFfhD+j0sZZT/6brQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^17.0.16":
   version "17.0.16"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.16.tgz#056f40c45645761527baeb7d89d842a6abdf285a"
@@ -2140,6 +2152,11 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/shortid/-/shortid-0.0.29.tgz#8093ee0416a6e2bf2aa6338109114b3fbffa0e9b"
   integrity sha1-gJPuBBam4r8qpjOBCRFLP7/6Dps=
+
+"@types/sinon@^4.0.0":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-4.3.3.tgz#97cbbfddc3282b5fd40c7abf80b99db426fd4237"
+  integrity sha512-Tt7w/ylBS/OEAlSCwzB0Db1KbxnkycP/1UkQpbvKFYoUuRn4uYsC3xh5TRPrOjTy0i8TIkSz1JdNL4GPVdf3KQ==
 
 "@types/source-list-map@*":
   version "0.1.2"
@@ -6428,6 +6445,11 @@ filter-invalid-dom-props@1.0.0:
   resolved "https://registry.yarnpkg.com/filter-invalid-dom-props/-/filter-invalid-dom-props-1.0.0.tgz#44d0d0306657b2584e04f71d428229ebb9867ca1"
   dependencies:
     html-attributes "1.1.0"
+
+filter-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
+  integrity sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==
 
 finalhandler@~1.1.2:
   version "1.1.2"
@@ -11544,13 +11566,15 @@ qss@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/qss/-/qss-2.0.3.tgz#630b38b120931b52d04704f3abfb0f861604a9ec"
 
-query-string@5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.1.1.tgz#a78c012b71c17e05f2e3fa2319dd330682efb3cb"
+query-string@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.0.0.tgz#aaad2c8d5c6a6d0c6afada877fecbd56af79e609"
+  integrity sha512-Iy7moLybliR5ZgrK/1R3vjrXq03S13Vz4Rbm5Jg3EFq1LUmQppto0qtXz4vqZ386MSRjZgnTSZ9QC+NZOSd/XA==
   dependencies:
     decode-uri-component "^0.2.0"
-    object-assign "^4.1.0"
-    strict-uri-encode "^1.0.0"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
 
 querystring-es3@^0.2.0, querystring-es3@~0.2.0:
   version "0.2.1"
@@ -13734,6 +13758,11 @@ spdy@^4.0.2:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -13846,9 +13875,10 @@ stream-splicer@^2.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.2"
 
-strict-uri-encode@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Changes:
- Added *very* rough draft of project type declarations in `src/types.d.ts` for when components are converted to `.ts(x)` 
- Added 1st half of utilities to new typescript utilities overhaul file `src/utilities.tsx`
- Added typescript converted unit test file `src/utilities.test.ts` that uses new type-safe functions
- Added type dependencies needed for project
- Allow Jest to search for `.ts(x)` files
- Minor fixes to utility functions from testing (e.g., fixed types, handling return)

Dual Merge: 
- [API PR](linkToAPIPR)
- [Mock PR](linkToMockPR)

[Ticket](linkToTicket)
