### PR TITLE
TM-3819, add admin placeholder functionality in Cycle Search

### DIFF
--- a/src/Components/CycleManagement/CycleManagement.jsx
+++ b/src/Components/CycleManagement/CycleManagement.jsx
@@ -16,17 +16,20 @@ import SelectForm from 'Components/SelectForm';
 import { usePrevious } from 'hooks';
 import { filtersFetchData } from 'actions/filters/filters';
 import { cycleManagementFetchData, saveCycleManagementSelections } from 'actions/cycleManagement';
+import { userHasPermissions } from 'utilities';
 import CycleSearchCard from './CycleSearchCard';
 
 const CycleManagement = () => {
   const dispatch = useDispatch();
 
+  const userProfile = useSelector(state => state.userProfile);
   const genericFiltersIsLoading = useSelector(state => state.filtersIsLoading);
   const userSelections = useSelector(state => state.cycleManagementSelections);
   const cycleManagementDataLoading = useSelector(state => state.cycleManagementFetchDataLoading);
   const cycleManagementData = useSelector(state => state.cycleManagement);
   const cycleManagementError = useSelector(state => state.cycleManagementFetchDataErrored);
   const genericFilters = useSelector(state => state.filters);
+  const isSuperUser = userHasPermissions(['superuser'], userProfile?.permission_groups);
 
   // Filters
   const [selectedCycles, setSelectedCycles] = useState(userSelections?.selectedCycles || []);
@@ -173,6 +176,13 @@ const CycleManagement = () => {
         <div className="cycle-management-page">
           <div className="usa-grid-full cm-upper-section">
             <ProfileSectionTitle title="Cycle Search" icon="cogs" />
+            { isSuperUser &&
+              <div className="cm-admin-button">
+                <button className="usa-button-primary">
+                  Add Cycle
+                </button>
+              </div>
+            }
             <div className="filterby-container" style={{ marginTop: '40px' }}>
               <div className="filterby-label">Filter by:</div>
               <span className="filterby-clear">

--- a/src/Components/CycleManagement/CycleSearchCard.jsx
+++ b/src/Components/CycleManagement/CycleSearchCard.jsx
@@ -1,7 +1,8 @@
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 import { Column, Row } from 'Components/Layout';
-import { formatDate } from 'utilities';
+import { formatDate, userHasPermissions } from 'utilities';
 
 const CycleSearchCard = (props) => {
   const {
@@ -16,6 +17,8 @@ const CycleSearchCard = (props) => {
   } = props;
 
   const cycleLink = `/profile/bureau/cyclemanagement/${id}`;
+  const userProfile = useSelector(state => state.userProfile);
+  const isSuperUser = userHasPermissions(['superuser'], userProfile?.permission_groups);
 
   return (
     <Row fluid className="cycle-search-card">
@@ -48,6 +51,13 @@ const CycleSearchCard = (props) => {
             {<Link to={cycleLink}>
               View Cycle Positions
             </Link>}
+            { isSuperUser &&
+            <div className="cyc-admin-link">
+              <Link to={cycleLink}>
+                Edit Cycle Details
+              </Link>
+            </div>
+            }
           </span>
         </Column>
       </Row>

--- a/src/sass/_positionSearch.scss
+++ b/src/sass/_positionSearch.scss
@@ -139,6 +139,10 @@
     background-color: $bg-blue-dark-1;
     color: $color-white;
   }
+  .cm-admin-button {
+    display: flex;
+    justify-content: flex-end;
+  }
   .cm-filters {
     display: grid;
     grid-template-columns: repeat(auto-fill,minmax(450px, 1fr));
@@ -219,6 +223,9 @@
   border-left: 8px solid $blue-primary;
   box-shadow: 5px 5px 10px $bg-gray-dark-2;
   padding: 1em;
+  .cyc-admin-link {
+    text-align: center;
+  }
   .cyc-card--row {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Caught by testing 🎉

There is an A/C for adding a button and link for Admins only - though, for now, that link will do nothing

[Ticket](https://metaphase.atlassian.net/browse/TM-3819)

<img width="625" alt="image" src="https://github.com/MetaPhase-Consulting/State-TalentMAP/assets/12723877/bf2d4eee-8a81-4111-87f5-3568f3eb81d6">

<img width="557" alt="image" src="https://github.com/MetaPhase-Consulting/State-TalentMAP/assets/12723877/a46bd186-ca48-4f6f-bf45-406b43d097b1">
