### PR TITLE
TM-4687: Updating Edit Cycle Position Incumbent Dropdown

### DIFF
--- a/src/Components/CyclePositionCard/CyclePositionCard.jsx
+++ b/src/Components/CyclePositionCard/CyclePositionCard.jsx
@@ -111,10 +111,10 @@ const CyclePositionCard = ({ data, cycle, onEditModeSearch }) => {
 
   // Hardcoded - find where to get this data
   const fakeIncumbents = [
-    { code: 'JH', name: 'Holden, James' },
-    { code: 'NN', name: 'Nagata, Naomi' },
-    { code: 'AB', name: 'Burton, Amos' },
-    { code: 'AK', name: 'Kamal, Alex' },
+    { code: 'CURR', name: 'Holden, James' },
+    { code: 'TBD', name: 'TBD' },
+    { code: 'VAC', name: 'Vacant' },
+    { code: 'NEW', name: 'New' },
   ];
   const [incumbent, setIncumbent] = useState(fakeIncumbents[0]);
 
@@ -142,7 +142,7 @@ const CyclePositionCard = ({ data, cycle, onEditModeSearch }) => {
             <label htmlFor="cycle-position-incumbent">Incumbent</label>
             <select
               id="cycle-position-incumbent"
-              defaultValue={status}
+              defaultValue={incumbent}
               onChange={(e) => setIncumbent(e?.target.value)}
             >
               {fakeIncumbents.map(s => (


### PR DESCRIPTION
ACs:
1. Verify incumbent dropdown in edit view of cycle position cards has new options:
    - Current Incumbent (fake)
    - TBD
    - Vacant
    - New

<img width="1471" alt="image" src="https://github.com/MetaPhase-Consulting/State-TalentMAP/assets/31417027/691f8360-bda1-42be-8ce2-abf5afdbb561">

[Ticket](https://metaphase.atlassian.net/browse/TM-4687)
