### PR TITLE
[TM-3820] Edit Publishable Position Card

### DIFF
--- a/src/Components/EditPositionDetails/EditPositionDetails.jsx
+++ b/src/Components/EditPositionDetails/EditPositionDetails.jsx
@@ -376,6 +376,7 @@ const EditPositionDetails = () => {
             <div className="usa-grid-full position-list">
               <PublishablePositionCard
                 result={dummyPositionDetails}
+                cycles={cycles}
               />
             </div>
           </div>

--- a/src/Components/PositionExpandableContent/PositionExpandableContent.jsx
+++ b/src/Components/PositionExpandableContent/PositionExpandableContent.jsx
@@ -61,10 +61,7 @@ const PositionExpandableContent = ({ sections, form }) => {
       ),
     });
   };
-  /* eslint-disable no-console */
-  console.log('🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄');
-  console.log('🦄 current: sections.bodyPrimary:', sections.bodyPrimary);
-  console.log('🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄');
+
   return (
     <div className="position-content">
       <Row fluid className="position-content--section position-content--subheader">

--- a/src/Components/PositionExpandableContent/PositionExpandableContent.jsx
+++ b/src/Components/PositionExpandableContent/PositionExpandableContent.jsx
@@ -22,6 +22,11 @@ const PositionExpandableContent = ({ sections, form }) => {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
+  useEffect(() => {
+    if (editMode) setShowMore(true);
+  }, [editMode]);
+
+
   const getBody = () => {
     if (editMode && form) return form.staticBody;
     if (showMore) return { ...sections.bodyPrimary, ...sections.bodySecondary };
@@ -56,7 +61,10 @@ const PositionExpandableContent = ({ sections, form }) => {
       ),
     });
   };
-
+  /* eslint-disable no-console */
+  console.log('🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄');
+  console.log('🦄 current: sections.bodyPrimary:', sections.bodyPrimary);
+  console.log('🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄');
   return (
     <div className="position-content">
       <Row fluid className="position-content--section position-content--subheader">

--- a/src/Components/ProfileMenu/ProfileMenuCollapsed/ProfileMenuCollapsed.jsx
+++ b/src/Components/ProfileMenu/ProfileMenuCollapsed/ProfileMenuCollapsed.jsx
@@ -12,7 +12,7 @@ const sortProfileMenu = sortBy(remove(GET_PROFILE_MENU(),
 const sortedMenu = [...getProfileOption, ...sortProfileMenu];
 
 const ProfileMenuCollapsed = ({ expand, roles, isGlossaryEditor }) => (
-  <div className="usa-grid-full profile-menu profile-menu-collapsed">
+  <div className="profile-menu profile-menu-collapsed width-70">
     <div className="menu-title">
       <button className="unstyled-button" title="Expand menu" onClick={expand}>
         <FontAwesome name="exchange" />

--- a/src/Components/ProfileMenu/ProfileMenuCollapsed/__snapshots__/ProfileMenuCollapsed.test.jsx.snap
+++ b/src/Components/ProfileMenu/ProfileMenuCollapsed/__snapshots__/ProfileMenuCollapsed.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ProfileMenuCollapsedComponent matches snapshot 1`] = `
 <div
-  className="usa-grid-full profile-menu profile-menu-collapsed"
+  className="profile-menu profile-menu-collapsed width-70"
 >
   <div
     className="menu-title"
@@ -60,7 +60,7 @@ exports[`ProfileMenuCollapsedComponent matches snapshot 1`] = `
 
 exports[`ProfileMenuCollapsedComponent matches snapshot when isGlossaryEditor is false 1`] = `
 <div
-  className="usa-grid-full profile-menu profile-menu-collapsed"
+  className="profile-menu profile-menu-collapsed width-70"
 >
   <div
     className="menu-title"

--- a/src/Components/ProfileMenu/ProfileMenuExpanded/ProfileMenuExpanded.jsx
+++ b/src/Components/ProfileMenu/ProfileMenuExpanded/ProfileMenuExpanded.jsx
@@ -60,7 +60,7 @@ const ProfileMenuExpanded = (props) => {
 
   getProfileMenuSort = [...getProfileMenuSort, ...getProfileMenuSort$];
   return (
-    <div className="usa-grid-full profile-menu">
+    <div className="profile-menu width-250">
       <div className="menu-title">
         <div className="menu-title-text">Menu</div>
         <button className="unstyled-button" title="Collapse menu" onClick={props.collapse}>

--- a/src/Components/ProfileMenu/ProfileMenuExpanded/ProfileMenuExpanded.jsx
+++ b/src/Components/ProfileMenu/ProfileMenuExpanded/ProfileMenuExpanded.jsx
@@ -60,7 +60,7 @@ const ProfileMenuExpanded = (props) => {
 
   getProfileMenuSort = [...getProfileMenuSort, ...getProfileMenuSort$];
   return (
-    <div className="profile-menu width-350">
+    <div className="profile-menu width-300">
       <div className="menu-title">
         <div className="menu-title-text">Menu</div>
         <button className="unstyled-button" title="Collapse menu" onClick={props.collapse}>

--- a/src/Components/ProfileMenu/ProfileMenuExpanded/ProfileMenuExpanded.jsx
+++ b/src/Components/ProfileMenu/ProfileMenuExpanded/ProfileMenuExpanded.jsx
@@ -60,7 +60,7 @@ const ProfileMenuExpanded = (props) => {
 
   getProfileMenuSort = [...getProfileMenuSort, ...getProfileMenuSort$];
   return (
-    <div className="profile-menu width-250">
+    <div className="profile-menu width-350">
       <div className="menu-title">
         <div className="menu-title-text">Menu</div>
         <button className="unstyled-button" title="Collapse menu" onClick={props.collapse}>

--- a/src/Components/ProfileMenu/ProfileMenuExpanded/ProfileMenuExpanded.jsx
+++ b/src/Components/ProfileMenu/ProfileMenuExpanded/ProfileMenuExpanded.jsx
@@ -60,7 +60,7 @@ const ProfileMenuExpanded = (props) => {
 
   getProfileMenuSort = [...getProfileMenuSort, ...getProfileMenuSort$];
   return (
-    <div className="profile-menu width-300">
+    <div className="profile-menu width-250">
       <div className="menu-title">
         <div className="menu-title-text">Menu</div>
         <button className="unstyled-button" title="Collapse menu" onClick={props.collapse}>

--- a/src/Components/ProfileMenu/ProfileMenuExpanded/__snapshots__/ProfileMenuExpanded.test.jsx.snap
+++ b/src/Components/ProfileMenu/ProfileMenuExpanded/__snapshots__/ProfileMenuExpanded.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ProfileMenuExpandedComponent matches snapshot when isGlossaryEditor is false 1`] = `
 <div
-  className="usa-grid-full profile-menu"
+  className="profile-menu width-250"
 >
   <div
     className="menu-title"
@@ -351,7 +351,7 @@ exports[`ProfileMenuExpandedComponent matches snapshot when isGlossaryEditor is 
 
 exports[`ProfileMenuExpandedComponent matches snapshot when user is bidcycle_admin 1`] = `
 <div
-  className="usa-grid-full profile-menu"
+  className="profile-menu width-250"
 >
   <div
     className="menu-title"

--- a/src/Components/PublishablePositionCard/PublishablePositionCard.jsx
+++ b/src/Components/PublishablePositionCard/PublishablePositionCard.jsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import Linkify from 'react-linkify';
 import TextareaAutosize from 'react-textarea-autosize';
 import Picky from 'react-picky';
-import { get } from 'lodash';
 import { getDifferentials, getPostName, getResult } from 'utilities';
 import { BID_CYCLES, POSITION_DETAILS } from 'Constants/PropTypes';
 import ListItem from 'Components/BidderPortfolio/BidControls/BidCyclePicker/ListItem';
@@ -18,7 +17,7 @@ import PositionExpandableContent from 'Components/PositionExpandableContent';
 
 
 const PublishablePositionCard = ({ data, cycles }) => {
-  const pos = get(data, 'position') || data;
+  const pos = data?.position || data;
 
   const updateUser = getResult(pos, 'description.last_editing_user');
   const updateDate = getResult(pos, 'description.date_updated');
@@ -34,7 +33,7 @@ const PublishablePositionCard = ({ data, cycles }) => {
     },
     bodyPrimary: {
       'Bureau': getResult(pos, 'bureau_short_desc') || NO_BUREAU,
-      'Location': getPostName(get(pos, 'post')) || NO_POST,
+      'Location': getPostName(pos?.post) || NO_POST,
       'Org/Code': getResult(pos, 'bureau_code') || NO_ORG,
       'Grade': getResult(pos, 'grade') || NO_GRADE,
       'Status': getResult(pos, 'status') || NO_STATUS,
@@ -96,7 +95,7 @@ const PublishablePositionCard = ({ data, cycles }) => {
     /* eslint-disable quote-props */
     staticBody: {
       'Bureau': getResult(pos, 'bureau_short_desc') || NO_BUREAU,
-      'Location': getPostName(get(pos, 'post')) || NO_POST,
+      'Location': getPostName(pos?.post) || NO_POST,
       'Org/Code': getResult(pos, 'bureau_code') || NO_ORG,
       'Grade': getResult(pos, 'grade') || NO_GRADE,
       'Bid Cycle': getResult(pos, 'latest_bidcycle.name', 'None Listed'),

--- a/src/Components/PublishablePositionCard/PublishablePositionCard.jsx
+++ b/src/Components/PublishablePositionCard/PublishablePositionCard.jsx
@@ -72,11 +72,13 @@ const PublishablePositionCard = ({ data, cycles }) => {
   }
 
   const pickyProps = {
-    includeFilter: true,
-    dropdownHeight: 300,
-    numberDisplayed: 4,
+    numberDisplayed: 2,
     multiple: true,
+    includeFilter: true,
+    dropdownHeight: 200,
     includeSelectAll: true,
+    renderList: renderSelectionList,
+    className: 'width-280',
   };
 
   const statusOptions = [
@@ -86,8 +88,9 @@ const PublishablePositionCard = ({ data, cycles }) => {
   ];
   const [status, setStatus] = useState(statusOptions[0]);
   const [exclude, setExclude] = useState(true);
-  const [cycleName, setCycleName] = useState('');
+  const [selectedCycles, setSelectedCycles] = useState([]);
 
+  /* eslint-disable no-console */
 
   const form = {
     /* eslint-disable quote-props */
@@ -152,37 +155,22 @@ const PublishablePositionCard = ({ data, cycles }) => {
         <span className="title">Future Cycle</span>
         <span className="subtitle">Please identify a cycle to add this position to.</span>
       </div>
-      <div className="position-form--input">
-        <label htmlFor="publishable-position-cycle">* Cycle:</label>
-        <input
-          id="publishable-position-cycle"
-          placeholder="Enter Cycle Name"
-          onChange={e => setCycleName(e.target.value)}
-          value={cycleName}
-        />
+      <div className="position-form--picky">
+        <div className="publishable-position-cycles-label">Chosen Bid Cycle(s):</div>
+        <div className="publishable-position-cycles">{selectedCycles.map(a => a.name).join(', ')}</div>
       </div>
-      <div className="position-form--input">
-        <div className="filter-div">
-          <div className="label">Bid Cycle:</div>
-          <Picky
-            {...pickyProps}
-            placeholder="Select Bid Cycle(s)"
-            value={cycleName}
-            options={cycles?.data}
-            onChange={setCycleName}
-            valueKey="id"
-            labelKey="name"
-            renderList={renderSelectionList}
-          />
-        </div>
-      </div>
-      <div className="text-button">
-        Add Another Cycle
-      </div>
+      <Picky
+        {...pickyProps}
+        placeholder="Choose Bid Cycle(s)"
+        value={selectedCycles}
+        options={cycles?.data}
+        onChange={setSelectedCycles}
+        valueKey="id"
+        labelKey="name"
+      />
     </div>,
     /* eslint-enable quote-props */
   };
-
 
   return (
     <TabbedCard

--- a/src/Components/PublishablePositionCard/PublishablePositionCard.jsx
+++ b/src/Components/PublishablePositionCard/PublishablePositionCard.jsx
@@ -49,7 +49,7 @@ const PublishablePositionCard = ({ data, cycles }) => {
       'Assignee': '---',
       'Post Differential | Danger Pay': getDifferentials(pos),
     },
-    textarea: get(pos, 'description.content') || 'No description.',
+    textarea: pos?.description?.content || 'No description.',
     metadata: {
       'Position Posted': getResult(pos, 'description.date_created') || NO_UPDATE_DATE,
       'Last Updated': (updateDate && updateUser) ? `${updateUser} ${updateDate}` : (updateDate || NO_UPDATE_DATE),
@@ -89,8 +89,8 @@ const PublishablePositionCard = ({ data, cycles }) => {
   const [status, setStatus] = useState(statusOptions[0]);
   const [exclude, setExclude] = useState(true);
   const [selectedCycles, setSelectedCycles] = useState([]);
+  const [textArea, setTextArea] = useState(pos?.description?.content || 'No description.');
 
-  /* eslint-disable no-console */
 
   const form = {
     /* eslint-disable quote-props */
@@ -141,12 +141,13 @@ const PublishablePositionCard = ({ data, cycles }) => {
               maxlength="4000"
               name="position-description"
               placeholder="No Description"
-              defaultValue={sections.textarea}
+              defaultValue={textArea}
+              onChange={(e) => setTextArea(e.target.value)}
               draggable={false}
             />
           </Linkify>
           <div className="word-count">
-            {sections.textarea.length} / 4,000
+            {textArea.length} / 4,000
           </div>
         </Row>
       </div>

--- a/src/Components/PublishablePositionCard/PublishablePositionCard.jsx
+++ b/src/Components/PublishablePositionCard/PublishablePositionCard.jsx
@@ -1,3 +1,6 @@
+import { useState } from 'react';
+import Linkify from 'react-linkify';
+import TextareaAutosize from 'react-textarea-autosize';
 import { get } from 'lodash';
 import { getDifferentials, getPostName, getResult } from 'utilities';
 import { POSITION_DETAILS } from 'Constants/PropTypes';
@@ -5,6 +8,7 @@ import {
   NO_BUREAU, NO_GRADE, NO_ORG, NO_POSITION_NUMBER, NO_POSITION_TITLE, NO_POST,
   NO_SKILL, NO_STATUS, NO_TOUR_END_DATE, NO_TOUR_OF_DUTY, NO_UPDATE_DATE, NO_USER_LISTED,
 } from 'Constants/SystemMessages';
+import { Row } from 'Components/Layout';
 import CheckBox from 'Components/CheckBox';
 import TabbedCard from 'Components/TabbedCard';
 import LanguageList from 'Components/LanguageList';
@@ -16,6 +20,9 @@ const PublishablePositionCard = ({ data }) => {
 
   const updateUser = getResult(pos, 'description.last_editing_user');
   const updateDate = getResult(pos, 'description.date_updated');
+
+
+  // =============== View Mode ===============
 
   const sections = {
     /* eslint-disable quote-props */
@@ -50,6 +57,19 @@ const PublishablePositionCard = ({ data }) => {
     /* eslint-enable quote-props */
   };
 
+
+  // =============== Edit Mode ===============
+
+  const statusOptions = [
+    { code: 1, name: 'Vet' },
+    { code: 2, name: 'Publishable' },
+    { code: 3, name: 'Non-Publishable' },
+  ];
+  const [status, setStatus] = useState(statusOptions[0]);
+  const [exclude, setExclude] = useState(true);
+  const [cycleName, setCycleName] = useState('');
+
+
   const form = {
     /* eslint-disable quote-props */
     staticBody: {
@@ -66,7 +86,66 @@ const PublishablePositionCard = ({ data }) => {
       'Assignee': '---',
       'Post Differential | Danger Pay': getDifferentials(pos),
     },
-    inputBody: <div />,
+    inputBody: <div className="position-form">
+      <div className="spaced-row">
+        <div className="position-form--input">
+          <label htmlFor="publishable-position-statuses">Status</label>
+          <select
+            id="publishable-position-statuses"
+            defaultValue={status}
+            onChange={(e) => setStatus(e?.target.value)}
+          >
+            {statusOptions.map(s => (
+              <option value={s.code}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <CheckBox
+          id="exclude-checkbox"
+          label="Exclude Position from Bid Audit"
+          value={exclude}
+          onCheckBoxClick={e => setExclude(e)}
+        />
+      </div>
+      <div>
+        <Row fluid className="position-form--description">
+          <span className="definition-title">Position Details</span>
+          <Linkify properties={{ target: '_blank' }}>
+            <TextareaAutosize
+              maxRows={6}
+              minRows={6}
+              maxlength="4000"
+              name="position-description"
+              placeholder="No Description"
+              defaultValue={sections.textarea}
+              draggable={false}
+            />
+          </Linkify>
+          <div className="word-count">
+            {sections.textarea.length} / 4,000
+          </div>
+        </Row>
+      </div>
+      <div className="content-divider" />
+      <div className="position-form--heading">
+        <span className="title">Future Cycle</span>
+        <span className="subtitle">Please identify a cycle to add this position to.</span>
+      </div>
+      <div className="position-form--input">
+        <label htmlFor="publishable-position-cycle">* Cycle:</label>
+        <input
+          id="publishable-position-cycle"
+          placeholder="Enter Remark Description"
+          onChange={e => setCycleName(e.target.value)}
+          value={cycleName}
+        />
+      </div>
+      <div className="text-button">
+        Add Another Cycle
+      </div>
+    </div>,
     /* eslint-enable quote-props */
   };
 

--- a/src/Components/PublishablePositionCard/PublishablePositionCard.jsx
+++ b/src/Components/PublishablePositionCard/PublishablePositionCard.jsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 import Linkify from 'react-linkify';
 import TextareaAutosize from 'react-textarea-autosize';
+import Picky from 'react-picky';
 import { get } from 'lodash';
 import { getDifferentials, getPostName, getResult } from 'utilities';
-import { POSITION_DETAILS } from 'Constants/PropTypes';
+import { BID_CYCLES, POSITION_DETAILS } from 'Constants/PropTypes';
+import ListItem from 'Components/BidderPortfolio/BidControls/BidCyclePicker/ListItem';
 import {
   NO_BUREAU, NO_GRADE, NO_ORG, NO_POSITION_NUMBER, NO_POSITION_TITLE, NO_POST,
   NO_SKILL, NO_STATUS, NO_TOUR_END_DATE, NO_TOUR_OF_DUTY, NO_UPDATE_DATE, NO_USER_LISTED,
@@ -15,12 +17,11 @@ import LanguageList from 'Components/LanguageList';
 import PositionExpandableContent from 'Components/PositionExpandableContent';
 
 
-const PublishablePositionCard = ({ data }) => {
+const PublishablePositionCard = ({ data, cycles }) => {
   const pos = get(data, 'position') || data;
 
   const updateUser = getResult(pos, 'description.last_editing_user');
   const updateDate = getResult(pos, 'description.date_updated');
-
 
   // =============== View Mode ===============
 
@@ -37,7 +38,6 @@ const PublishablePositionCard = ({ data }) => {
       'Org/Code': getResult(pos, 'bureau_code') || NO_ORG,
       'Grade': getResult(pos, 'grade') || NO_GRADE,
       'Status': getResult(pos, 'status') || NO_STATUS,
-      '': <CheckBox id="deto" label="DETO" value disabled />,
     },
     bodySecondary: {
       'Bid Cycle': getResult(pos, 'latest_bidcycle.name', 'None Listed'),
@@ -59,6 +59,25 @@ const PublishablePositionCard = ({ data }) => {
 
 
   // =============== Edit Mode ===============
+  function renderSelectionList({ items, selected, ...rest }) {
+    return items.map((item, index) => {
+      const keyId = `${index}-${item}`;
+      return (<ListItem
+        item={item}
+        {...rest}
+        key={keyId}
+        queryProp={'custom_description'}
+      />);
+    });
+  }
+
+  const pickyProps = {
+    includeFilter: true,
+    dropdownHeight: 300,
+    numberDisplayed: 4,
+    multiple: true,
+    includeSelectAll: true,
+  };
 
   const statusOptions = [
     { code: 1, name: 'Vet' },
@@ -142,6 +161,21 @@ const PublishablePositionCard = ({ data }) => {
           value={cycleName}
         />
       </div>
+      <div className="position-form--input">
+        <div className="filter-div">
+          <div className="label">Bid Cycle:</div>
+          <Picky
+            {...pickyProps}
+            placeholder="Select Bid Cycle(s)"
+            value={cycleName}
+            options={cycles?.data}
+            onChange={setCycleName}
+            valueKey="id"
+            labelKey="name"
+            renderList={renderSelectionList}
+          />
+        </div>
+      </div>
       <div className="text-button">
         Add Another Cycle
       </div>
@@ -166,6 +200,7 @@ const PublishablePositionCard = ({ data }) => {
 
 PublishablePositionCard.propTypes = {
   data: POSITION_DETAILS.isRequired,
+  cycles: BID_CYCLES.isRequired,
 };
 
 export default PublishablePositionCard;

--- a/src/Components/PublishablePositionCard/PublishablePositionCard.jsx
+++ b/src/Components/PublishablePositionCard/PublishablePositionCard.jsx
@@ -137,7 +137,7 @@ const PublishablePositionCard = ({ data }) => {
         <label htmlFor="publishable-position-cycle">* Cycle:</label>
         <input
           id="publishable-position-cycle"
-          placeholder="Enter Remark Description"
+          placeholder="Enter Cycle Name"
           onChange={e => setCycleName(e.target.value)}
           value={cycleName}
         />

--- a/src/Constants/SystemMessages.js
+++ b/src/Constants/SystemMessages.js
@@ -178,3 +178,8 @@ export const UPDATE_PANEL_MEETING_SUCCESS = 'This Panel Meeting has been saved s
 export const UPDATE_PANEL_MEETING_ERROR_TITLE = 'Panel Meeting Error';
 export const UPDATE_PANEL_MEETING_ERROR = 'There was an issue attempting to save this Panel Meeting. Please try again.';
 
+export const UPDATE_PUBLISAHBLE_POSITION_SUCCESS_TITLE = 'Publishable Position Saved';
+export const UPDATE_PUBLISAHBLE_POSITION_SUCCESS = 'This Publishable Position has been successfully saved.';
+export const UPDATE__PUBLISAHBLE_POSITION__ERROR_TITLE = 'Publishable Position Error';
+export const UPDATE__PUBLISAHBLE_POSITION__ERROR = 'There was an issue attempting to save this Publishable Position. Please try again.';
+

--- a/src/Constants/SystemMessages.js
+++ b/src/Constants/SystemMessages.js
@@ -180,6 +180,6 @@ export const UPDATE_PANEL_MEETING_ERROR = 'There was an issue attempting to save
 
 export const UPDATE_PUBLISAHBLE_POSITION_SUCCESS_TITLE = 'Publishable Position Saved';
 export const UPDATE_PUBLISAHBLE_POSITION_SUCCESS = 'This Publishable Position has been successfully saved.';
-export const UPDATE__PUBLISAHBLE_POSITION__ERROR_TITLE = 'Publishable Position Error';
-export const UPDATE__PUBLISAHBLE_POSITION__ERROR = 'There was an issue attempting to save this Publishable Position. Please try again.';
+export const UPDATE_PUBLISAHBLE_POSITION__ERROR_TITLE = 'Publishable Position Error';
+export const UPDATE_PUBLISAHBLE_POSITION__ERROR = 'There was an issue attempting to save this Publishable Position. Please try again.';
 

--- a/src/actions/editPositionDetails.js
+++ b/src/actions/editPositionDetails.js
@@ -222,8 +222,8 @@ export function editPositionDetailsEditData(id, data) {
       .catch((err) => {
         if (err?.message === 'cancel') {
           batch(() => {
-            dispatch(editPositionDetailsEditDataErrored(false));
             dispatch(editPositionDetailsEditDataLoading(true));
+            dispatch(editPositionDetailsEditDataErrored(false));
           });
         } else {
           const toastTitle = UPDATE_PUBLISAHBLE_POSITION__ERROR_TITLE;

--- a/src/actions/editPositionDetails.js
+++ b/src/actions/editPositionDetails.js
@@ -1,6 +1,11 @@
 import { batch } from 'react-redux';
-import { convertQueryToString, downloadFromResponse, formatDate } from 'utilities';
 import api from '../api';
+import {
+  UPDATE_PUBLISAHBLE_POSITION_SUCCESS_TITLE,
+  UPDATE_PUBLISAHBLE_POSITION_SUCCESS,
+  UPDATE__PUBLISAHBLE_POSITION__ERROR_TITLE,
+  UPDATE__PUBLISAHBLE_POSITION__ERROR,
+} from 'Constants/SystemMessages';
 
 const dummyPositionDetails = {
   id: '2561',
@@ -162,6 +167,89 @@ export function editPositionDetailsFetchDataSuccess(results) {
   };
 }
 
+export function editPositionDetailsFetchData() {
+  return (dispatch) => {
+    batch(() => {
+      dispatch(editPositionDetailsFetchDataSuccess(dummyPositionDetails));
+      dispatch(editPositionDetailsFetchDataLoading(false));
+      dispatch(editPositionDetailsFetchDataErrored(false));
+    });
+  };
+}
+
+
+export function editPositionDetailsEditDataErrored(bool) {
+  return {
+    type: 'PUBLISHABLE_POSITION_EDIT_HAS_ERRORED',
+    hasErrored: bool,
+  };
+}
+
+export function editPositionDetailsEditDataLoading(bool) {
+  return {
+    type: 'PUBLISHABLE_POSITION_EDIT_IS_LOADING',
+    isLoading: bool,
+  };
+}
+
+export function editPositionDetailsEditDataSuccess(success) {
+  return {
+    type: 'PUBLISHABLE_POSITION_EDIT_SUCCESS',
+    success,
+  };
+}
+
+export function editPositionDetailsEditData(id, data) {
+  return (dispatch) => {
+    batch(() => {
+      dispatch(editPositionDetailsEditDataLoading(true));
+      dispatch(editPositionDetailsEditDataErrored(false));
+    });
+
+    api().patch(`ao/${id}/publishablePosition/`, data)
+      .then(() => {
+        const toastTitle = UPDATE_PUBLISAHBLE_POSITION_SUCCESS_TITLE;
+        const toastMessage = UPDATE_PUBLISAHBLE_POSITION_SUCCESS;
+        batch(() => {
+          dispatch(editPositionDetailsEditDataErrored(false));
+          dispatch(editPositionDetailsEditDataLoading(false));
+          dispatch(editPositionDetailsEditDataSuccess(true));
+          dispatch(toastSuccess(toastMessage, toastTitle));
+          dispatch(editPositionDetailsFetchData());
+        });
+      })
+      .catch((err) => {
+        if (get(err, 'message') === 'cancel') {
+          batch(() => {
+            dispatch(editPositionDetailsEditDataErrored(false));
+            dispatch(editPositionDetailsEditDataLoading(true));
+          });
+        } else {
+          const toastTitle = UPDATE__PUBLISAHBLE_POSITION__ERROR_TITLE;
+          const toastMessage = UPDATE__PUBLISAHBLE_POSITION__ERROR;
+          dispatch(toastError(toastMessage, toastTitle));
+          batch(() => {
+            dispatch(editPositionDetailsEditDataErrored(true));
+            dispatch(editPositionDetailsEditDataLoading(false));
+          });
+        }
+      });
+  };
+}
+
+
+export function editPositionDetailsSelectionsSaveSuccess(result) {
+  return {
+    type: 'EDIT_POSITION_DETAILS_SELECTIONS_SAVE_SUCCESS',
+    result,
+  };
+}
+
+export function saveEditPositionDetailsSelections(queryObject) {
+  return (dispatch) => dispatch(editPositionDetailsSelectionsSaveSuccess(queryObject));
+}
+
+
 export function editPositionDetailsFiltersFetchDataErrored(bool) {
   return {
     type: 'EDIT_POSITION_DETAILS_FILTERS_FETCH_HAS_ERRORED',
@@ -181,38 +269,6 @@ export function editPositionDetailsFiltersFetchDataSuccess(results) {
     type: 'EDIT_POSITION_DETAILS_FILTERS_FETCH_SUCCESS',
     results,
   };
-}
-
-export function editPositionDetailsExport(query = {}) {
-  const q = convertQueryToString(query);
-  const endpoint = '/fsbid/agenda_employees/export/'; // Replace with correct endpoint when available
-  const ep = `${endpoint}?${q}`;
-  return api()
-    .get(ep)
-    .then((response) => {
-      downloadFromResponse(response, `Edit_Position_Details_${formatDate(new Date().getTime(), 'YYYY_M_D_Hms')}`);
-    });
-}
-
-export function editPositionDetailsFetchData() {
-  return (dispatch) => {
-    batch(() => {
-      dispatch(editPositionDetailsFetchDataSuccess(dummyPositionDetails));
-      dispatch(editPositionDetailsFetchDataLoading(false));
-      dispatch(editPositionDetailsFetchDataErrored(false));
-    });
-  };
-}
-
-export function editPositionDetailsSelectionsSaveSuccess(result) {
-  return {
-    type: 'EDIT_POSITION_DETAILS_SELECTIONS_SAVE_SUCCESS',
-    result,
-  };
-}
-
-export function saveEditPositionDetailsSelections(queryObject) {
-  return (dispatch) => dispatch(editPositionDetailsSelectionsSaveSuccess(queryObject));
 }
 
 export function editPositionDetailsFiltersFetchData() {

--- a/src/actions/editPositionDetails.js
+++ b/src/actions/editPositionDetails.js
@@ -1,11 +1,12 @@
 import { batch } from 'react-redux';
-import api from '../api';
 import {
-  UPDATE_PUBLISAHBLE_POSITION_SUCCESS_TITLE,
   UPDATE_PUBLISAHBLE_POSITION_SUCCESS,
-  UPDATE__PUBLISAHBLE_POSITION__ERROR_TITLE,
+  UPDATE_PUBLISAHBLE_POSITION_SUCCESS_TITLE,
   UPDATE__PUBLISAHBLE_POSITION__ERROR,
+  UPDATE__PUBLISAHBLE_POSITION__ERROR_TITLE,
 } from 'Constants/SystemMessages';
+import { toastError, toastSuccess } from './toast';
+import api from '../api';
 
 const dummyPositionDetails = {
   id: '2561',
@@ -219,7 +220,7 @@ export function editPositionDetailsEditData(id, data) {
         });
       })
       .catch((err) => {
-        if (get(err, 'message') === 'cancel') {
+        if (err?.message === 'cancel') {
           batch(() => {
             dispatch(editPositionDetailsEditDataErrored(false));
             dispatch(editPositionDetailsEditDataLoading(true));

--- a/src/actions/editPositionDetails.js
+++ b/src/actions/editPositionDetails.js
@@ -2,8 +2,8 @@ import { batch } from 'react-redux';
 import {
   UPDATE_PUBLISAHBLE_POSITION_SUCCESS,
   UPDATE_PUBLISAHBLE_POSITION_SUCCESS_TITLE,
-  UPDATE__PUBLISAHBLE_POSITION__ERROR,
-  UPDATE__PUBLISAHBLE_POSITION__ERROR_TITLE,
+  UPDATE_PUBLISAHBLE_POSITION__ERROR,
+  UPDATE_PUBLISAHBLE_POSITION__ERROR_TITLE,
 } from 'Constants/SystemMessages';
 import { toastError, toastSuccess } from './toast';
 import api from '../api';
@@ -226,8 +226,8 @@ export function editPositionDetailsEditData(id, data) {
             dispatch(editPositionDetailsEditDataLoading(true));
           });
         } else {
-          const toastTitle = UPDATE__PUBLISAHBLE_POSITION__ERROR_TITLE;
-          const toastMessage = UPDATE__PUBLISAHBLE_POSITION__ERROR;
+          const toastTitle = UPDATE_PUBLISAHBLE_POSITION__ERROR_TITLE;
+          const toastMessage = UPDATE_PUBLISAHBLE_POSITION__ERROR;
           dispatch(toastError(toastMessage, toastTitle));
           batch(() => {
             dispatch(editPositionDetailsEditDataErrored(true));

--- a/src/actions/editPositionDetails.js
+++ b/src/actions/editPositionDetails.js
@@ -172,8 +172,8 @@ export function editPositionDetailsFetchData() {
   return (dispatch) => {
     batch(() => {
       dispatch(editPositionDetailsFetchDataSuccess(dummyPositionDetails));
-      dispatch(editPositionDetailsFetchDataLoading(false));
       dispatch(editPositionDetailsFetchDataErrored(false));
+      dispatch(editPositionDetailsFetchDataLoading(false));
     });
   };
 }
@@ -213,10 +213,10 @@ export function editPositionDetailsEditData(id, data) {
         const toastMessage = UPDATE_PUBLISAHBLE_POSITION_SUCCESS;
         batch(() => {
           dispatch(editPositionDetailsEditDataErrored(false));
-          dispatch(editPositionDetailsEditDataLoading(false));
           dispatch(editPositionDetailsEditDataSuccess(true));
           dispatch(toastSuccess(toastMessage, toastTitle));
           dispatch(editPositionDetailsFetchData());
+          dispatch(editPositionDetailsEditDataLoading(false));
         });
       })
       .catch((err) => {

--- a/src/reducers/editPositionDetails/editPositionDetails.js
+++ b/src/reducers/editPositionDetails/editPositionDetails.js
@@ -23,6 +23,32 @@ export function editPositionDetails(state = {}, action) {
   }
 }
 
+export function editPositionDetailsEditDataErrored(state = false, action) {
+  switch (action.type) {
+    case 'PUBLISHABLE_POSITION_EDIT_HAS_ERRORED':
+      return action.hasErrored;
+    default:
+      return state;
+  }
+}
+export function editPositionDetailsEditDataLoading(state = false, action) {
+  switch (action.type) {
+    case 'PUBLISHABLE_POSITION_EDIT_IS_LOADING':
+      return action.isLoading;
+    default:
+      return state;
+  }
+}
+export function editPositionDetailsEdit(state = {}, action) {
+  switch (action.type) {
+    case 'PUBLISHABLE_POSITION_EDIT_SUCCESS':
+      return action.results;
+    default:
+      return state;
+  }
+}
+
+
 export function editPositionDetailsSelections(state = {}, action) {
   switch (action.type) {
     case 'EDIT_POSITION_DETAILS_SELECTIONS_SAVE_SUCCESS':

--- a/src/reducers/editPositionDetails/index.js
+++ b/src/reducers/editPositionDetails/index.js
@@ -1,25 +1,25 @@
 import {
-  editPositionDetailsFetchDataErrored,
-  editPositionDetailsFetchDataLoading,
   editPositionDetails,
+  editPositionDetailsEdit,
   editPositionDetailsEditDataErrored,
   editPositionDetailsEditDataLoading,
-  editPositionDetailsEdit,
-  editPositionDetailsSelections,
+  editPositionDetailsFetchDataErrored,
+  editPositionDetailsFetchDataLoading,
+  editPositionDetailsFilters,
   editPositionDetailsFiltersFetchDataErrored,
   editPositionDetailsFiltersFetchDataLoading,
-  editPositionDetailsFilters,
+  editPositionDetailsSelections,
 } from './editPositionDetails';
 
 export default {
+  editPositionDetails,
   editPositionDetailsFetchDataErrored,
   editPositionDetailsFetchDataLoading,
-  editPositionDetails,
+  editPositionDetailsEdit,
   editPositionDetailsEditDataErrored,
   editPositionDetailsEditDataLoading,
-  editPositionDetailsEdit,
   editPositionDetailsSelections,
+  editPositionDetailsFilters,
   editPositionDetailsFiltersFetchDataErrored,
   editPositionDetailsFiltersFetchDataLoading,
-  editPositionDetailsFilters,
 };

--- a/src/reducers/editPositionDetails/index.js
+++ b/src/reducers/editPositionDetails/index.js
@@ -1,19 +1,25 @@
 import {
-  editPositionDetails,
   editPositionDetailsFetchDataErrored,
   editPositionDetailsFetchDataLoading,
-  editPositionDetailsFilters,
+  editPositionDetails,
+  editPositionDetailsEditDataErrored,
+  editPositionDetailsEditDataLoading,
+  editPositionDetailsEdit,
+  editPositionDetailsSelections,
   editPositionDetailsFiltersFetchDataErrored,
   editPositionDetailsFiltersFetchDataLoading,
-  editPositionDetailsSelections,
+  editPositionDetailsFilters,
 } from './editPositionDetails';
 
 export default {
-  editPositionDetails,
   editPositionDetailsFetchDataErrored,
   editPositionDetailsFetchDataLoading,
-  editPositionDetailsFilters,
+  editPositionDetails,
+  editPositionDetailsEditDataErrored,
+  editPositionDetailsEditDataLoading,
+  editPositionDetailsEdit,
+  editPositionDetailsSelections,
   editPositionDetailsFiltersFetchDataErrored,
   editPositionDetailsFiltersFetchDataLoading,
-  editPositionDetailsSelections,
+  editPositionDetailsFilters,
 };

--- a/src/sass/_common.scss
+++ b/src/sass/_common.scss
@@ -2,6 +2,14 @@
   min-width: 155px;
 }
 
+.width-70 {
+  width: 70px;
+}
+
+.width-250 {
+  width: 250px;
+}
+
 .width-280 {
   width: 280px;
 }

--- a/src/sass/_common.scss
+++ b/src/sass/_common.scss
@@ -14,6 +14,10 @@
   width: 280px;
 }
 
+.width-300 {
+  width: 300px;
+}
+
 .width-350 {
   width: 350px;
 }

--- a/src/sass/_common.scss
+++ b/src/sass/_common.scss
@@ -6,6 +6,10 @@
   width: 70px;
 }
 
+.width-200 {
+  width: 200px;
+}
+
 .width-250 {
   width: 250px;
 }

--- a/src/sass/_common.scss
+++ b/src/sass/_common.scss
@@ -13,3 +13,7 @@
 .width-280 {
   width: 280px;
 }
+
+.width-350 {
+  width: 350px;
+}

--- a/src/sass/_positionContent.scss
+++ b/src/sass/_positionContent.scss
@@ -219,3 +219,63 @@
     padding-top: 28px;
   }
 }
+
+.position-form {
+  .position-form--heading {
+    display: flex;
+    flex-direction: column;
+
+    .title {
+      font-weight: 500;
+      font-size: 18px;
+      padding-bottom: 10px;
+    }
+
+    .subtitle {
+      padding: 5px 0px 15px;
+    }
+  }
+
+  .position-form--input {
+    display: flex;
+    align-items: baseline;
+    flex-direction: column;
+
+    select,
+    input {
+      border: 1px solid $bg-gray-dark-1;
+      border-radius: 0px;
+      font-size: 15px;
+      height: 44px;
+      max-width: 460px;
+      width: 100%;
+    }
+
+    select {
+      padding: 0 35px 0 10.5px;
+    }
+
+    label {
+      font-weight: 500;
+      font-size: 15px;
+      padding-bottom: 5px;
+      margin-top: 0px;
+    }
+  }
+
+  .position-form--description {
+    padding: 15px 0px;
+  }
+
+  .spaced-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+  }
+
+  .text-button {
+    color: $primary-blue;
+    cursor: pointer;
+    padding-top: 15px;
+  }
+}

--- a/src/sass/_positionContent.scss
+++ b/src/sass/_positionContent.scss
@@ -252,7 +252,7 @@
     }
 
     select {
-      padding: 0 35px 0 10.5px;
+      padding: 0 35px 0 11px;
     }
 
     label {
@@ -263,6 +263,21 @@
     }
   }
 
+  .position-form--picky {
+    >* {
+      display: inline;
+    }
+
+    .publishable-position-cycles-label {
+      font-weight: 500;
+    }
+
+    .publishable-position-cycles {
+      margin-inline-start: 10px;
+    }
+  }
+
+
   .position-form--description {
     padding: 15px 0px;
   }
@@ -271,11 +286,5 @@
     display: flex;
     justify-content: space-between;
     align-items: flex-end;
-  }
-
-  .text-button {
-    color: $primary-blue;
-    cursor: pointer;
-    padding-top: 15px;
   }
 }

--- a/src/sass/_profile.scss
+++ b/src/sass/_profile.scss
@@ -530,6 +530,8 @@ $padding-no-border: $total-padding - $border;
 .profile-menu {
   font-size: 15px;
   height: 100%;
+  flex-shrink: 0;
+
   .fa {
     color: $blue-primary;
   }

--- a/src/sass/_profile.scss
+++ b/src/sass/_profile.scss
@@ -528,10 +528,8 @@ $border: 5px;
 $padding-no-border: $total-padding - $border;
 
 .profile-menu {
-
   font-size: 15px;
   height: 100%;
-  min-width: 230px;
   .fa {
     color: $blue-primary;
   }
@@ -579,7 +577,6 @@ $padding-no-border: $total-padding - $border;
   .expandable-link {
     border-left: unset;
     margin-bottom: 7px;
-    max-width: 300px;
 
     .list-item-wrapper {
       padding-left: $total-padding;
@@ -643,7 +640,6 @@ $padding-no-border: $total-padding - $border;
 }
 
 .profile-menu-collapsed {
-  min-width: 65px;
 
   .menu-title {
     padding-bottom: 2px;


### PR DESCRIPTION
Features:
- Added form prop to PublishablePositionCard component to activate and format the edit mode card
- Added basic input fields and state management
- Styled form
- Action on "Add Another Cycle" (updated to Picky)
- Array of cycle inputs
- Array state management
- Adding new input fields
- ~Clear text button on cycle input field ("X")~
- Dummy redux state management in preparation for when the component is linked with the API

Note:

The results object doesn't contain information for publishable status, exclude, and cycle names yet (I don't believe) so right now there are just placeholders for those fields. The position details is using the actual value though.

[TM-3820](https://metaphase.atlassian.net/browse/TM-3820)


[TM-3820]: https://metaphase.atlassian.net/browse/TM-3820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ