### PR TITLE
Bureau-Exception-List Header

### DIFF
--- a/src/Components/AdministratorPage/BureauExceptionList/BureauExceptionList.jsx
+++ b/src/Components/AdministratorPage/BureauExceptionList/BureauExceptionList.jsx
@@ -39,6 +39,14 @@ const BureauExceptionList = () => {
       {
         getOverlay() ||
           <div className="bel-lower-section">
+            <table className="bel-table-head">
+              <thead>
+                <tr>
+                  <th className="first-header">Name</th>
+                  <th>Bureau Access</th>
+                </tr>
+              </thead>
+            </table>
             {BureauExceptionData?.filter((x => x.id != null)).map(data => (
               <BureauExceptionListCard
                 key={data?.id}

--- a/src/Components/AdministratorPage/BureauExceptionList/BureauExceptionListCard.jsx
+++ b/src/Components/AdministratorPage/BureauExceptionList/BureauExceptionListCard.jsx
@@ -178,8 +178,8 @@ const BureauExceptionListCard = (props) => {
     <div className="position-form">
       <Row fluid className="bureau-card box-shadow-standard">
         <Row fluid className="bs-card--row">
-          <Column>Person: {name || 'N/A'}</Column>
-          <Column>Bureau Access: {isBureauAccess ? bureaus : 'No Access'}</Column>
+          <Column>{name || 'N/A'}</Column>
+          <Column>{isBureauAccess ? bureaus : 'No Access'}</Column>
           <Column columns={3} className="bs-card--link-col">
             <Link
               onClick={(e) => {

--- a/src/sass/_bureauExceptionList.scss
+++ b/src/sass/_bureauExceptionList.scss
@@ -80,9 +80,6 @@
     .bel-table-head {
       width: 85%;
     }
-    .first-header {
-      width: 45%;
-    }
   }
   @media screen and (max-width: 1200px) {
     .first-header {

--- a/src/sass/_bureauExceptionList.scss
+++ b/src/sass/_bureauExceptionList.scss
@@ -49,6 +49,22 @@
   overflow-y: clip;
   padding: 0 35px 20px;
   min-width: 1000px;
+  .bel-table-head {
+    margin-bottom: 0;
+    width: 100%;
+    tr {
+      th {
+        background-color: $color-white;
+        border: 1px solid $color-gray-lighter;
+        margin-bottom: 1em;
+        margin-top: 1em;
+        padding: 1em;
+      }
+    }
+  }
+  .first-header {
+    width: 45%;
+  }
   .bureau-exception-table {
     .tm-spinner {
       position: absolute;
@@ -61,7 +77,17 @@
     .position-form {
       width: 85%;
     }
-    
+    .bel-table-head {
+      width: 85%;
+    }
+    .first-header {
+      width: 45%;
+    }
+  }
+  @media screen and (max-width: 1200px) {
+    .first-header {
+      width: 41%;
+    }
   }
 }
 


### PR DESCRIPTION
-Adjusted CSS for header of BEL by removing the Person and Bureau Access tag from each card and moving it to head.

https://github.com/MetaPhase-Consulting/State-TalentMAP/assets/135657303/c001526a-28e6-4d32-995a-ae85ba0f758f

