### PR TITLE
TM-5564: Update Org to "Location/Org" on AIM/Panel

### DIFF
--- a/src/Components/Agenda/AgendaItemLegs/AgendaItemLegs.jsx
+++ b/src/Components/Agenda/AgendaItemLegs/AgendaItemLegs.jsx
@@ -68,7 +68,7 @@ const AgendaItemLegs = props => {
       cardView: false,
     },
     {
-      title: 'Org',
+      title: 'Location/Org',
       content: (getData('org', formatStr)),
       cardView: true,
     },

--- a/src/Components/Agenda/AgendaItemLegs/__snapshots__/AgendaItemLegs.test.jsx.snap
+++ b/src/Components/Agenda/AgendaItemLegs/__snapshots__/AgendaItemLegs.test.jsx.snap
@@ -25,11 +25,11 @@ exports[`AgendaItemLegs Component matches snapshot 1`] = `
         </th>
       </tr>
       <tr
-        key="Org"
+        key="Location/Org"
       >
         <th>
           <dt>
-            Org
+            Location/Org
           </dt>
         </th>
       </tr>

--- a/src/Components/Agenda/AgendaItemLegsForm/AgendaItemLegsForm.jsx
+++ b/src/Components/Agenda/AgendaItemLegsForm/AgendaItemLegsForm.jsx
@@ -39,7 +39,7 @@ const AgendaItemLegsForm = props => {
   const legHeaderData = [
     'Position Title',
     'Position Number',
-    'Org',
+    'Location/Org',
     'Grade',
     'Lang',
     'Skills',

--- a/src/Components/Agenda/AgendaItemLegsForm/AgendaItemLegsForm.jsx
+++ b/src/Components/Agenda/AgendaItemLegsForm/AgendaItemLegsForm.jsx
@@ -39,7 +39,7 @@ const AgendaItemLegsForm = props => {
   const legHeaderData = [
     'Position Title',
     'Position Number',
-    'Location/Org',
+    'Location/ Org',
     'Grade',
     'Lang',
     'Skills',

--- a/src/Components/Agenda/AgendaItemLegsForm/__snapshots__/AgendaItemLegsForm.test.jsx.snap
+++ b/src/Components/Agenda/AgendaItemLegsForm/__snapshots__/AgendaItemLegsForm.test.jsx.snap
@@ -28,12 +28,12 @@ exports[`AgendaItemLegs Component matches snapshot 1`] = `
       </InteractiveElement>
       <InteractiveElement
         className="grid-col-1 grid-row-4"
-        key="Org"
+        key="Location/ Org"
         onMouseLeave={[Function]}
         onMouseOver={[Function]}
         type="div"
       >
-        Org
+        Location/ Org
       </InteractiveElement>
       <InteractiveElement
         className="grid-col-1 grid-row-5"

--- a/src/Components/Agenda/AgendaItemLegsFormReadOnly/AgendaItemLegsFormReadOnly.jsx
+++ b/src/Components/Agenda/AgendaItemLegsFormReadOnly/AgendaItemLegsFormReadOnly.jsx
@@ -37,7 +37,7 @@ const AgendaItemLegsFormReadOnly = props => {
       content: (a => <div>{a?.pos_num || DEFAULT_TEXT}</div>),
     },
     {
-      title: 'Org',
+      title: 'Location/Org',
       content: (a => <div>{a?.org || DEFAULT_TEXT}</div>),
     },
     {

--- a/src/Components/Agenda/AgendaItemLegsFormReadOnly/AgendaItemLegsFormReadOnly.jsx
+++ b/src/Components/Agenda/AgendaItemLegsFormReadOnly/AgendaItemLegsFormReadOnly.jsx
@@ -37,7 +37,7 @@ const AgendaItemLegsFormReadOnly = props => {
       content: (a => <div>{a?.pos_num || DEFAULT_TEXT}</div>),
     },
     {
-      title: 'Location/Org',
+      title: 'Location/ Org',
       content: (a => <div>{a?.org || DEFAULT_TEXT}</div>),
     },
     {

--- a/src/Components/Agenda/AgendaItemLegsFormReadOnly/__snapshots__/AgendaItemLegsForm.test.jsx.snap
+++ b/src/Components/Agenda/AgendaItemLegsFormReadOnly/__snapshots__/AgendaItemLegsForm.test.jsx.snap
@@ -28,12 +28,12 @@ exports[`AgendaItemLegs Component matches snapshot 1`] = `
       </InteractiveElement>
       <InteractiveElement
         className="grid-col-1-read-only grid-row-3-read-only"
-        key="Org"
+        key="Location/ Org"
         onMouseLeave={[Function]}
         onMouseOver={[Function]}
         type="div"
       >
-        Org
+        Location/ Org
       </InteractiveElement>
       <InteractiveElement
         className="grid-col-1-read-only grid-row-4-read-only"
@@ -156,7 +156,7 @@ exports[`AgendaItemLegs Component matches snapshot 1`] = `
       </InteractiveElement>
       <InteractiveElement
         className="grid-col-2-read-only grid-row-3-read-only"
-        key="Org"
+        key="Location/ Org"
         onMouseLeave={[Function]}
         onMouseOver={[Function]}
         type="div"

--- a/src/Components/Agenda/AgendaLeg/AgendaLeg.jsx
+++ b/src/Components/Agenda/AgendaLeg/AgendaLeg.jsx
@@ -386,7 +386,7 @@ const AgendaLeg = props => {
       content: (<div>{defaultSepText || get(leg, 'pos_num') || DEFAULT_TEXT}</div>),
     },
     {
-      title: 'Org',
+      title: 'Location/Org',
       content: isSeparation ?
         getLocation()
         :

--- a/src/Components/Agenda/AgendaLeg/__snapshots__/AgendaLeg.test.jsx.snap
+++ b/src/Components/Agenda/AgendaLeg/__snapshots__/AgendaLeg.test.jsx.snap
@@ -40,7 +40,7 @@ exports[`AgendaLeg Component matches snapshot 1`] = `
   </InteractiveElement>
   <InteractiveElement
     className="grid-col-3 grid-row-4"
-    key="Org"
+    key="Location/Org"
     onMouseLeave={[Function]}
     onMouseOver={[Function]}
     type="div"

--- a/src/Components/Panel/PanelMeetingAgendas/PrintPanelMeetingAgendas.jsx
+++ b/src/Components/Panel/PanelMeetingAgendas/PrintPanelMeetingAgendas.jsx
@@ -153,7 +153,7 @@ const PrintPanelMeetingAgendas = ({ panelMeetingData, closePrintView, agendas })
                       <thead>
                         <tr>
                           <th>Action</th>
-                          <th>Org</th>
+                          <th>Location/Org</th>
                           <th>Position Number</th>
                           <th>Skill/Title</th>
                           <th>Grade</th>


### PR DESCRIPTION
ACs:
Update the Org field label to “Location/Org” on the following:
1. Agenda Item Maintenance
2. Agenda Item history
3. Panel Meeting Agenda items
4. Print View of Panel

[Ticket](https://metaphase.atlassian.net/browse/TM-5564)
