### PR TITLE
Additional download set up for redacted

### DIFF
--- a/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/EmployeeProfileLink.jsx
+++ b/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/EmployeeProfileLink.jsx
@@ -1,5 +1,4 @@
 import { Component } from 'react';
-import { get } from 'lodash';
 import swal from '@sweetalert/with-react';
 import { USER_PROFILE } from 'Constants/PropTypes';
 import InteractiveElement from 'Components/InteractiveElement';
@@ -15,10 +14,11 @@ class EmployeeProfileLink extends Component {
   }
   render() {
     const { userProfile } = this.props;
+    const emp_profile_urls = userProfile?.employee_profile_url;
 
-    let url$ = get(userProfile, 'employee_profile_url.internal');
+    let url$ = emp_profile_urls?.internal || emp_profile_urls?.internalRedacted;
     if (isOnProxy()) {
-      url$ = get(userProfile, 'employee_profile_url.external');
+      url$ = emp_profile_urls?.external || emp_profile_urls?.externalRedacted;
     }
 
     const openPdf = () => swal({

--- a/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/UserProfileGeneralInformation.jsx
+++ b/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/UserProfileGeneralInformation.jsx
@@ -31,7 +31,6 @@ class UserProfileGeneralInformation extends Component {
   getEmployeeProfile = (redactedVersion) => {
     const id = shortid.generate();
     const { onToastError, onToastInfo, onToastSuccess, userProfile } = this.props;
-    // eslint-disable-next-line no-unused-vars
     const emp_profile_urls = userProfile?.employee_profile_url;
 
     let url$ = (redactedVersion ? emp_profile_urls?.internalRedacted

--- a/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/UserProfileGeneralInformation.jsx
+++ b/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/UserProfileGeneralInformation.jsx
@@ -71,6 +71,7 @@ class UserProfileGeneralInformation extends Component {
     const userID = get(userProfile, 'employee_id');
 
     const browser = getBrowser();
+    const isIE11 = browser?.name === 'Internet Explorer' && browser?.version.startsWith('11');
 
     const openPdf = (redactedVersion = false) => {
       this.getEmployeeProfile(redactedVersion);
@@ -89,7 +90,7 @@ class UserProfileGeneralInformation extends Component {
             <SectionTitle small title={`${userProfile.user.last_name ? `${userProfile.user.last_name}, ` : ''}${userProfile.user.first_name}`} className="current-user-name" />
             <ErrorBoundary fallback="Employee Profile is currently unavailable">
               {
-                get(userProfile, 'employee_profile_url') && browser.name === 'Internet Explorer' && browser.version.startsWith('11') &&
+                get(userProfile, 'employee_profile_url') && isIE11 &&
                   <InformationDataPoint
                     content={
                       <InteractiveElement
@@ -103,8 +104,8 @@ class UserProfileGeneralInformation extends Component {
                   />
               }
               {
-                get(userProfile, 'employee_profile_url') && !(browser.name === 'Internet Explorer' && browser.version.startsWith('11')) &&
-              <EmployeeProfileLink userProfile={userProfile} />
+                get(userProfile, 'employee_profile_url') && !isIE11 &&
+                  <EmployeeProfileLink userProfile={userProfile} />
               }
               {
                 <InteractiveElement

--- a/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/UserProfileGeneralInformation.jsx
+++ b/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/UserProfileGeneralInformation.jsx
@@ -1,6 +1,7 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
+import FA from 'react-fontawesome';
 import axios from 'axios';
 import { connect } from 'react-redux';
 import shortid from 'shortid';
@@ -27,13 +28,19 @@ class UserProfileGeneralInformation extends Component {
       data: null,
     };
   }
-  getEmployeeProfile = () => {
+  getEmployeeProfile = (redactedVersion) => {
     const id = shortid.generate();
     const { onToastError, onToastInfo, onToastSuccess, userProfile } = this.props;
-    let url$ = get(userProfile, 'employee_profile_url.internal');
+    // eslint-disable-next-line no-unused-vars
+    const emp_profile_urls = userProfile?.employee_profile_url;
+
+    let url$ = (redactedVersion ? emp_profile_urls?.internalRedacted
+      : emp_profile_urls?.internal) || emp_profile_urls?.internalRedacted;
     if (isOnProxy()) {
-      url$ = get(userProfile, 'employee_profile_url.external');
+      url$ = (redactedVersion ? emp_profile_urls?.externalRedacted
+        : emp_profile_urls?.external) || emp_profile_urls?.externalRedacted;
     }
+
     onToastInfo(id);
     axios.get(url$, {
       withCredentials: true,
@@ -66,8 +73,8 @@ class UserProfileGeneralInformation extends Component {
 
     const browser = getBrowser();
 
-    const openPdf = () => {
-      this.getEmployeeProfile();
+    const openPdf = (redactedVersion = false) => {
+      this.getEmployeeProfile(redactedVersion);
     };
 
     return (
@@ -99,6 +106,15 @@ class UserProfileGeneralInformation extends Component {
               {
                 get(userProfile, 'employee_profile_url') && !(browser.name === 'Internet Explorer' && browser.version.startsWith('11')) &&
               <EmployeeProfileLink userProfile={userProfile} />
+              }
+              {
+                <InteractiveElement
+                  onClick={() => openPdf(true)}
+                  type="a"
+                  title="Download Employee Profile PDF"
+                >
+                  <FA name="download" />
+                </InteractiveElement>
               }
             </ErrorBoundary>
             { isPublic &&

--- a/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/__snapshots__/UserProfileGeneralInformation.test.jsx.snap
+++ b/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/__snapshots__/UserProfileGeneralInformation.test.jsx.snap
@@ -135,6 +135,16 @@ exports[`UserProfileGeneralInformationComponent matches snapshot 1`] = `
             }
           }
         />
+        <InteractiveElement
+          className=""
+          onClick={[Function]}
+          title="Download Employee Profile PDF"
+          type="a"
+        >
+          <FontAwesome
+            name="download"
+          />
+        </InteractiveElement>
       </ErrorBoundary>
       <InformationDataPoint
         className="skill-code-data-point-container skill-code-data-point-container-gen-spec"
@@ -305,6 +315,16 @@ exports[`UserProfileGeneralInformationComponent matches snapshot when showEditLi
             }
           }
         />
+        <InteractiveElement
+          className=""
+          onClick={[Function]}
+          title="Download Employee Profile PDF"
+          type="a"
+        >
+          <FontAwesome
+            name="download"
+          />
+        </InteractiveElement>
       </ErrorBoundary>
       <InformationDataPoint
         className="skill-code-data-point-container skill-code-data-point-container-gen-spec"
@@ -475,6 +495,16 @@ exports[`UserProfileGeneralInformationComponent matches snapshot when useGroup i
             }
           }
         />
+        <InteractiveElement
+          className=""
+          onClick={[Function]}
+          title="Download Employee Profile PDF"
+          type="a"
+        >
+          <FontAwesome
+            name="download"
+          />
+        </InteractiveElement>
       </ErrorBoundary>
       <InformationDataPoint
         className="skill-code-data-point-container skill-code-data-point-container-gen-spec"

--- a/src/Constants/PropTypes.js
+++ b/src/Constants/PropTypes.js
@@ -213,6 +213,12 @@ export const USER_PROFILE = PropTypes.shape({
     office_address: PropTypes.string,
     office_phone: PropTypes.string,
   }),
+  employee_profile_url: PropTypes.shape({
+    internalRedacted: PropTypes.string,
+    externalRedacted: PropTypes.string,
+    internal: PropTypes.string,
+    external: PropTypes.string,
+  }),
   id: PropTypes.number,
   skill_code: USER_SKILL_CODE_ARRAY,
   initials: PropTypes.string,

--- a/src/Containers/ProfilePublic/ProfilePublic.jsx
+++ b/src/Containers/ProfilePublic/ProfilePublic.jsx
@@ -26,7 +26,7 @@ class ProfilePublic extends Component {
   }
 
   isView = (view) => {
-    const viewType = this.props?.match?.params?.viewType;
+    const viewType = get(this.props, 'match.params.viewType');
     return viewType === view;
   }
 

--- a/src/Containers/ProfilePublic/ProfilePublic.jsx
+++ b/src/Containers/ProfilePublic/ProfilePublic.jsx
@@ -147,16 +147,14 @@ const mapStateToProps = (state, ownProps) => ({
 
 export const mapDispatchToProps = (dispatch, ownProps) => {
   const id$ = get(ownProps, 'match.params.id');
-  const isBureau = get(ownProps, 'match.params.viewType') === 'bureau';
-  const config = {
-    fetchData: (id, includeBids) => dispatch(userProfilePublicFetchData(id, false, includeBids, 'status', isBureau)),
+  return {
+    fetchData: (id, includeBids) => dispatch(userProfilePublicFetchData(id, false, includeBids)),
     onNavigateTo: dest => dispatch(push(dest)),
     fetchClassifications: () => dispatch(fetchClassifications()),
     registerHandshakePosition: id => dispatch(registerHandshake(id, id$)),
     unregisterHandshakePosition: id => dispatch(unregisterHandshake(id, id$)),
     deleteBid: id => dispatch(toggleBidPosition(id, true, false, id$, true)),
   };
-  return config;
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(withRouter(ProfilePublic));

--- a/src/Containers/ProfilePublic/ProfilePublic.jsx
+++ b/src/Containers/ProfilePublic/ProfilePublic.jsx
@@ -16,8 +16,8 @@ import { toggleBidPosition } from 'actions/bidList';
 class ProfilePublic extends Component {
   UNSAFE_componentWillMount() {
     const id = get(this.props, 'match.params.id');
-    const isBureauView = this.isBureauView();
-    const isPostView = this.isPostView();
+    const isBureauView = this.isView('bureau');
+    const isPostView = this.isView('post');
     const bureauOrPost = isBureauView || isPostView;
     this.props.fetchData(id, !bureauOrPost);
     if (!bureauOrPost) {
@@ -25,20 +25,9 @@ class ProfilePublic extends Component {
     }
   }
 
-  isBureauView = () => {
-    const viewType = get(this.props, 'match.params.viewType');
-    const isBureauView = viewType === 'bureau';
-    return isBureauView;
-  }
-
-  isPostView = () => {
-    const viewType = get(this.props, 'match.params.viewType');
-    return viewType === 'post';
-  }
-
-  isAOView = () => {
-    const viewType = get(this.props, 'match.params.viewType');
-    return viewType === 'ao';
+  isView = (view) => {
+    const viewType = this.props?.match?.params?.viewType;
+    return viewType === view;
   }
 
   render() {
@@ -57,9 +46,9 @@ class ProfilePublic extends Component {
     const clientClassifications = userProfile.classifications;
     const combinedLoading = isLoading || classificationsIsLoading;
     const combinedErrored = hasErrored || classificationsHasErrored;
-    const isBureauView = this.isBureauView();
-    const isPostView = this.isPostView();
-    const isAOView = this.isAOView();
+    const isBureauView = this.isView('bureau');
+    const isPostView = this.isView('post');
+    const isAOView = this.isView('ao');
     let props = {};
     if (isBureauView) {
       props = {
@@ -158,8 +147,9 @@ const mapStateToProps = (state, ownProps) => ({
 
 export const mapDispatchToProps = (dispatch, ownProps) => {
   const id$ = get(ownProps, 'match.params.id');
+  const isBureau = get(ownProps, 'match.params.viewType') === 'bureau';
   const config = {
-    fetchData: (id, includeBids) => dispatch(userProfilePublicFetchData(id, false, includeBids)),
+    fetchData: (id, includeBids) => dispatch(userProfilePublicFetchData(id, false, includeBids, 'status', isBureau)),
     onNavigateTo: dest => dispatch(push(dest)),
     fetchClassifications: () => dispatch(fetchClassifications()),
     registerHandshakePosition: id => dispatch(registerHandshake(id, id$)),

--- a/src/actions/userProfilePublic.js
+++ b/src/actions/userProfilePublic.js
@@ -19,10 +19,6 @@ export function userProfilePublicIsLoading(bool) {
 }
 
 export function userProfilePublicFetchDataSuccess(userProfile) {
-  /* eslint-disable no-console */
-  console.log('🥳🥳🥳🥳🥳🥳🥳🥳🥳🥳');
-  console.log('🥳 current: userProfilePublic:', userProfile);
-  console.log('🥳🥳🥳🥳🥳🥳🥳🥳🥳🥳');
   return {
     type: 'USER_PROFILE_PUBLIC_FETCH_DATA_SUCCESS',
     userProfile,

--- a/src/actions/userProfilePublic.js
+++ b/src/actions/userProfilePublic.js
@@ -32,7 +32,7 @@ export function unsetUserProfilePublic() {
 }
 
 // include an optional bypass for when we want to silently update the profile
-export function userProfilePublicFetchData(id, bypass, includeBids = true, bidSort = 'status', isBureau) {
+export function userProfilePublicFetchData(id, bypass, includeBids = true, bidSort = 'status') {
   return (dispatch, getState) => {
     if (!bypass) {
       dispatch(userProfilePublicIsLoading(true));
@@ -57,12 +57,6 @@ export function userProfilePublicFetchData(id, bypass, includeBids = true, bidSo
       .then(axios.spread((acct, bids) => {
         // form the userProfile object
         const acct$ = get(acct, 'data', {});
-
-        // Option 1: api remains consistent for all users and we remove here on FE
-        if (isBureau) {
-          delete acct$?.employee_profile_url?.internal;
-          delete acct$?.employee_profile_url?.external;
-        }
 
         if (!get(acct$, 'perdet_seq_number')) {
           dispatch(userProfilePublicHasErrored(true));

--- a/src/actions/userProfilePublic.js
+++ b/src/actions/userProfilePublic.js
@@ -19,6 +19,10 @@ export function userProfilePublicIsLoading(bool) {
 }
 
 export function userProfilePublicFetchDataSuccess(userProfile) {
+  /* eslint-disable no-console */
+  console.log('🥳🥳🥳🥳🥳🥳🥳🥳🥳🥳');
+  console.log('🥳 current: userProfilePublic:', userProfile);
+  console.log('🥳🥳🥳🥳🥳🥳🥳🥳🥳🥳');
   return {
     type: 'USER_PROFILE_PUBLIC_FETCH_DATA_SUCCESS',
     userProfile,
@@ -32,7 +36,7 @@ export function unsetUserProfilePublic() {
 }
 
 // include an optional bypass for when we want to silently update the profile
-export function userProfilePublicFetchData(id, bypass, includeBids = true, bidSort = 'status') {
+export function userProfilePublicFetchData(id, bypass, includeBids = true, bidSort = 'status', isBureau) {
   return (dispatch, getState) => {
     if (!bypass) {
       dispatch(userProfilePublicIsLoading(true));
@@ -57,6 +61,13 @@ export function userProfilePublicFetchData(id, bypass, includeBids = true, bidSo
       .then(axios.spread((acct, bids) => {
         // form the userProfile object
         const acct$ = get(acct, 'data', {});
+
+        // Option 1: api remains consistent for all users and we remove here on FE
+        if (isBureau) {
+          delete acct$?.employee_profile_url?.internal;
+          delete acct$?.employee_profile_url?.external;
+        }
+
         if (!get(acct$, 'perdet_seq_number')) {
           dispatch(userProfilePublicHasErrored(true));
           dispatch(userProfilePublicIsLoading(false));


### PR DESCRIPTION
Dual Merge: 
- [API PR](https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/818)

[Ticket TM-4423](https://metaphase.atlassian.net/browse/TM-4423)

There are currently 4 branches of logic for viewing options:
- external
- internal
- IE11
- not IE11

PV: Profile View (not Projected Vacancy lol)
URLs were only ever being pulled for PublicPV via `/fsbid/client/${id}/` call. FE logic for displaying the employee profile did not differentiate between PrivatePV and PublicPV, we just would not show the link if they did not have any in the payload(which we were never pulling for PrivatePV)

Additional viewing branching logic:
- redacted
- unredacted