### PR TITLE
TM-4446, remove completed status from panel meetings

### DIFF
--- a/src/Components/Panel/PanelMeetingTracker/__snapshots__/PanelMeetingTracker.test.jsx.snap
+++ b/src/Components/Panel/PanelMeetingTracker/__snapshots__/PanelMeetingTracker.test.jsx.snap
@@ -32,9 +32,6 @@ exports[`PanelMeetingTracker matches snapshot 1`] = `
           Object {
             "label": "Post-Panel",
           },
-          Object {
-            "label": "Complete",
-          },
         ]
       }
     />

--- a/src/Components/Panel/helpers.js
+++ b/src/Components/Panel/helpers.js
@@ -8,7 +8,6 @@ export const formatPanelMeetingTrackerData = (meetingDates = []) => {
   const add = { label: 'Addendum' };
   const panel = { label: 'Panel' };
   const post = { label: 'Post-Panel' };
-  const complete = { label: 'Complete' };
 
   meetingDates.forEach(pmd => {
     const meetingDate = formatDate(get(pmd, 'pmd_dttm'), 'MM/DD/YYYY HH:mm') || '';
@@ -43,12 +42,8 @@ export const formatPanelMeetingTrackerData = (meetingDates = []) => {
       post.description ??= meetingDate;
       post.isActive ??= isPast$;
     }
-    if (code === 'COMP') {
-      complete.description = meetingDate;
-      complete.isActive = isPast$;
-    }
   });
-  const trackerData = [pre, add, panel, post, complete];
+  const trackerData = [pre, add, panel, post];
   const idx = findLastIndex(trackerData, (d) => !!d.isActive);
   if (idx >= 0) { trackerData[idx].isCurrent = true; }
   return trackerData;
@@ -77,8 +72,6 @@ export const submitPanelMeeting = (originalFields, newFields) => {
   const postPanelStarted = panelMeetingDates?.find(x => x.mdt_code === 'POSS');
   // eslint-disable-next-line no-unused-vars
   const postPanelRuntime = panelMeetingDates?.find(x => x.mdt_code === 'POST');
-  // eslint-disable-next-line no-unused-vars
-  const agendaCompletedTime = panelMeetingDates?.find(x => x.mdt_code === 'COMP');
 
   const data = {
     originalReference: originalFields,

--- a/src/Components/ProfileMenu/ProfileMenuExpanded/__snapshots__/ProfileMenuExpanded.test.jsx.snap
+++ b/src/Components/ProfileMenu/ProfileMenuExpanded/__snapshots__/ProfileMenuExpanded.test.jsx.snap
@@ -150,6 +150,14 @@ exports[`ProfileMenuExpandedComponent matches snapshot when isGlossaryEditor is 
       />
       <withRouter(NavLink)
         hidden={true}
+        iconName="users"
+        key="Bureau Exceptions"
+        link="/profile/administrator/bureauexceptions/"
+        search=""
+        title="Bureau Exceptions"
+      />
+      <withRouter(NavLink)
+        hidden={true}
         iconName="cogs"
         key="Cycle Job Categories"
         link="/profile/administrator/cyclejobcategories/"
@@ -624,6 +632,14 @@ exports[`ProfileMenuExpandedComponent matches snapshot when user is bidcycle_adm
         link="/profile/administrator/biddingtool/"
         search=""
         title="Bidding Tool"
+      />
+      <withRouter(NavLink)
+        hidden={true}
+        iconName="users"
+        key="Bureau Exceptions"
+        link="/profile/administrator/bureauexceptions/"
+        search=""
+        title="Bureau Exceptions"
       />
       <withRouter(NavLink)
         hidden={true}


### PR DESCRIPTION
A few notes:
- there is no mapping for the `COMP` value in the API - the values for `mdt_code` (which is the status) come directly from the FSBID side
- there was no need to update the filters, as the reference table already doesn't return a completed status 

<img width="330" alt="image" src="https://github.com/MetaPhase-Consulting/State-TalentMAP/assets/12723877/91940b64-bbbb-414d-a665-31b52ae1e45f">


[Ticket](https://metaphase.atlassian.net/browse/TM-4446)

<img width="1662" alt="image" src="https://github.com/MetaPhase-Consulting/State-TalentMAP/assets/12723877/fec13905-b83b-4559-9ea0-22894d0077f2">

<img width="1642" alt="image" src="https://github.com/MetaPhase-Consulting/State-TalentMAP/assets/12723877/9a3cae8d-4854-47ac-b455-1719b6c67177">
