### PR TITLE
increase permissions for labeler

### DIFF
--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -5,6 +5,8 @@ on:
       - 'dependabot/*'
 jobs:
   size-label:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: size-label


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
See the bit about `pull-requests` key

More info: https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/