### PR TITLE
[TM-4914] Org Stats Fix Definition Label

### DIFF
--- a/src/Components/AdministratorPage/OrgStats/OrgStats.jsx
+++ b/src/Components/AdministratorPage/OrgStats/OrgStats.jsx
@@ -182,7 +182,7 @@ const OrgStats = () => {
                 'Bureau: ': bureauSummary.bureau_short_desc,
                 'Total POS': bureauSummary.total_pos,
                 'Total Filled': bureauSummary.total_filled,
-                '% POS': bureauSummary.total_percent,
+                '% Filled': bureauSummary.total_percent,
                 'Overseas POS': bureauSummary.overseas_pos,
                 'Overseas Filled': bureauSummary.overseas_filled,
                 '% Overseas': bureauSummary.overseas_percent,

--- a/src/Components/AdministratorPage/OrgStats/OrgStatsCard.jsx
+++ b/src/Components/AdministratorPage/OrgStats/OrgStatsCard.jsx
@@ -13,7 +13,7 @@ const OrgStatsCard = (props) => {
     body: {
       'Total POS': getResult(props, 'total_pos'),
       'Total Filled': getResult(props, 'total_filled'),
-      '% POS': getResult(props, 'total_percent'),
+      '% Filled': getResult(props, 'total_percent'),
       'Overseas POS': getResult(props, 'overseas_pos'),
       'Overseas Filled': getResult(props, 'overseas_filled'),
       '% Overseas': getResult(props, 'overseas_percent'),


### PR DESCRIPTION
Quick fix to rename `% POS` to `% Filled`

[TM-4914](https://metaphase.atlassian.net/browse/TM-4914)


[TM-4914]: https://metaphase.atlassian.net/browse/TM-4914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ