### PR TITLE
HOTFIX - Search Post Access Page CSS Fix

### DIFF
--- a/src/sass/_postAccess.scss
+++ b/src/sass/_postAccess.scss
@@ -1,3 +1,42 @@
+.custom-table {
+  position: relative;
+  width: 100%;
+  border-collapse: collapse; /* Collapse borders */
+  border-spacing: 0;
+  th {
+    border: none;
+    border-top: 1px solid #ddd;
+    border-bottom: 1px solid #ddd;
+    padding: 8px; /* Add padding to cells for better readability */
+  }
+  tr {
+    height: 50px;
+  }
+  tbody {
+    td {
+      border: none;
+      border-top: 1px solid #ddd;
+      border-bottom: 1px solid #ddd;
+      padding: 8px;
+    }
+  }
+  .checkbox-pac {
+      min-width: 30px;
+    }
+    .checkbox-pos {
+      > div{
+        > label {
+          margin-top: 0;
+        }
+      }
+    }
+}
+
+.post-access-scroll-container {
+overflow: auto;
+height: 800px;
+}
+
 .post-access-container-cb {
   position: relative;
   bottom: 10px;


### PR DESCRIPTION
Deleted this as a part of another PR - but turns out this CSS was used by the Search Post Access page

Feel free to merge it in if I'm out

<img width="1078" alt="image" src="https://github.com/MetaPhase-Consulting/State-TalentMAP/assets/12723877/9f49c17d-058e-424a-9950-5be819fbd1f9">
should be
<img width="2028" alt="image" src="https://github.com/MetaPhase-Consulting/State-TalentMAP/assets/12723877/88929dbb-528e-4efa-af81-e94b7925dd2d">
