### PR TITLE
Show legacy date if not in drop down

### DIFF
--- a/src/Components/Agenda/AgendaItemMaintenancePane/AgendaItemMaintenancePane.jsx
+++ b/src/Components/Agenda/AgendaItemMaintenancePane/AgendaItemMaintenancePane.jsx
@@ -98,6 +98,10 @@ const AgendaItemMaintenancePane = (props) => {
   };
   const [selectedPanelMLDate, setPanelMLDate] = useState(calcPanelDates()?.ml);
   const [selectedPanelIDDate, setPanelIDDate] = useState(calcPanelDates()?.id);
+  const isLegacyPanelDate = () => (
+    (panelDates.some(p => p?.pm_seq_num === agendaItem?.pmi_pm_seq_num))
+  );
+  const [showLegacyPanelMeetingDate, setShowLegacyPanelMeetingDate] = useState(isLegacyPanelDate());
 
   const createdByFirst = agendaItem?.creators?.first_name || '';
   const createdByLast = agendaItem?.creators?.last_name ? `${agendaItem.creators.last_name},` : '';
@@ -168,6 +172,7 @@ const AgendaItemMaintenancePane = (props) => {
       setCombinedTod(agendaItem?.aiCombinedTodCode);
       setCombinedTodMonthsNum(agendaItem?.aiCombinedTodMonthsNum);
       setCombinedTodOtherText(agendaItem?.aiCombinedTodOtherText);
+      setShowLegacyPanelMeetingDate(isLegacyPanelDate());
     }
   }, [agendaItem]);
 
@@ -229,6 +234,12 @@ const AgendaItemMaintenancePane = (props) => {
         dispatch(positionsFetchData(`limit=50&page=1&position_num=${selectedPositionNumber}`));
       }
     }
+  };
+
+  const showPanelDatesDropdown = () => {
+    setShowLegacyPanelMeetingDate(false);
+    setPanelIDDate('');
+    setPanelMLDate('');
   };
 
   const setDate = (seq_num, isML) => {
@@ -407,46 +418,54 @@ const AgendaItemMaintenancePane = (props) => {
                     <div className="validation-error-message-label validation-error-message width-280">
                       {AIvalidation?.panelDate?.errorMessage}
                     </div>
-                    <div>
-                      <select
-                        className={`aim-select-small ${AIvalidation?.panelDate?.valid ? '' : 'validation-error-border'}`}
-                        id="ai-maintenance-status"
-                        onChange={(e) => setDate(get(e, 'target.value'), true)}
-                        value={selectedPanelMLDate}
-                        disabled={readMode}
-                      >
-                        <option value={''}>ML Dates</option>
-                        {
-                          panelDatesML.map(a => (
-                            <option
-                              key={get(a, 'pm_seq_num')}
-                              value={get(a, 'pm_seq_num')}
-                            >
-                              {get(a, 'pmt_code')} - {formatDate(get(a, 'pmd_dttm'))}
-                            </option>
-                          ))
-                        }
-                      </select>
-                      <select
-                        className={`aim-select-small ${AIvalidation?.panelDate?.valid ? '' : 'validation-error-border'}`}
-                        id="ai-maintenance-status"
-                        onChange={(e) => setDate(get(e, 'target.value'), false)}
-                        value={selectedPanelIDDate}
-                        disabled={readMode}
-                      >
-                        <option value={''}>ID Dates</option>
-                        {
-                          panelDatesID.map(a => (
-                            <option
-                              key={get(a, 'pm_seq_num')}
-                              value={get(a, 'pm_seq_num')}
-                            >
-                              {get(a, 'pmt_code')} - {formatDate(get(a, 'pmd_dttm'))}
-                            </option>
-                          ))
-                        }
-                      </select>
-                    </div>
+                    {
+                      showLegacyPanelMeetingDate ?
+                        <div className="">
+                          <span>{agendaItem?.pmt_code} {agendaItem?.pmd_dttm}</span>
+                          {!readMode && <FA name="times" className="other-tod-icon" onClick={showPanelDatesDropdown} />}
+                        </div>
+                        :
+                        <div>
+                          <select
+                            className={`aim-select-small ${AIvalidation?.panelDate?.valid ? '' : 'validation-error-border'}`}
+                            id="ai-maintenance-status"
+                            onChange={(e) => setDate(get(e, 'target.value'), true)}
+                            value={selectedPanelMLDate}
+                            disabled={readMode}
+                          >
+                            <option value={''}>ML Dates</option>
+                            {
+                              panelDatesML.map(a => (
+                                <option
+                                  key={get(a, 'pm_seq_num')}
+                                  value={get(a, 'pm_seq_num')}
+                                >
+                                  {get(a, 'pmt_code')} - {formatDate(get(a, 'pmd_dttm'))}
+                                </option>
+                              ))
+                            }
+                          </select>
+                          <select
+                            className={`aim-select-small ${AIvalidation?.panelDate?.valid ? '' : 'validation-error-border'}`}
+                            id="ai-maintenance-status"
+                            onChange={(e) => setDate(get(e, 'target.value'), false)}
+                            value={selectedPanelIDDate}
+                            disabled={readMode}
+                          >
+                            <option value={''}>ID Dates</option>
+                            {
+                              panelDatesID.map(a => (
+                                <option
+                                  key={get(a, 'pm_seq_num')}
+                                  value={get(a, 'pm_seq_num')}
+                                >
+                                  {get(a, 'pmt_code')} - {formatDate(get(a, 'pmd_dttm'))}
+                                </option>
+                              ))
+                            }
+                          </select>
+                        </div>
+                    }
                   </div>
                 </div>
             }

--- a/src/Components/Agenda/AgendaItemMaintenancePane/AgendaItemMaintenancePane.jsx
+++ b/src/Components/Agenda/AgendaItemMaintenancePane/AgendaItemMaintenancePane.jsx
@@ -98,9 +98,10 @@ const AgendaItemMaintenancePane = (props) => {
   };
   const [selectedPanelMLDate, setPanelMLDate] = useState(calcPanelDates()?.ml);
   const [selectedPanelIDDate, setPanelIDDate] = useState(calcPanelDates()?.id);
-  const isLegacyPanelDate = () => (
-    (panelDates.some(p => p?.pm_seq_num === agendaItem?.pmi_pm_seq_num))
-  );
+  const isLegacyPanelDate = () => {
+    if (!panelDates.length || isEmpty(agendaItem)) return false;
+    return !(panelDates.some(p => p?.pm_seq_num === agendaItem?.pmi_pm_seq_num));
+  };
   const [showLegacyPanelMeetingDate, setShowLegacyPanelMeetingDate] = useState(isLegacyPanelDate());
 
   const createdByFirst = agendaItem?.creators?.first_name || '';
@@ -165,6 +166,7 @@ const AgendaItemMaintenancePane = (props) => {
 
   useEffect(() => {
     if (!isEmpty(agendaItem)) {
+      // Reset form values when agenda loads
       setStatus(agendaItem?.status_code);
       setPanelCat(agendaItem?.report_category?.code);
       setPanelMLDate(calcPanelDates()?.ml);
@@ -172,9 +174,13 @@ const AgendaItemMaintenancePane = (props) => {
       setCombinedTod(agendaItem?.aiCombinedTodCode);
       setCombinedTodMonthsNum(agendaItem?.aiCombinedTodMonthsNum);
       setCombinedTodOtherText(agendaItem?.aiCombinedTodOtherText);
-      setShowLegacyPanelMeetingDate(isLegacyPanelDate());
     }
   }, [agendaItem]);
+
+  useEffect(() => {
+    // Recalculate [legacy] panel meeting when agenda or dates load
+    setShowLegacyPanelMeetingDate(isLegacyPanelDate());
+  }, [agendaItem, panelDates]);
 
   useEffect(() => {
     const aiV = AIvalidation?.allValid;

--- a/src/Components/Agenda/AgendaItemMaintenancePane/AgendaItemMaintenancePane.jsx
+++ b/src/Components/Agenda/AgendaItemMaintenancePane/AgendaItemMaintenancePane.jsx
@@ -316,7 +316,6 @@ const AgendaItemMaintenancePane = (props) => {
           }
         </select>
       </div>
-
       {combinedTod === 'X' && (
         <>
           <div />
@@ -326,7 +325,6 @@ const AgendaItemMaintenancePane = (props) => {
           </div>
         </>
       )}
-
     </>
   );
 
@@ -420,8 +418,8 @@ const AgendaItemMaintenancePane = (props) => {
                     </div>
                     {
                       showLegacyPanelMeetingDate ?
-                        <div className="">
-                          <span>{agendaItem?.pmt_code} {agendaItem?.pmd_dttm}</span>
+                        <div className="read-only-pmd">
+                          <span>{agendaItem?.pmt_code} {formatDate(agendaItem?.pmd_dttm)}</span>
                           {!readMode && <FA name="times" className="other-tod-icon" onClick={showPanelDatesDropdown} />}
                         </div>
                         :

--- a/src/sass/_agendaItemMaintenance.scss
+++ b/src/sass/_agendaItemMaintenance.scss
@@ -224,7 +224,7 @@
       div {
         display: flex;
         flex: 70%;
-        align-items: baseline;
+        align-items: center;
       }
 
       .select-label {
@@ -298,6 +298,10 @@
       font-size: 10px;
       align-self: center;
     }
+  }
+
+  .read-only-pmd {
+    height: 33px;
   }
 
   // ---- end: styling for left pane ----


### PR DESCRIPTION
If pmd on the agenda is no longer in the ref data for the dates - then just display the raw date and type of meeting. 

If in edit mode, display an x to remove the date and the date dropdowns will appear. No way to re-add old date unless you don't save and refresh the page. This is only relevant for agendas on pmd that are no longer active