### PR TITLE
Remove Duplicate Names from Manage Post Access

### DIFF
--- a/src/Components/ManagePostAccess/ManagePostAccess.jsx
+++ b/src/Components/ManagePostAccess/ManagePostAccess.jsx
@@ -227,7 +227,7 @@ const ManagePostAccess = () => {
                     selectedOrgs.filter(y => y.code !== x.code))}
                   className="mpa-remove-item"
                 />
-                {x.description}
+                {`${x.description} (${x.code})`}
               </div>
             </div>
           ))}

--- a/src/Components/ManagePostAccess/ManagePostAccess.jsx
+++ b/src/Components/ManagePostAccess/ManagePostAccess.jsx
@@ -32,11 +32,15 @@ const ManagePostAccess = () => {
     (personSelected || positionSelected) && selectedOrgs.length > 0 && selectedRoles.length > 0;
 
   // Filter Options
-  const peopleOptionsHRO = managePostFilters?.personFilters?.filter(
+  const personSeqNums = new Set(managePostFilters?.personFilters?.map(x => x.code) || [])
+  const uniquePersons = personSeqNums.length
+    ? personSeqNums.map(ids => managePostFilters?.personFilters?.find(y => y.code === ids))
+    : []
+  const peopleOptionsHRO = uniquePersons?.filter(
     person => person.skillCode === '2010' || person.skillCode === '2201') || [];
   const positionOptionsHRO = managePostFilters?.positionFilters?.filter(
     position => position.skillCode === '2201' || position.skillCode === '2010') || [];
-  const peopleOptions = personHRO ? peopleOptionsHRO : managePostFilters?.personFilters || [];
+  const peopleOptions = personHRO ? peopleOptionsHRO : uniquePersons || [];
   const positionOptions = positionHRO
     ? positionOptionsHRO : managePostFilters?.positionFilters || [];
   const roleOptions = managePostFilters?.roleFilters || [];


### PR DESCRIPTION
A request from testing

also added the ORG code to the form when rendering (same as the search post access page)