### PR TITLE
[TM-5052] Run Panel Hold

### DIFF
--- a/src/Components/AdministratorPage/PanelAdmin/PostPanelProcessing.jsx
+++ b/src/Components/AdministratorPage/PanelAdmin/PostPanelProcessing.jsx
@@ -245,6 +245,13 @@ const PostPanelProcessing = (props) => {
   const disableSave = !isSuperUser &&
     (!beforeAgendaCompletedTime);
 
+  const disableHold = (agenda, status) => {
+    const isHold = status.code === 'H';
+    const isChairHold = agenda.aht_code === 'C';
+    const reachedMax = agenda.max_aih_hold_number > 2;
+    return isHold && !isChairHold && reachedMax;
+  }
+
   return (
     (isLoading) ?
       <Spinner type="panel-admin-remarks" size="small" /> :
@@ -324,7 +331,7 @@ const PostPanelProcessing = (props) => {
                         name={`${d.label}-status-${o.description}`}
                         checked={d.status === o.description}
                         onClick={() => handleStatusSelection(d.label, o.description)}
-                        disabled={disableTable}
+                        disabled={disableTable || disableHold(d, o)}
                         className="interactive-element"
                       />
                     );

--- a/src/Components/AdministratorPage/PanelAdmin/PostPanelProcessing.jsx
+++ b/src/Components/AdministratorPage/PanelAdmin/PostPanelProcessing.jsx
@@ -6,6 +6,7 @@ import FA from 'react-fontawesome';
 import PropTypes from 'prop-types';
 import swal from '@sweetalert/with-react';
 import Spinner from 'Components/Spinner';
+import { Tooltip } from 'react-tippy';
 import { editPostPanelProcessing, postPanelProcessingFetchData } from 'actions/postPanelProcessing';
 import { panelMeetingsFetchData } from 'actions/panelMeetings';
 import { runPanelMeeting } from 'actions/panelMeetingAdmin';
@@ -83,7 +84,7 @@ const PostPanelProcessing = (props) => {
 
   const handleHold = (label) => {
     const ref = formData.find(o => o.label === label);
-    let option = ref?.aih_hold_number || ref?.aih_hold_number || '';
+    let option = ref?.aih_hold_number || ref?.max_aih_hold_number || holdOptions[0].code;
     let description = ref?.aih_hold_comment || ref?.max_aih_hold_comment || '';
 
     swal({
@@ -291,7 +292,9 @@ const PostPanelProcessing = (props) => {
                 <th>Label</th>
                 <th>Name</th>
                 {statuses.map((o) => (
-                  <th key={o.code}>{o.description}</th>
+                  <th key={o.code}>
+                    {o.description}
+                  </th>
                 ))}
               </tr>
             </thead>
@@ -311,8 +314,8 @@ const PostPanelProcessing = (props) => {
                   </td>
                   <td key={`${d.label}-label`}>{d.label}</td>
                   <td key={`${d.label}-employee`}>{d.employee}</td>
-                  {statuses.map((o) => (
-                    <td key={`${d.label}-${o.code}`}>
+                  {statuses.map((o) => {
+                    const radio = (
                       <input
                         id={`${d.label}-status-${o.code}`}
                         type="radio"
@@ -322,8 +325,38 @@ const PostPanelProcessing = (props) => {
                         disabled={disableTable}
                         className="interactive-element"
                       />
-                    </td>
-                  ))}
+                    );
+                    return (
+                      <td key={`${d.label}-${o.code}`}>
+                        {(o.code === 'H' && d.status === o.description) ?
+                          <Tooltip
+                            html={
+                              <div className="tooltip-text">
+                                <div>
+                                  <span className="title">
+                                    {holdOptions
+                                      .find(h => h.code === d.aih_hold_number)?.description}
+                                  </span>
+                                </div>
+                                <div>
+                                  <span className="text">
+                                    {d.aih_hold_comment}
+                                  </span>
+                                </div>
+                              </div>
+                            }
+                            theme="oc-status"
+                            arrow
+                            interactive
+                            useContext
+                          >
+                            {radio}
+                          </Tooltip> :
+                          radio
+                        }
+                      </td>
+                    );
+                  })}
                 </tr>
               ))}
             </tbody>

--- a/src/Components/AdministratorPage/PanelAdmin/PostPanelProcessing.jsx
+++ b/src/Components/AdministratorPage/PanelAdmin/PostPanelProcessing.jsx
@@ -84,7 +84,7 @@ const PostPanelProcessing = (props) => {
 
   const handleHold = (label) => {
     const ref = formData.find(o => o.label === label);
-    let option = ref?.aih_hold_number || ref?.max_aih_hold_number || holdOptions[0].code;
+    let option = ref?.aht_code || ref?.max_aht_code || holdOptions[0].code;
     let description = ref?.aih_hold_comment || ref?.max_aih_hold_comment || '';
 
     swal({
@@ -123,7 +123,7 @@ const PostPanelProcessing = (props) => {
                     return {
                       ...o,
                       status: 'HLD',
-                      aih_hold_number: option,
+                      aht_code: option,
                       aih_hold_comment: description,
                     };
                   }
@@ -156,6 +156,8 @@ const PostPanelProcessing = (props) => {
           return {
             ...o,
             status: newStatus,
+            aht_code: '',
+            aih_hold_comment: '',
           };
         }
         return o;
@@ -335,7 +337,7 @@ const PostPanelProcessing = (props) => {
                                 <div>
                                   <span className="title">
                                     {holdOptions
-                                      .find(h => h.code === d.aih_hold_number)?.description}
+                                      .find(h => h.code === d.aht_code)?.description}
                                   </span>
                                 </div>
                                 <div>

--- a/src/Components/AdministratorPage/PanelAdmin/PostPanelProcessing.jsx
+++ b/src/Components/AdministratorPage/PanelAdmin/PostPanelProcessing.jsx
@@ -250,7 +250,7 @@ const PostPanelProcessing = (props) => {
     const isChairHold = agenda.aht_code === 'C';
     const reachedMax = agenda.max_aih_hold_number > 2;
     return isHold && !isChairHold && reachedMax;
-  }
+  };
 
   return (
     (isLoading) ?

--- a/src/sass/_positionContent.scss
+++ b/src/sass/_positionContent.scss
@@ -241,6 +241,14 @@
   .modal-controls {
     padding-top: 28px;
   }
+
+  .position-form--label-input-container {
+    label {
+      margin-top: 0px;
+    }
+
+    padding: 10px 0px;
+  }
 }
 
 .position-form {


### PR DESCRIPTION
Updates:
- Post Panel Processing: Selecting HLD (Hold) status for an agenda item opens a modal to allow users to select a hold options and add a description
- User can cancel the modal to cancel the change to HOLD + any text they drafted
- When user clicks save, status is changed to HOLD and the option + description is saved
- User can click on the radio button to access the HOLD metadata again and save/cancel the edits if needed
- To save any changes officially, user must click save at the bottom of the page
- Hovering over hold radio buttons that are selected displays the inputs that were saved for that option
- When changing to a new status, the hold metadata is cleared

Dual Merge: 
- [API PR](https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/860)

[TM-5052](https://metaphase.atlassian.net/browse/TM-5052)


[TM-5052]: https://metaphase.atlassian.net/browse/TM-5052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ