### PR TITLE
TM-4442, use v2/assignments endpoint to populate assignment history

### DIFF
--- a/src/Components/ProfileDashboard/Assignments/AssignmentsList.jsx
+++ b/src/Components/ProfileDashboard/Assignments/AssignmentsList.jsx
@@ -1,4 +1,4 @@
-import { BID_RESULTS } from '../../../Constants/PropTypes';
+import PropTypes from 'prop-types';
 import SectionTitle from '../SectionTitle';
 import BorderedList from '../../BorderedList';
 import AssignmentsListResultsCard from './AssignmentsListResultsCard';
@@ -19,7 +19,7 @@ const AssignmentList = ({ assignments }) => {
     <div className="usa-grid-full profile-section-container">
       <div className="usa-grid-full section-padded-inner-container">
         <div className="usa-width-one-whole">
-          <SectionTitle title="Position and Detail History" icon="clipboard" />
+          <SectionTitle title="Assignment History" icon="clipboard" />
         </div>
       </div>
       <div className="favorites-list-container">
@@ -37,7 +37,7 @@ const AssignmentList = ({ assignments }) => {
 };
 
 AssignmentList.propTypes = {
-  assignments: BID_RESULTS.isRequired,
+  assignments: PropTypes.arrayOf(PropTypes.shape({})),
 };
 
 AssignmentList.defaultProps = {

--- a/src/Components/ProfileDashboard/Assignments/__snapshots__/AssignmentsList.test.jsx.snap
+++ b/src/Components/ProfileDashboard/Assignments/__snapshots__/AssignmentsList.test.jsx.snap
@@ -14,7 +14,7 @@ exports[`AssignmentsListComponent matches snapshot 1`] = `
         className=""
         icon="clipboard"
         small={false}
-        title="Position and Detail History"
+        title="Assignment History"
       />
     </div>
   </div>
@@ -71,7 +71,7 @@ exports[`AssignmentsListComponent matches snapshot when there are no bids 1`] = 
         className=""
         icon="clipboard"
         small={false}
-        title="Position and Detail History"
+        title="Assignment History"
       />
     </div>
   </div>

--- a/src/Components/ProfileDashboard/ProfileDashboard.jsx
+++ b/src/Components/ProfileDashboard/ProfileDashboard.jsx
@@ -25,7 +25,7 @@ const ProfileDashboard = ({
   submitBidPosition, deleteBid, classifications, clientClassifications, registerHandshake,
   showBidTracker, showClassifications, showAssignmentHistory, showSearchAsClient,
   unregisterHandshake, showLanguages, canEditClassifications,
-  showAgendaItemHistory, isAOView,
+  showAgendaItemHistory, isAOView, assignments,
 }) => (
   <div className="usa-grid-full user-dashboard user-dashboard-main profile-content-inner-container">
     {isLoading || favoritePositionsIsLoading ||
@@ -154,7 +154,7 @@ const ProfileDashboard = ({
                     {
                       showAssignmentHistory &&
                       <BoxShadow className="usa-width-one-whole user-dashboard-section assignments-section">
-                        <Assignments assignments={userProfile.assignments} />
+                        <Assignments assignments={assignments} />
                       </BoxShadow>
                     }
                   </Column>
@@ -191,6 +191,7 @@ ProfileDashboard.propTypes = {
   classifications: CLASSIFICATIONS,
   clientClassifications: CLIENT_CLASSIFICATIONS,
   isAOView: PropTypes.bool,
+  assignments: PropTypes.arrayOf(PropTypes.shape({})),
 };
 
 ProfileDashboard.defaultProps = {
@@ -209,6 +210,7 @@ ProfileDashboard.defaultProps = {
   classifications: [],
   clientClassifications: [],
   isAOView: false,
+  assignments: [],
 };
 
 export default ProfileDashboard;

--- a/src/Containers/Dashboard/Dashboard.jsx
+++ b/src/Containers/Dashboard/Dashboard.jsx
@@ -6,6 +6,7 @@ import { userHasPermissions } from 'utilities';
 import { notificationsFetchData } from 'actions/notifications';
 import { bidListFetchData, submitBid, toggleBidPosition } from 'actions/bidList';
 import { favoritePositionsFetchData } from 'actions/favoritePositions';
+import { assignmentFetchData } from 'actions/assignment';
 import { get } from 'lodash';
 import { BID_LIST, CLASSIFICATIONS, CLIENT_CLASSIFICATIONS, EMPTY_FUNCTION, FAVORITE_POSITIONS, NOTIFICATION_LIST, USER_PROFILE } from 'Constants/PropTypes';
 import { DEFAULT_FAVORITES, DEFAULT_USER_PROFILE } from 'Constants/DefaultProps';
@@ -19,6 +20,7 @@ class DashboardContainer extends Component {
     this.props.fetchBidList();
     this.props.fetchFavorites();
     this.props.fetchNotifications();
+    this.props.assignmentFetchData();
     if (userHasPermissions(['bidder'], get(this.props.userProfile, 'permission_groups', []))) {
       this.props.fetchClassifications();
       this.props.fetchUserClassifications(this.props.userProfile.id);
@@ -30,7 +32,8 @@ class DashboardContainer extends Component {
       notifications, notificationsIsLoading, bidList, bidListIsLoading, favoritePositions,
       favoritePositionsIsLoading, favoritePositionsHasErrored, submitBidPosition,
       deleteBid, classifications, classificationsIsLoading, userClassificationsHasErrored,
-      userClassificationsIsLoading, userClassifications } = this.props;
+      userClassificationsIsLoading, userClassifications, assignments,
+    } = this.props;
     const allFavorites = (favoritePositions.favorites || [])
       .concat(favoritePositions.favoritesPV || []);
 
@@ -50,12 +53,13 @@ class DashboardContainer extends Component {
         classifications={classifications}
         clientClassifications={userClassifications}
         showAgendaHistory={false}
-        showAssignmentHistory={false}
+        showAssignmentHistory
         showBidTracker
         showClassifications={!userClassificationsHasErrored}
         showLanguages={false}
         showSearchAsClient={false}
         canEditClassifications={false}
+        assignments={assignments}
       />
     );
   }
@@ -83,6 +87,8 @@ DashboardContainer.propTypes = {
   fetchNotifications: PropTypes.func.isRequired,
   fetchClassifications: PropTypes.func,
   fetchUserClassifications: PropTypes.func,
+  assignmentFetchData: PropTypes.func.isRequired,
+  assignments: PropTypes.arrayOf(PropTypes.shape({})),
 };
 
 DashboardContainer.defaultProps = {
@@ -103,6 +109,7 @@ DashboardContainer.defaultProps = {
   userClassifications: [],
   fetchClassifications: EMPTY_FUNCTION,
   fetchUserClassifications: EMPTY_FUNCTION,
+  assignments: [],
 };
 
 const mapStateToProps = state => ({
@@ -120,6 +127,7 @@ const mapStateToProps = state => ({
   userClassificationsHasErrored: state.userClassificationsHasErrored,
   userClassificationsIsLoading: state.userClassificationsIsLoading,
   userClassifications: state.userClassifications,
+  assignments: state.assignment,
 });
 
 export const mapDispatchToProps = dispatch => ({
@@ -130,6 +138,7 @@ export const mapDispatchToProps = dispatch => ({
   submitBidPosition: id => dispatch(submitBid(id)),
   fetchClassifications: () => dispatch(fetchClassifications()),
   fetchUserClassifications: id => dispatch(fetchUserClassifications(id)),
+  assignmentFetchData: id => dispatch(assignmentFetchData(id)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(DashboardContainer);

--- a/src/Containers/ProfilePublic/ProfilePublic.jsx
+++ b/src/Containers/ProfilePublic/ProfilePublic.jsx
@@ -6,6 +6,7 @@ import { push } from 'connected-react-router';
 import { get } from 'lodash';
 import ProfileDashboard from 'Components/ProfileDashboard';
 import Alert from 'Components/Alert';
+import { assignmentFetchData } from 'actions/assignment';
 import { fetchClassifications } from 'actions/classifications';
 import { userProfilePublicFetchData } from 'actions/userProfilePublic';
 import { CLASSIFICATIONS, EMPTY_FUNCTION, USER_PROFILE } from 'Constants/PropTypes';
@@ -19,6 +20,7 @@ class ProfilePublic extends Component {
     const isBureauView = this.isView('bureau');
     const isPostView = this.isView('post');
     const bureauOrPost = isBureauView || isPostView;
+    this.props.assignmentFetchData(this.props?.match?.params?.id);
     this.props.fetchData(id, !bureauOrPost);
     if (!bureauOrPost) {
       this.props.fetchClassifications();
@@ -41,6 +43,7 @@ class ProfilePublic extends Component {
       registerHandshakePosition,
       unregisterHandshakePosition,
       deleteBid,
+      assignments,
     } = this.props;
     const { bidList } = userProfile;
     const clientClassifications = userProfile.classifications;
@@ -113,6 +116,7 @@ class ProfilePublic extends Component {
           deleteBid={deleteBid}
           isPublic
           isAOView={this.isView('ao')}
+          assignments={assignments}
           {...props}
         />
     );
@@ -131,6 +135,13 @@ ProfilePublic.propTypes = {
   registerHandshakePosition: PropTypes.func,
   unregisterHandshakePosition: PropTypes.func,
   deleteBid: PropTypes.func,
+  assignments: PropTypes.arrayOf(PropTypes.shape({})),
+  assignmentFetchData: PropTypes.func.isRequired,
+  match: PropTypes.PropTypes.shape({
+    params: PropTypes.PropTypes.shape({
+      id: PropTypes.string,
+    }),
+  }).isRequired,
 };
 
 ProfilePublic.defaultProps = {
@@ -145,6 +156,7 @@ ProfilePublic.defaultProps = {
   registerHandshakePosition: EMPTY_FUNCTION,
   unregisterHandshakePosition: EMPTY_FUNCTION,
   deleteBid: EMPTY_FUNCTION,
+  assignments: [],
 };
 
 ProfilePublic.contextTypes = {
@@ -159,6 +171,7 @@ const mapStateToProps = (state, ownProps) => ({
   classificationsIsLoading: state.classificationsIsLoading,
   classificationsHasErrored: state.classificationsHasErrored,
   classifications: state.classifications,
+  assignments: state.assignment,
 });
 
 export const mapDispatchToProps = (dispatch, ownProps) => {
@@ -170,6 +183,7 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
     registerHandshakePosition: id => dispatch(registerHandshake(id, id$)),
     unregisterHandshakePosition: id => dispatch(unregisterHandshake(id, id$)),
     deleteBid: id => dispatch(toggleBidPosition(id, true, false, id$, true)),
+    assignmentFetchData: id => dispatch(assignmentFetchData(id)),
   };
 };
 

--- a/src/actions/assignment.js
+++ b/src/actions/assignment.js
@@ -19,13 +19,12 @@ export function assignmentFetchDataSuccess(assignment) {
   };
 }
 
-export function assignmentFetchData(status = 'active') {
+export function assignmentFetchData(id) {
   return (dispatch) => {
     api()
-      .get(`/profile/assignments/?status=${status}`)
-      .then(({ data }) => data.results[0] || {})
-      .then((assignment) => {
-        dispatch(assignmentFetchDataSuccess(assignment));
+      .get(`/fsbid/assignment_history/${id ? `${id}/` : ''}`)
+      .then(({ data }) => {
+        dispatch(assignmentFetchDataSuccess(data));
         dispatch(assignmentIsLoading(false));
         dispatch(assignmentHasErrored(false));
       })

--- a/src/actions/userProfile.js
+++ b/src/actions/userProfile.js
@@ -10,52 +10,6 @@ import { favoritePositionsFetchData } from './favoritePositions';
 import { toastError, toastSuccess } from './toast';
 import * as SystemMessages from '../Constants/SystemMessages';
 
-const assignment =
-  [
-    {
-      id: null,
-      position_id: '105344',
-      start_date: '2022-07-21T19:47:44.935000Z',
-      end_date: '2022-07-21T19:47:44.935000Z',
-      position: {
-        grade: '02',
-        skill: 'PASSPORT AFFAIRS (3020)',
-        skill_code: '3020',
-        bureau: '(EUR) BUR OF EUROPEAN AFF AND EURASIAN AFFAIRS',
-        bureau_code: 'EUR',
-        organization: null,
-        position_number: 'D0950904',
-        position_id: '105344',
-        title: 'INFO MANAGEMENT TECHNICAL SPEC',
-        post: {
-          code: 'UG5000000',
-          post_overview_url: null,
-          post_bidding_considerations_url: null,
-          obc_id: null,
-          location: {
-            country: 'French Guiana',
-            code: 'UG5000000',
-            city: 'Brenton',
-            state: '',
-          },
-        },
-        language: 'Spanish 3/3',
-      },
-    },
-  ];
-
-const language =
-  [
-    {
-      code: 'GG',
-      language: 'Georgian',
-      test_date: '2003-05-28T04:00:00Z',
-      speaking_score: '2+',
-      reading_score: '2',
-      custom_description: 'Georgian 2+/2',
-    },
-  ];
-
 export function userProfileHasErrored(bool) {
   return {
     type: 'USER_PROFILE_HAS_ERRORED',
@@ -114,8 +68,6 @@ export function userProfileFetchData(bypass, cb) {
      */
     // profile
     const getUserAccount = () => api().get('/profile/', { headers: { [INTERCEPTORS.PUT_PERDET.value]: true } });
-    // const getAssignments = () => api().get();
-
     // permissions
     const getUserPermissions = () => api().get('/permission/user/', { headers: { [INTERCEPTORS.PUT_PERDET.value]: true } });
     // AP favorites
@@ -161,8 +113,6 @@ export function userProfileFetchData(bypass, cb) {
           cdo: account.cdo_info, // don't use deprecated CDO API model
           bureau_permissions: bureauPermissions,
           org_permissions: orgPermissions,
-          assignments: assignment,
-          languages: language,
         };
 
         if (!bypass) {

--- a/src/reducers/assignment/assignment.js
+++ b/src/reducers/assignment/assignment.js
@@ -14,7 +14,7 @@ export function assignmentIsLoading(state = true, action) {
       return state;
   }
 }
-export function assignment(state = {}, action) {
+export function assignment(state = [], action) {
   switch (action.type) {
     case 'ASSIGNMENT_FETCH_DATA_SUCCESS':
       return action.assignment;


### PR DESCRIPTION
Still need to double check in dev...

All this really does is hijack the `Assignment` action to start using the `v2/assignments` endpoint (which is the `assignment_history` service in the API) to pass assignment data to the `Assignment History` cards

When viewed from the CDO page it will pass in an ID and show that user's ass history ... from the dash - no user ID, and will return the logged in user's assignments 

Dashboard
<img width="476" alt="image" src="https://github.com/MetaPhase-Consulting/State-TalentMAP/assets/12723877/5192800d-5ab0-4d6f-9e7f-d4e5c103601e">
<img width="1972" alt="image" src="https://github.com/MetaPhase-Consulting/State-TalentMAP/assets/12723877/bf1908a4-3f50-4f0a-b747-0e7eaa2b25c1">

CDO > Profile View
<img width="531" alt="image" src="https://github.com/MetaPhase-Consulting/State-TalentMAP/assets/12723877/b3447491-fc53-442c-80c7-bb0e85bbf941">
<img width="1961" alt="image" src="https://github.com/MetaPhase-Consulting/State-TalentMAP/assets/12723877/55734a3a-09b6-4683-baae-266a7cdbc49d">


[Ticket](https://metaphase.atlassian.net/browse/TM-4442)


NOTE - the `userProfile` action still returns `current_assginment` and the `userProfilePublic` action still returns both `current_assignment` and a list of `assignments` ... i think these might be wrong or outdated, and that their API counterparts might need to be cleaned up 🤷 ...  i might be off, but should it be a tech debt ticket?

(also ^^ that bit was confusing the hell out of me) 