### PR TITLE
Panel-Text-Language-TOD

### DIFF
--- a/src/Components/Agenda/AgendaItemLegs/AgendaItemLegs.jsx
+++ b/src/Components/Agenda/AgendaItemLegs/AgendaItemLegs.jsx
@@ -29,11 +29,22 @@ const AgendaItemLegs = props => {
     <>
       {
         legs$.map((leg, index) => {
+          const legTemp = leg;
           const keyId = index;
+          let currentData;
+          if (key === 'languages') {
+            const keyValue = helperFunc(leg[key]);
+            currentData = (keyValue === null || keyValue === '-') ? 'None Listed' : keyValue;
+          } else if (key === 'tod_short_desc' && (leg.tod_short_desc) === 'IND') {
+            legTemp.ted = 'N/A';
+          } else {
+            currentData = helperFunc(leg[key]);
+          }
+
           return (
             <td key={`${leg.id}-${keyId}`}>
               {
-                <dd>{helperFunc(leg[key]) ?? leg[key] ?? 'None listed'}</dd>
+                <dd>{currentData ?? leg[key] ?? 'None listed'}</dd>
               }
             </td>
           );


### PR DESCRIPTION
https://metaphase.atlassian.net/browse/TM-4991

-When there is no Language data, display as None Listed instead of blank (all legs)
-When there is an IND (indefinite) TOD, the TED should display as N/A

![Screenshot 2023-10-19 at 4 52 57 PM](https://github.com/MetaPhase-Consulting/State-TalentMAP/assets/135657303/e9a20bb4-95d7-47f9-875e-cbd0d3e61a1f)