### PR TITLE
[TM-5456] Bug: Panel Meeting Form States Reset on Edit Save

### DIFF
--- a/src/Components/AdministratorPage/PanelAdmin/PanelMeetingAdmin.jsx
+++ b/src/Components/AdministratorPage/PanelAdmin/PanelMeetingAdmin.jsx
@@ -149,12 +149,12 @@ const PanelMeetingAdmin = (props) => {
         panelMeetingStatus,
       },
     ));
-    if (isCreate) {
-      if (savePanelSuccess.length !== 0) {
+    if (savePanelSuccess.length !== 0) {
+      if (isCreate) {
         clear();
+      } else {
+        dispatch(panelMeetingAgendasFetchData({}, pmSeqNum));
       }
-    } else {
-      dispatch(panelMeetingAgendasFetchData({}, pmSeqNum));
     }
   };
 

--- a/src/Components/AdministratorPage/PanelAdmin/PanelMeetingAdmin.jsx
+++ b/src/Components/AdministratorPage/PanelAdmin/PanelMeetingAdmin.jsx
@@ -36,6 +36,7 @@ const PanelMeetingAdmin = (props) => {
   const panelMeetingsFiltersIsLoading = useSelector(state =>
     state.panelMeetingsFiltersFetchDataLoading);
 
+  const savePanelSuccess = useSelector(state => state.createPanelMeetingSuccess);
   const runPreliminarySuccess = useSelector(state => state.runOfficialPreliminarySuccess);
   const runAddendumSuccess = useSelector(state => state.runOfficialAddendumSuccess);
 
@@ -149,7 +150,11 @@ const PanelMeetingAdmin = (props) => {
       },
     ));
     if (isCreate) {
-      clear();
+      if (savePanelSuccess.length !== 0) {
+        clear();
+      }
+    } else {
+      dispatch(panelMeetingAgendasFetchData({}, pmSeqNum));
     }
   };
 

--- a/src/Components/AdministratorPage/PanelAdmin/PanelMeetingAdmin.jsx
+++ b/src/Components/AdministratorPage/PanelAdmin/PanelMeetingAdmin.jsx
@@ -148,7 +148,9 @@ const PanelMeetingAdmin = (props) => {
         panelMeetingStatus,
       },
     ));
-    clear();
+    if (isCreate) {
+      clear();
+    }
   };
 
   // ============= Form Conditions =============

--- a/src/Components/AdministratorPage/PanelAdmin/PanelMeetingMessage.jsx
+++ b/src/Components/AdministratorPage/PanelAdmin/PanelMeetingMessage.jsx
@@ -1,15 +1,38 @@
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
-const PanelMeetingMessage = ({ id }) => (
-  <span>Panel ({id}) has been successfully added to Panel Meetings. <span><Link to={`/profile/administrator/panel/${id}/`}>Go to edit panel</Link>, or <Link to={`/profile/ao/panelmeetingagendas/${id}/`}>Go to panel details</Link>.</span></span>
-);
+const PanelMeetingMessage = ({ id, isCreate }) => {
+  if (isCreate) {
+    return (
+      <span>
+        Panel ({id}) has been successfully added to Panel Meetings.
+        <span>
+          <Link to={`/profile/administrator/panel/${id}/`}>
+            Go to edit panel
+          </Link>
+          , or
+          <Link to={`/profile/ao/panelmeetingagendas/${id}/`}>
+            Go to panel details
+          </Link>
+          .
+        </span>
+      </span>
+    );
+  }
+  return (
+    <span>
+      Panel ({id}) has been successfully updated.
+    </span>
+  );
+};
 
 PanelMeetingMessage.propTypes = {
   id: PropTypes.string.isRequired,
+  isCreate: PropTypes.bool,
 };
 
 PanelMeetingMessage.defaultProps = {
+  isCreate: false,
 };
 
 export default PanelMeetingMessage;

--- a/src/Components/Panel/helpers.js
+++ b/src/Components/Panel/helpers.js
@@ -92,5 +92,5 @@ export const submitPanelMeeting = (originalFields, newFields) => {
     //  (agendaCompletedTime ? new Date(agendaCompletedTime.pmd_dttm) : undefined),
   };
 
-  return createPanelMeeting(data);
+  return createPanelMeeting(data, !originalFields);
 };

--- a/src/Components/Panel/helpers.js
+++ b/src/Components/Panel/helpers.js
@@ -1,4 +1,4 @@
-import { findLastIndex, get } from 'lodash';
+import { findLastIndex, get, isEmpty } from 'lodash';
 import { formatDate } from 'utilities';
 import { isPast } from 'date-fns-v2';
 import { createPanelMeeting } from '../../actions/panelMeetingAdmin';
@@ -92,5 +92,5 @@ export const submitPanelMeeting = (originalFields, newFields) => {
     //  (agendaCompletedTime ? new Date(agendaCompletedTime.pmd_dttm) : undefined),
   };
 
-  return createPanelMeeting(data, !originalFields);
+  return createPanelMeeting(data, isEmpty(originalFields));
 };

--- a/src/Constants/SystemMessages.js
+++ b/src/Constants/SystemMessages.js
@@ -175,7 +175,7 @@ export const SAVE_ADMIN_REMARK_HAS_ERRORED_TITLE = 'Remark Save Error';
 export const SAVE_ADMIN_REMARK_HAS_ERRORED = 'There was an issue attempting to save this Remark. Please try again.';
 
 export const UPDATE_PANEL_MEETING_SUCCESS_TITLE = 'Panel Meeting Saved';
-export const UPDATE_PANEL_MEETING_SUCCESS = (id) => PanelMeetingMessage({ id });
+export const UPDATE_PANEL_MEETING_SUCCESS = (id, isCreate) => PanelMeetingMessage({ id }, isCreate);
 export const UPDATE_PANEL_MEETING_ERROR_TITLE = 'Panel Meeting Error';
 export const UPDATE_PANEL_MEETING_ERROR = 'There was an issue attempting to save this Panel Meeting. Please try again.';
 

--- a/src/actions/panelMeetingAdmin.js
+++ b/src/actions/panelMeetingAdmin.js
@@ -33,7 +33,7 @@ export function createPanelMeetingSuccess(data) {
 }
 
 // eslint-disable-next-line no-unused-vars
-export function createPanelMeeting(request) {
+export function createPanelMeeting(request, isCreate) {
   return (dispatch) => {
     dispatch(createPanelMeetingSuccess([]));
     dispatch(createPanelMeetingIsLoading(true));
@@ -41,7 +41,7 @@ export function createPanelMeeting(request) {
     api().post('/fsbid/admin/panel/edit/',
       request,
     ).then(({ data }) => {
-      const message = UPDATE_PANEL_MEETING_SUCCESS(data);
+      const message = UPDATE_PANEL_MEETING_SUCCESS(data, isCreate);
       batch(() => {
         dispatch(createPanelMeetingHasErrored(false));
         dispatch(createPanelMeetingSuccess(data || []));


### PR DESCRIPTION
Bug:
- Form states reset after saving on edit
- Edit and Create success toast messages are not differentiated

Updates
- Fixed so that it only resets after successfully saving on create
- Fixed so that it refetched panel data after successfully saving on edit
- Fixed so that save and edit messages are differentiated

[TM-5456](https://metaphase.atlassian.net/browse/TM-5456)

[TM-5456]: https://metaphase.atlassian.net/browse/TM-5456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ