### PR TITLE
TM-4610 fix frontend circle ci test bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
     "webpack-manifest-plugin": "^2.2.0",
     "webpack-plugin-ramdisk": "^0.2.0",
     "whatwg-fetch": "2.0.3",
-    "workbox-webpack-plugin": "^6.5.3",
+    "workbox-webpack-plugin": "6.5.3",
     "worker-loader": "^3.0.8",
     "yarn": "^1.22.18"
   },


### PR DESCRIPTION
It's kinda funny - they bumped up the required node version in `6.6.1` but `6.6.0` can still use older node - then they immediately jumped from `6.6.1` right into `7.0` 😂

that being said - I've had to maintain packages and versioning is a huge pain, so i get it

[Ticket](https://metaphase.atlassian.net/browse/TM-4610)