### PR TITLE
field changes for Publishable Positions

### DIFF
--- a/src/Components/PublishablePositionCard/PublishablePositionCard.jsx
+++ b/src/Components/PublishablePositionCard/PublishablePositionCard.jsx
@@ -32,6 +32,16 @@ const PublishablePositionCard = ({
   additionalCallsLoading, onShowMorePP }) => {
   // =============== Overview: View Mode ===============
 
+  const additionalRO = [
+    { TED: data?.status || DEFAULT_TEXT },
+    { Incumbent: data?.status || DEFAULT_TEXT },
+    { 'Default TOD': data?.status || DEFAULT_TEXT },
+    { Assignee: data?.status || DEFAULT_TEXT },
+    { 'Post Differential | Danger Pay': data?.status || DEFAULT_TEXT },
+    { 'Employee ID': data?.status || DEFAULT_TEXT },
+    { 'Employee Status': data?.status || DEFAULT_TEXT },
+  ];
+
   const sections = {
     /* eslint-disable quote-props */
     subheading: [
@@ -49,13 +59,7 @@ const PublishablePositionCard = ({
     bodySecondary: PP_FLAG() ?
       [
         { 'Bid Cycle': data?.status || DEFAULT_TEXT },
-        { 'TED': data?.status || DEFAULT_TEXT },
-        { 'Incumbent': data?.status || DEFAULT_TEXT },
-        { 'Default TOD': data?.status || DEFAULT_TEXT },
-        { 'Assignee': data?.status || DEFAULT_TEXT },
-        { 'Post Differential | Danger Pay': data?.status || DEFAULT_TEXT },
-        { 'Employee ID': data?.status || DEFAULT_TEXT },
-        { 'Employee Status': data?.status || DEFAULT_TEXT },
+        ...additionalRO,
       ]
       : [],
     textarea: data?.positionDetails || 'No description.',
@@ -252,15 +256,7 @@ const PublishablePositionCard = ({
   };
 
   if (PP_FLAG()) {
-    form.staticBody.push(
-      { TED: data?.status || DEFAULT_TEXT },
-      { Incumbent: data?.status || DEFAULT_TEXT },
-      { 'Default TOD': data?.status || DEFAULT_TEXT },
-      { Assignee: data?.status || DEFAULT_TEXT },
-      { 'Post Differential | Danger Pay': data?.status || DEFAULT_TEXT },
-      { 'Employee ID': data?.status || DEFAULT_TEXT },
-      { 'Employee Status': data?.status || DEFAULT_TEXT },
-    );
+    form.staticBody.push(...additionalRO);
   }
 
   return (

--- a/src/Components/PublishablePositionCard/PublishablePositionCard.jsx
+++ b/src/Components/PublishablePositionCard/PublishablePositionCard.jsx
@@ -5,7 +5,7 @@ import Picky from 'react-picky';
 import PropTypes from 'prop-types';
 import { Tooltip } from 'react-tippy';
 import { BID_CYCLES, EMPTY_FUNCTION, POSITION_DETAILS } from 'Constants/PropTypes';
-import { formatDateFromStr, renderSelectionList } from 'utilities';
+import { formatDateFromStr, ppGrade, renderSelectionList } from 'utilities';
 import { DEFAULT_TEXT } from 'Constants/SystemMessages';
 import { Row } from 'Components/Layout';
 import CheckBox from 'Components/CheckBox';
@@ -42,19 +42,20 @@ const PublishablePositionCard = ({
     bodyPrimary: [
       { 'Bureau': data?.bureau || DEFAULT_TEXT },
       { 'Organization': data?.org || DEFAULT_TEXT },
-      { 'Grade': data?.grade || DEFAULT_TEXT },
-      { 'Status': data?.status || DEFAULT_TEXT },
+      { 'PP/Grade': ppGrade(data?.payPlan, data?.grade) },
+      { 'Publishable Status': data?.status || DEFAULT_TEXT },
       { 'Language': data?.language || DEFAULT_TEXT },
-      { 'Pay Plan': data?.payPlan || DEFAULT_TEXT },
     ],
     bodySecondary: PP_FLAG() ?
       [
         { 'Bid Cycle': data?.status || DEFAULT_TEXT },
         { 'TED': data?.status || DEFAULT_TEXT },
         { 'Incumbent': data?.status || DEFAULT_TEXT },
-        { 'Tour of Duty': data?.status || DEFAULT_TEXT },
+        { 'Default TOD': data?.status || DEFAULT_TEXT },
         { 'Assignee': data?.status || DEFAULT_TEXT },
         { 'Post Differential | Danger Pay': data?.status || DEFAULT_TEXT },
+        { 'Employee ID': data?.status || DEFAULT_TEXT },
+        { 'Employee Status': data?.status || DEFAULT_TEXT },
       ]
       : [],
     textarea: data?.positionDetails || 'No description.',
@@ -117,10 +118,8 @@ const PublishablePositionCard = ({
     staticBody: [
       { 'Bureau': data?.bureau || DEFAULT_TEXT },
       { 'Organization': data?.org || DEFAULT_TEXT },
-      { 'Grade': data?.grade || DEFAULT_TEXT },
-      { 'Status': data?.status || DEFAULT_TEXT },
+      { 'PP/Grade': ppGrade(data?.payPlan, data?.grade) },
       { 'Language': data?.language || DEFAULT_TEXT },
-      { 'Pay Plan': data?.payPlan || DEFAULT_TEXT },
     ],
     inputBody: (
       <div className="position-form">
@@ -128,7 +127,7 @@ const PublishablePositionCard = ({
           <div className="spaced-row">
             <div className="dropdown-container">
               <div className="position-form--input">
-                <label htmlFor="publishable-position-statuses">Status</label>
+                <label htmlFor="publishable-position-statuses">Publishable Status</label>
                 <select
                   id="publishable-position-statuses"
                   defaultValue={status}
@@ -142,7 +141,7 @@ const PublishablePositionCard = ({
                 </select>
               </div>
               <div className="position-form--input">
-                <label htmlFor="publishable-pos-tod-override">Override Tour of Duty</label>
+                <label htmlFor="publishable-pos-tod-override">Override Position TOD</label>
                 <select
                   id="publishable-pos-tod-override"
                   defaultValue={overrideTOD}
@@ -201,7 +200,7 @@ const PublishablePositionCard = ({
           <>
             <div className="content-divider" />
             <div className="position-form--heading">
-              <span className="title">Future Cycle</span>
+              <span className="title">Proposed Cycle</span>
               <span className="subtitle">Please identify a cycle to add this position to.</span>
             </div>
             <div className="position-form--picky">
@@ -251,6 +250,18 @@ const PublishablePositionCard = ({
     },
     /* eslint-enable quote-props */
   };
+
+  if (PP_FLAG()) {
+    form.staticBody.push(
+      { TED: data?.status || DEFAULT_TEXT },
+      { Incumbent: data?.status || DEFAULT_TEXT },
+      { 'Default TOD': data?.status || DEFAULT_TEXT },
+      { Assignee: data?.status || DEFAULT_TEXT },
+      { 'Post Differential | Danger Pay': data?.status || DEFAULT_TEXT },
+      { 'Employee ID': data?.status || DEFAULT_TEXT },
+      { 'Employee Status': data?.status || DEFAULT_TEXT },
+    );
+  }
 
   return (
     <TabbedCard

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1123,4 +1123,21 @@ export const joinIfThere = (array, defaultText = 'None Listed', orderMatters = f
   return defaultText;
 };
 
+/*
+  Search Tags: pay plan grade, pp/grade, format pay plan, format grade, format pp
+
+  Examples:
+  ('FP', '02')    ->  'FP/02'
+  (falsy, falsy)  ->  'None Listed'
+  (falsy, '02')   ->  'None Listed/02'
+  ('FP', falsy)   ->  'FP/None Listed'
+*/
+export const ppGrade = (pp, grade) => {
+  const defaultText = 'None Listed';
+  if (!pp && !grade) {
+    return defaultText;
+  }
+  return `${pp || defaultText}/${grade || defaultText}`;
+};
+
 // Search Tags: common.js, helper file, helper functions, common helper file, common file

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1137,7 +1137,7 @@ export const ppGrade = (pp, grade) => {
   if (!pp && !grade) {
     return defaultText;
   }
-  return `${pp || defaultText}/${grade || defaultText}`;
+  return `${pp || defaultText} ${grade || defaultText}`;
 };
 
 // Search Tags: common.js, helper file, helper functions, common helper file, common file


### PR DESCRIPTION
[TM-5833](https://metaphase.atlassian.net/browse/TM-5833)

1. Rename the following read only fields:
    - [ ] ~Organization → Location/Org~ - we do not currently show location org, just org, so it doesn’t make sense to rename this
    - [x] Status → Publishable Status
    - [ ] ~Language → Language/Training~ - we do not currently show training, just language, so it doesn’t make sense to rename this
    - [x] Tour of Duty → Default TOD
2. Rename the following edit form fields:
    - [x] Override Tour of Duty → Override Position TOD
    - [x] Future Cycle → Proposed Cycle
    - [x] Add Default TOD to Edit form
    - [x] Status → Publishable Status
    - [x] Removed Status from the read-only part of the Edit Form, since that value is editable and is presented in a dropdown
3. Add the following fields to read-only section - added them statically to the edit form, as well to avoid confusion
    - [x] Employee ID
        * This is the Incumbent’s employee ID
    - [x] Employee Status 
        * ex: Effected
        * This is the Incumbent’s status
4. Combine Pay Plan and Grade fields
    - [x] PP/Grade
5. - [x] Added missing static fields to the Edit mode to not have fields disappearing on the user when they flip to edit mode

[TM-5833]: https://metaphase.atlassian.net/browse/TM-5833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ