### PR TITLE
TM-5228-Unassigned-Bidders

### DIFF
--- a/src/actions/bidderPortfolio.js
+++ b/src/actions/bidderPortfolio.js
@@ -216,13 +216,13 @@ export function bidderPortfolioFetchData(query = {}) {
       query$ = omit(query$, ['hasHandshake']);
       const UAvalues = unassigned.map(a => a.value);
       if (includes(UAvalues, 'noHandshake')) {
-        query$.hasHandshake = false;
+        query$.hasHandshake = 'N';
       }
       if (includes(UAvalues, 'noPanel')) {
-        query$.noPanel = true;
+        query$.noPanel = 'Y';
       }
       if (includes(UAvalues, 'noBids')) {
-        query$.noBids = true;
+        query$.noBids = 'Y';
       }
     }
     if (!query$.ordering) {


### PR DESCRIPTION
[Ticket](https://metaphase.atlassian.net/browse/TM-5228)

Values from the FE being passed back were boolean, but needed to be strings per request of Pat(WS). This needed to be changed for all unassigned bidder options.

![Screenshot 2024-04-04 at 2 14 12 PM](https://github.com/MetaPhase-Consulting/State-TalentMAP/assets/135657303/66b897ad-32f0-4fb7-b7d9-83d9267a9ad2)
