### PR TITLE
[TM-4542] Employee Profile Temporary Reversions

### DIFF
--- a/src/Containers/ProfilePublic/ProfilePublic.jsx
+++ b/src/Containers/ProfilePublic/ProfilePublic.jsx
@@ -52,8 +52,10 @@ class ProfilePublic extends Component {
     const viewType = get(this.props, 'match.params.viewType');
 
     let props = {};
-    // making the props isRequired essentially makes this a living document
-    // for profiles
+    // Making props isRequired makes this a living document for profiles
+    // Employee Profile Props:
+    // showRedactedProfilePreview is only applicable when showEmployeeProfileLinks is true
+    // when true, the employee profile link accesses the redacted version in the preview
     switch (viewType) {
       case 'bureau':
         props = {

--- a/src/Containers/ProfilePublic/ProfilePublic.jsx
+++ b/src/Containers/ProfilePublic/ProfilePublic.jsx
@@ -65,7 +65,7 @@ class ProfilePublic extends Component {
           canEditClassifications: false,
           showLanguages: true,
           showSearchAsClient: false,
-          showEmployeeProfileLinks: true,
+          showEmployeeProfileLinks: false, // Temporarily off (pending WS changes)
           showRedactedProfilePreview: true,
         };
         break;
@@ -79,7 +79,7 @@ class ProfilePublic extends Component {
           canEditClassifications: false,
           showLanguages: true,
           showSearchAsClient: false,
-          showEmployeeProfileLinks: true,
+          showEmployeeProfileLinks: false, // Temporarily off (pending WS changes)
           showRedactedProfilePreview: true,
         };
         break;


### PR DESCRIPTION
Updates:
- Temporarily set employee profile link props to false for bureau and props until WS makes changes

[TM-4542](https://metaphase.atlassian.net/browse/TM-4542)


[TM-4542]: https://metaphase.atlassian.net/browse/TM-4542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ