### PR TITLE
TM-5676-Bid-Audit-UI

### DIFF
--- a/src/Components/AdministratorPage/bidAudit/BidAuditCard.jsx
+++ b/src/Components/AdministratorPage/bidAudit/BidAuditCard.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { get } from 'lodash';
-import { Link } from 'react-router-dom';
 import DatePicker from 'react-datepicker';
 import FA from 'react-fontawesome';
 import TextareaAutosize from 'react-textarea-autosize';
@@ -278,7 +277,7 @@ const BidAuditCard = ({ result, id, onEditModeSearch, atGrades, inCategories }) 
       { 'Audit Number': result.id || NO_BUREAU },
       { 'Description': result.description || NO_SKILL },
       { 'Posted': result.bid_audit_date || NO_POSITION_TITLE },
-      { '': <span><FA name="pencil" /><Link to="#" onClick={onNewAtGrades}>Edit</Link></span> },
+      { '': <button className="toggle-edit-mode" onClick={onNewAtGrades}><FA name="pencil" /><div>Edit</div></button> },
     ],
     bodyPrimary: [
       { '': <BidAuditSections rows={atGrades} onEditChange={onEditChange} /> },
@@ -357,7 +356,7 @@ const BidAuditCard = ({ result, id, onEditModeSearch, atGrades, inCategories }) 
       { 'Audit Number': result.id || NO_BUREAU },
       { 'Description': result.description || NO_SKILL },
       { 'Posted': result.bid_audit_date || NO_POSITION_TITLE },
-      { '': <span><FA name="pencil" /><Link to="#" onClick={onNewInCateogries}>Edit</Link></span> },
+      { '': <button className="toggle-edit-mode" onClick={onNewInCateogries}><FA name="pencil" /><div>Edit</div></button> },
     ],
     bodyPrimary: [
       { '': <BidAuditSections rows={inCategories} onEditChange={onEditChange} /> },

--- a/src/Components/AdministratorPage/bidAudit/BidAuditCard.jsx
+++ b/src/Components/AdministratorPage/bidAudit/BidAuditCard.jsx
@@ -277,7 +277,7 @@ const BidAuditCard = ({ result, id, onEditModeSearch, atGrades, inCategories }) 
       { 'Audit Number': result.id || NO_BUREAU },
       { 'Description': result.description || NO_SKILL },
       { 'Posted': result.bid_audit_date || NO_POSITION_TITLE },
-      { '': <button className="toggle-edit-mode" onClick={onNewAtGrades}><FA name="pencil" /><div>Edit</div></button> },
+      { '': <button className="toggle-edit-mode edit-position" onClick={onNewAtGrades}><FA name="pencil" /><div>Edit</div></button> },
     ],
     bodyPrimary: [
       { '': <BidAuditSections rows={atGrades} onEditChange={onEditChange} /> },
@@ -356,7 +356,7 @@ const BidAuditCard = ({ result, id, onEditModeSearch, atGrades, inCategories }) 
       { 'Audit Number': result.id || NO_BUREAU },
       { 'Description': result.description || NO_SKILL },
       { 'Posted': result.bid_audit_date || NO_POSITION_TITLE },
-      { '': <button className="toggle-edit-mode" onClick={onNewInCateogries}><FA name="pencil" /><div>Edit</div></button> },
+      { '': <button className="toggle-edit-mode edit-position" onClick={onNewInCateogries}><FA name="pencil" /><div>Edit</div></button> },
     ],
     bodyPrimary: [
       { '': <BidAuditSections rows={inCategories} onEditChange={onEditChange} /> },

--- a/src/Components/AdministratorPage/bidAudit/BidAuditCard.jsx
+++ b/src/Components/AdministratorPage/bidAudit/BidAuditCard.jsx
@@ -278,7 +278,7 @@ const BidAuditCard = ({ result, id, onEditModeSearch, atGrades, inCategories }) 
       { 'Audit Number': result.id || NO_BUREAU },
       { 'Description': result.description || NO_SKILL },
       { 'Posted': result.bid_audit_date || NO_POSITION_TITLE },
-      { '': <Link to="#" onClick={onNewAtGrades}>Edit</Link> },
+      { '': <span><FA name="pencil" /><Link to="#" onClick={onNewAtGrades}>Edit</Link></span> },
     ],
     bodyPrimary: [
       { '': <BidAuditSections rows={atGrades} onEditChange={onEditChange} /> },
@@ -357,7 +357,7 @@ const BidAuditCard = ({ result, id, onEditModeSearch, atGrades, inCategories }) 
       { 'Audit Number': result.id || NO_BUREAU },
       { 'Description': result.description || NO_SKILL },
       { 'Posted': result.bid_audit_date || NO_POSITION_TITLE },
-      { '': <Link to="#" onClick={onNewInCateogries}>Edit</Link> },
+      { '': <span><FA name="pencil" /><Link to="#" onClick={onNewInCateogries}>Edit</Link></span> },
     ],
     bodyPrimary: [
       { '': <BidAuditSections rows={inCategories} onEditChange={onEditChange} /> },

--- a/src/Components/AdministratorPage/bidAudit/BidAuditCard.jsx
+++ b/src/Components/AdministratorPage/bidAudit/BidAuditCard.jsx
@@ -278,7 +278,7 @@ const BidAuditCard = ({ result, id, onEditModeSearch, atGrades, inCategories }) 
       { 'Audit Number': result.id || NO_BUREAU },
       { 'Description': result.description || NO_SKILL },
       { 'Posted': result.bid_audit_date || NO_POSITION_TITLE },
-      { '': <Link to="#" onClick={onNewAtGrades}>Add New At Grade</Link> },
+      { '': <Link to="#" onClick={onNewAtGrades}>Edit</Link> },
     ],
     bodyPrimary: [
       { '': <BidAuditSections rows={atGrades} onEditChange={onEditChange} /> },
@@ -357,7 +357,7 @@ const BidAuditCard = ({ result, id, onEditModeSearch, atGrades, inCategories }) 
       { 'Audit Number': result.id || NO_BUREAU },
       { 'Description': result.description || NO_SKILL },
       { 'Posted': result.bid_audit_date || NO_POSITION_TITLE },
-      { '': <Link to="#" onClick={onNewInCateogries}>Add New In Category</Link> },
+      { '': <Link to="#" onClick={onNewInCateogries}>Edit</Link> },
     ],
     bodyPrimary: [
       { '': <BidAuditSections rows={inCategories} onEditChange={onEditChange} /> },

--- a/src/Components/AdministratorPage/bidAudit/BidAuditCard.jsx
+++ b/src/Components/AdministratorPage/bidAudit/BidAuditCard.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { Link } from 'react-router-dom';
 import { get } from 'lodash';
 import DatePicker from 'react-datepicker';
 import FA from 'react-fontawesome';
@@ -277,7 +278,7 @@ const BidAuditCard = ({ result, id, onEditModeSearch, atGrades, inCategories }) 
       { 'Audit Number': result.id || NO_BUREAU },
       { 'Description': result.description || NO_SKILL },
       { 'Posted': result.bid_audit_date || NO_POSITION_TITLE },
-      { '': <button className="toggle-edit-mode edit-position" onClick={onNewAtGrades}><FA name="pencil" /><div>Edit</div></button> },
+      { '': <Link to="#" onClick={onNewAtGrades}>Add New At Grade</Link> },
     ],
     bodyPrimary: [
       { '': <BidAuditSections rows={atGrades} onEditChange={onEditChange} /> },
@@ -356,7 +357,7 @@ const BidAuditCard = ({ result, id, onEditModeSearch, atGrades, inCategories }) 
       { 'Audit Number': result.id || NO_BUREAU },
       { 'Description': result.description || NO_SKILL },
       { 'Posted': result.bid_audit_date || NO_POSITION_TITLE },
-      { '': <button className="toggle-edit-mode edit-position" onClick={onNewInCateogries}><FA name="pencil" /><div>Edit</div></button> },
+      { '': <Link to="#" onClick={onNewInCateogries}>Add New In Category</Link> },
     ],
     bodyPrimary: [
       { '': <BidAuditSections rows={inCategories} onEditChange={onEditChange} /> },
@@ -425,7 +426,6 @@ const BidAuditCard = ({ result, id, onEditModeSearch, atGrades, inCategories }) 
             <PositionExpandableContent
               sections={atGradesSections}
               form={atGradesForm}
-              tempHideEdit
               saveText="Save At Grade"
             />
           </div>
@@ -439,7 +439,6 @@ const BidAuditCard = ({ result, id, onEditModeSearch, atGrades, inCategories }) 
             <PositionExpandableContent
               sections={inCategoriesSections}
               form={inCategoriesForm}
-              tempHideEdit
               saveText="Save In Category"
             />
           </div>

--- a/src/Components/AdministratorPage/bidAudit/BidAuditCard.jsx
+++ b/src/Components/AdministratorPage/bidAudit/BidAuditCard.jsx
@@ -413,6 +413,7 @@ const BidAuditCard = ({ result, id, onEditModeSearch, atGrades, inCategories }) 
             <PositionExpandableContent
               sections={bidAuditSections}
               form={bidAuditForm}
+              saveText="Save Audit Cycle"
             />
           </div>
         ),
@@ -426,6 +427,7 @@ const BidAuditCard = ({ result, id, onEditModeSearch, atGrades, inCategories }) 
               sections={atGradesSections}
               form={atGradesForm}
               tempHideEdit
+              saveText="Save At Grade"
             />
           </div>
         ),
@@ -439,6 +441,7 @@ const BidAuditCard = ({ result, id, onEditModeSearch, atGrades, inCategories }) 
               sections={inCategoriesSections}
               form={inCategoriesForm}
               tempHideEdit
+              saveText="Save In Category"
             />
           </div>
         ),

--- a/src/Components/AdministratorPage/bidAudit/BidAuditSections/BidAuditSections.jsx
+++ b/src/Components/AdministratorPage/bidAudit/BidAuditSections/BidAuditSections.jsx
@@ -18,7 +18,7 @@ const BidAuditSections = ({ onEditChange, rows }) => {
       />
       {rows.map((row) => (
         <div key={row?.header}>
-          <h5 className="bid-audit-headers">{row?.header}</h5>
+          <dt className="bid-audit-headers">{row?.header}</dt>
           <div className="bid-audit-card-rows">
             {row?.row3data &&
             <div className="bid-audit-contents-container">

--- a/src/Components/PositionExpandableContent/PositionExpandableContent.jsx
+++ b/src/Components/PositionExpandableContent/PositionExpandableContent.jsx
@@ -101,7 +101,7 @@ const PositionExpandableContent = ({
                     const key = Object.keys(item)[0];
                     return (
                       <div key={`subheading-${key}`}>
-                        <span>{key}:</span>
+                        <span>{key && `${key} :`}</span>
                         <span>{item[key]}</span>
                       </div>
                     );

--- a/src/Components/PositionExpandableContent/PositionExpandableContent.jsx
+++ b/src/Components/PositionExpandableContent/PositionExpandableContent.jsx
@@ -12,7 +12,7 @@ import { Definition } from '../DefinitionList';
 
 const PositionExpandableContent = ({
   sections, form, appendAdditionalFieldsToBodyPrimary, tempHideEdit,
-  showLoadingAnimation, onShowMore, isCondensed }) => {
+  showLoadingAnimation, onShowMore, isCondensed, saveText }) => {
   const handleEdit = form?.handleEdit ?? {};
   const { editMode, setEditMode, disableEdit } = handleEdit;
 
@@ -163,7 +163,7 @@ const PositionExpandableContent = ({
               {form.inputBody}
               <div className="position-form--actions">
                 <button onClick={showCancelModal}>Cancel</button>
-                <button onClick={form.handleSubmit}>Save Position</button>
+                <button onClick={form.handleSubmit}>{saveText}</button>
               </div>
             </div>
             }
@@ -199,6 +199,7 @@ PositionExpandableContent.propTypes = {
     textarea: PropTypes.string,
     metadata: PropTypes.arrayOf(PropTypes.shape({})),
   }),
+  saveText: PropTypes.string,
   form: PropTypes.shape({
     staticBody: PropTypes.arrayOf(PropTypes.shape({})),
     inputBody: PropTypes.element,
@@ -221,6 +222,7 @@ PositionExpandableContent.propTypes = {
 PositionExpandableContent.defaultProps = {
   form: undefined,
   sections: undefined,
+  saveText: 'Save Position',
   appendAdditionalFieldsToBodyPrimary: true,
   showLoadingAnimation: false,
   tempHideEdit: false,

--- a/src/sass/_bidAudit.scss
+++ b/src/sass/_bidAudit.scss
@@ -23,6 +23,7 @@
       display: grid;
       grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
       .filter-div {
+        font-size: 15px;
         width: 400px;
       }
     }

--- a/src/sass/_positionContent.scss
+++ b/src/sass/_positionContent.scss
@@ -42,15 +42,6 @@
     &.no-space {
       justify-content: flex-start !important;
     }
-    .line-separated-fields {
-      .edit-position {
-        position: absolute;
-        right: 0;
-        span {
-          margin: 0px;
-        }
-      }
-    }
   }
 
   .title-link {

--- a/src/sass/_positionContent.scss
+++ b/src/sass/_positionContent.scss
@@ -42,6 +42,15 @@
     &.no-space {
       justify-content: flex-start !important;
     }
+    .line-separated-fields {
+      .edit-position {
+        position: absolute;
+        right: 0;
+        span {
+          margin: 0px;
+        }
+      }
+    }
   }
 
   .title-link {
@@ -424,11 +433,12 @@
     flex-direction: row;
     flex-wrap: wrap;
 
-    .span-label {
+    span:first-of-type {
       font-weight: 500;
       padding-right: 5px;
     }
-    .span-label, .span-text {
+
+    span {
       font-size: 15px;
     }
 

--- a/src/sass/_positionContent.scss
+++ b/src/sass/_positionContent.scss
@@ -424,12 +424,12 @@
     flex-direction: row;
     flex-wrap: wrap;
 
-    span:first-of-type {
+    .span-label {
       font-weight: 500;
       padding-right: 5px;
     }
 
-    span {
+    .span-label, .span-text {
       font-size: 15px;
     }
 


### PR DESCRIPTION
[Ticket](https://metaphase.atlassian.net/browse/TM-5676)

- [x] On the Bid Audit edit form update the Save button from “Save Position” to “Save Audit Cycle”
- [x] On the At Grades tab update the Position, Employee and Tenure fields fonts to be the same as the rest of the card
- [x] On the At Grades edit form update the Save button from “Save Position” to “Save At Grade”
- [x] On the In Categories tab update the Position and Employee fields fonts to be the same as the rest of the card
- [x] On the In Categories edit form update the Save button from “Save Position” to “Save In Category”
- [x] On the At Grades and In Categories tabs update the edit buttons to the same edit button as on the Bid Audit tab