### PR TITLE
TM-5457, panel meeting dates not rendering correctly

### DIFF
--- a/src/Components/Panel/helpers.js
+++ b/src/Components/Panel/helpers.js
@@ -1,5 +1,5 @@
 import { findLastIndex, get } from 'lodash';
-import { formatDate } from 'utilities';
+import { formatDateWithTime } from 'utilities';
 import { isPast } from 'date-fns-v2';
 import { createPanelMeeting } from '../../actions/panelMeetingAdmin';
 
@@ -10,7 +10,7 @@ export const formatPanelMeetingTrackerData = (meetingDates = []) => {
   const post = { label: 'Post-Panel' };
 
   meetingDates.forEach(pmd => {
-    const meetingDate = formatDate(get(pmd, 'pmd_dttm'), 'MM/DD/YYYY HH:mm') || '';
+    const meetingDate = formatDateWithTime(get(pmd, 'pmd_dttm'), 'MM/DD/YYYY hh:mm') || '';
     const code = get(pmd, 'mdt_code');
     const isPast$ = isPast(new Date(pmd.pmd_dttm));
 

--- a/src/Components/Panel/helpers.js
+++ b/src/Components/Panel/helpers.js
@@ -10,7 +10,7 @@ export const formatPanelMeetingTrackerData = (meetingDates = []) => {
   const post = { label: 'Post-Panel' };
 
   meetingDates.forEach(pmd => {
-    const meetingDate = formatDateWithTime(get(pmd, 'pmd_dttm'), 'MM/DD/YYYY hh:mm') || '';
+    const meetingDate = formatDateWithTime(get(pmd, 'pmd_dttm'), 'MM/DD/YYYY hh:mm A') || '';
     const code = get(pmd, 'mdt_code');
     const isPast$ = isPast(new Date(pmd.pmd_dttm));
 

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -342,8 +342,15 @@ export const formatDate = (date, dateFormat = 'MM/DD/YYYY') => {
 
 // Format dates that also have a time value
 export const formatDateWithTime = (date, dateFormat = 'MM/DD/YYYY HH:mm') => {
+  // Check if the DB stored the value with a Zulu (UTC indicator)
+  const regex = /Z$/;
   if (date) {
-    const formattedDate = format(date, dateFormat);
+    let newDate = date;
+    if (!regex.test(date)) {
+      // If not, assume it was stripped, but still in UTC
+      newDate = `${date}.000Z`;
+    }
+    const formattedDate = format(newDate, dateFormat);
     return formattedDate;
   }
   return null;

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -322,6 +322,7 @@ export const getTimeDistanceInWords = (dateToCompare, date = new Date(), options
 // Format the date into our preferred format.
 // We can take any valid date and convert it into M.D.YYYY format, or any
 // format provided with the dateFormat param.
+// DO NOT USE FOR DATES WHERE TIME MATTERS
 export const formatDate = (date, dateFormat = 'MM/DD/YYYY') => {
   if (date) {
     // date-fns assumes incoming date is UTC, must adjust for timezones
@@ -334,6 +335,15 @@ export const formatDate = (date, dateFormat = 'MM/DD/YYYY') => {
     // then format the date with dateFormat
     const formattedDate = format(timezoneAdjustedDate, dateFormat);
     // and finally return the formatted date
+    return formattedDate;
+  }
+  return null;
+};
+
+// Format dates that also have a time value
+export const formatDateWithTime = (date, dateFormat = 'MM/DD/YYYY hh:mm') => {
+  if (date) {
+    const formattedDate = format(date, dateFormat);
     return formattedDate;
   }
   return null;

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -341,7 +341,7 @@ export const formatDate = (date, dateFormat = 'MM/DD/YYYY') => {
 };
 
 // Format dates that also have a time value
-export const formatDateWithTime = (date, dateFormat = 'MM/DD/YYYY hh:mm') => {
+export const formatDateWithTime = (date, dateFormat = 'MM/DD/YYYY HH:mm') => {
   if (date) {
     const formattedDate = format(date, dateFormat);
     return formattedDate;


### PR DESCRIPTION
So, this kind of goes back to this other PR - https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2763 - it has to do with the UTC offset. 

Generally, what we want to do is to store all dates in the UTC format - then, have the client's browser convert that to whatever their local time zone is.  We do that by just passing in the UTC date from the server to `new Date( )` or using `date-fns` on the frontend.

This gets a little weird when considering what the above PR fixes (if we store a date - where we don't care about the time - at Midnight UTC, the timezone adjustment could render the date as the previous day)

</br>
</br>

Now - this PR would normally fix our time issue, by avoiding the fix from the other PR - **BUT  that 'Z' at the end of a date signifies that a time is in the UTC format - so if we strip it, it will mess with the offset when using `new Date( )`**
<img width="483" alt="image" src="https://github.com/MetaPhase-Consulting/State-TalentMAP/assets/12723877/6d120a82-e9c9-4952-abb4-5ddd0f927e6f">
<img width="479" alt="image" src="https://github.com/MetaPhase-Consulting/State-TalentMAP/assets/12723877/06fb7ce4-f646-469d-8900-570aa7749226">

To complicate it some more - our local data has the Z in the dates, whereas dev does not

as of now - i think the only thing broken is dates where the time matters

TL;DR - Dates are hard and I still need to double check somethings

[Ticket](https://metaphase.atlassian.net/browse/TM-5457)