### PR TITLE
[TM-5691] Handling Legacy Values for Action and Travel

### DIFF
--- a/src/Components/Agenda/AgendaLegFormEdit/AgendaLegFormEdit.jsx
+++ b/src/Components/Agenda/AgendaLegFormEdit/AgendaLegFormEdit.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable indent */
 import PropTypes from 'prop-types';
 import { AI_VALIDATION, EMPTY_FUNCTION } from 'Constants/PropTypes';
 import { get, includes } from 'lodash';
@@ -202,80 +203,57 @@ const AgendaLegFormEdit = props => {
     });
   };
 
-  const getTravel = () => {
-    if (isEf) {
-      return (<div className="read-only">{leg?.travel_desc}</div>);
+  const getDropdown = (type) => {
+    // Attribute and constants to handle Travel dropdown
+    let showLegacy = showLegacyTravel;
+    let setShowLegacy = setShowLegacyTravelToFalse;
+    let refArray = travelFunctions;
+    let codeAttr = 'travel_code';
+    let descAttr = 'travel_desc';
+    let nullText = 'No Travel';
+    // Attribute and constants to handle Action dropdown
+    if (type === 'action') {
+      showLegacy = showLegacyAction;
+      setShowLegacy = setShowLegacyActionToFalse;
+      refArray = getLegActionTypes();
+      codeAttr = 'action_code';
+      descAttr = 'action';
+      nullText = 'Keep Unselected';
     }
 
-    return (
-      showLegacyTravel ?
-        <div>
-          {leg?.travel_desc}
-          <FA name="times" className="" onClick={() => setShowLegacyTravelToFalse('travel_code')} />
-        </div>
-        :
-        <div className="error-message-wrapper">
-          <div className="validation-error-message-label validation-error-message">
-            {legValidation?.travel_code?.errorMessage}
-          </div>
-          <div>
-            <select
-              className={`leg-dropdown ${legValidation?.travel_code?.valid ? '' : 'validation-error-border'}`}
-              value={leg?.travel_code || ''}
-              onChange={(e) => updateDropdown('travel_code', e.target.value)}
-              disabled={disabled}
-            >
-              <option key={null} value={''}>
-                No Travel
-              </option>
-              {
-                travelFunctions.map((a, i) => {
-                  const keyId = `${a?.code}-${i}`;
-                  return <option key={keyId} value={a?.code}>{a?.desc_text}</option>;
-                })
-              }
-            </select>
-          </div>
-        </div>
-    );
-  };
-  const getAction = () => {
     if (isEf) {
-      return (<div className="read-only">{leg?.action || 'None listed'}</div>);
+      return (<div className="read-only">{leg?.[descAttr] || 'None listed'}</div>);
     }
 
-    return (
-      showLegacyAction ?
+    return (showLegacy ?
+      <div>
+        {leg?.[descAttr]}
+        <FA name="times" className="" onClick={() => setShowLegacy(codeAttr)} />
+      </div> :
+      <div className="error-message-wrapper">
+        <div className="validation-error-message-label validation-error-message">
+          {legValidation?.[codeAttr]?.errorMessage}
+        </div>
         <div>
-          {leg?.action}
-          <FA name="times" className="" onClick={() => setShowLegacyActionToFalse('action_code')} />
+          <select
+            className={`leg-dropdown ${legValidation?.[codeAttr]?.valid ? '' : 'validation-error-border'}`}
+            value={leg?.[codeAttr] || ''}
+            onChange={(e) => updateDropdown(codeAttr, e.target.value)}
+            disabled={disabled}
+          >
+            <option key={null} value={''}>
+              {nullText}
+            </option>
+            {refArray.map((a, i) => {
+              const keyId = `${a?.code}-${i}`;
+              return <option key={keyId} value={a?.code}>{a?.desc_text}</option>;
+            })}
+          </select>
         </div>
-        :
-        <div className="error-message-wrapper">
-          <div className="validation-error-message-label validation-error-message">
-            {legValidation?.action_code?.errorMessage}
-          </div>
-          <div>
-            <select
-              className={`leg-dropdown ${legValidation?.action_code?.valid ? '' : 'validation-error-border'}`}
-              value={leg?.action_code || ''}
-              onChange={(e) => updateDropdown('action_code', e.target.value)}
-              disabled={disabled}
-            >
-              <option key={null} value={''}>
-                Keep Unselected
-              </option>
-              {
-                getLegActionTypes().map((a, i) => {
-                  const keyId = `${a?.code}-${i}`;
-                  return <option key={keyId} value={a?.code}>{a?.abbr_desc_text}</option>;
-                })
-              }
-            </select>
-          </div>
-        </div>
+      </div>
     );
   };
+
 
   const closeOtherTod = () => {
     updateLeg(leg?.ail_seq_num, {
@@ -427,7 +405,7 @@ const AgendaLegFormEdit = props => {
   const columnData = [
     {
       title: 'Action',
-      content: (getAction()),
+      content: (getDropdown('action')),
     },
     {
       title: 'Position Title',
@@ -470,7 +448,7 @@ const AgendaLegFormEdit = props => {
     },
     {
       title: 'Travel',
-      content: (getTravel()),
+      content: (getDropdown()),
     },
     {
       title: 'Vice',

--- a/src/Components/Agenda/AgendaLegFormEdit/AgendaLegFormEdit.jsx
+++ b/src/Components/Agenda/AgendaLegFormEdit/AgendaLegFormEdit.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable indent */
 import PropTypes from 'prop-types';
 import { AI_VALIDATION, EMPTY_FUNCTION } from 'Constants/PropTypes';
 import { get, includes } from 'lodash';
@@ -38,10 +37,7 @@ const AgendaLegFormEdit = props => {
   const legValidation = AIvalidation?.legs?.individualLegs?.[leg?.ail_seq_num];
   const disabled = isEf;
 
-
-  const getLegActionTypes = () => (
-    legActionTypes.filter(lat => lat.is_separation === isSeparation)
-  );
+  const getLegActionTypes = legActionTypes.filter(lat => lat.is_separation === isSeparation);
 
   const isLegacyValue = (val, data) => {
     if (['', null, undefined].includes(val)) return false;
@@ -49,7 +45,7 @@ const AgendaLegFormEdit = props => {
   };
 
   const [showLegacyAction, setShowLegacyAction] = useState(
-    isLegacyValue(leg?.action_code, getLegActionTypes()));
+    isLegacyValue(leg?.action_code, getLegActionTypes));
   const [showLegacyTravel, setShowLegacyTravel] = useState(
     isLegacyValue(leg?.travel_code, travelFunctions));
 
@@ -215,7 +211,7 @@ const AgendaLegFormEdit = props => {
     if (type === 'action') {
       showLegacy = showLegacyAction;
       setShowLegacy = setShowLegacyActionToFalse;
-      refArray = getLegActionTypes();
+      refArray = getLegActionTypes;
       codeAttr = 'action_code';
       descAttr = 'action';
       nullText = 'Keep Unselected';

--- a/src/Components/Agenda/AgendaLegFormEdit/AgendaLegFormEdit.jsx
+++ b/src/Components/Agenda/AgendaLegFormEdit/AgendaLegFormEdit.jsx
@@ -306,36 +306,6 @@ const AgendaLegFormEdit = props => {
     );
   };
 
-  const getActionDropdown = () => {
-    const actionOptions = getLegActionTypes();
-    if (isEf) {
-      return <div className="read-only">{leg.action_code || 'None listed'}</div>;
-    }
-
-    return (
-      <div className="error-message-wrapper">
-        <div className="validation-error-message-label validation-error-message">
-          {AIvalidation?.legs?.individualLegs?.[leg?.ail_seq_num]?.action_code?.errorMessage}
-        </div>
-        <div>
-          <select
-            className={`leg-dropdown ${AIvalidation?.legs?.individualLegs?.[leg?.ail_seq_num]?.action_code?.valid ? '' : 'validation-error-border'}`}
-            value={leg?.action_code}
-            onChange={(e) => updateDropdown('action_code', e.target.value)}
-            disabled={disabled}
-          >
-            {
-              actionOptions.map((action) => {
-                const { code, abbr_desc_text } = action;
-                return <option key={code} value={code}>{abbr_desc_text}</option>;
-              })
-            }
-          </select>
-        </div>
-      </div>
-    );
-  };
-
   const onAddLocationClick = () => {
     setActiveAIL(leg?.ail_seq_num);
     setLegsContainerExpanded(false);

--- a/src/Components/Agenda/AgendaLegFormEdit/__snapshots__/AgendaLegFormEdit.test.jsx.snap
+++ b/src/Components/Agenda/AgendaLegFormEdit/__snapshots__/AgendaLegFormEdit.test.jsx.snap
@@ -34,7 +34,15 @@ exports[`AgendaLeg Component matches snapshot 1`] = `
           className="leg-dropdown validation-error-border"
           disabled={false}
           onChange={[Function]}
-        />
+          value=""
+        >
+          <option
+            key="null"
+            value=""
+          >
+            Keep Unselected
+          </option>
+        </select>
       </div>
     </div>
   </InteractiveElement>


### PR DESCRIPTION
[TM-5691](https://metaphase.atlassian.net/browse/TM-5691)

When we get a legacy value for Action or Travel, we will now handle it like we do legacy Panel Date values:
- add legacy value to form as text (instead of pushing into dropdown)
- allow user to remove the legacy value
- once legacy value removed, show user the regular dropdown - making sure to trigger the validation


I found it useful to do something like this on API to see a legacy value:
in `agenda.py` `fsbid_legs_to_talentmap_legs()` before the res return
just update 1234 to be one of the ail_seq_num of the Agenda ur looking at in AIM
```
    sophie = 3333 if pydash.get(data, "ailseqnum", None) == 1234 else data.get("ailtfcd")
    elsa = 'i am legacy' if pydash.get(data, "ailseqnum", None) == 1234 else map_tf(pydash.get(data, "ailtfcd", None))
```
and in res{}
```
        "travel_code": sophie,
        "travel_desc": elsa, # pending change when WS adds 3.11
```


[TM-5541]: https://metaphase.atlassian.net/browse/TM-5541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[TM-5691]: https://metaphase.atlassian.net/browse/TM-5691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ