### PR TITLE
[TM-5975] Projected Vacancy Bugs

### DIFF
--- a/src/Components/BureauPage/ProjectedVacancy/ProjectedVacancy.jsx
+++ b/src/Components/BureauPage/ProjectedVacancy/ProjectedVacancy.jsx
@@ -352,7 +352,7 @@ const ProjectedVacancy = ({ isAO }) => {
       {disableSearch &&
         <Alert
           type="warning"
-          title={'Edit Mode (Search and Adding to Proposed Cycle Disabled)'}
+          title={'Edit Mode'}
           customClassName="mb-10"
           messages={[{
             body: 'Discard or save your edits before searching, adding to proposed cycle, or editing other projected vacancies. ' +

--- a/src/Components/BureauPage/ProjectedVacancy/ProjectedVacancy.jsx
+++ b/src/Components/BureauPage/ProjectedVacancy/ProjectedVacancy.jsx
@@ -119,6 +119,8 @@ const ProjectedVacancy = ({ isAO }) => {
     let overlay;
     if (resultsLoading) {
       overlay = <Spinner type="standard-center" class="homepage-position-results" size="big" />;
+    } else if (positionsData?.length > 500) {
+      overlay = <Alert type="error" title="Result Load Reached Limit" messages={[{ body: 'The number of searched projected vacancies is too high to be displayed. Please refine the filter criteria.' }]} />;
     } else if (resultsErrored) {
       overlay = <Alert type="error" title="Error displaying Projected Vacancies" messages={[{ body: 'Please try again.' }]} />;
     } else if (!filterSelectionValid()) {

--- a/src/Components/BureauPage/ProjectedVacancy/ProjectedVacancy.jsx
+++ b/src/Components/BureauPage/ProjectedVacancy/ProjectedVacancy.jsx
@@ -397,7 +397,7 @@ const ProjectedVacancy = ({ isAO }) => {
                 key={k.future_vacancy_seq_num}
                 updateIncluded={onIncludedUpdate}
                 disableIncluded={disableSearch || isAO}
-                disableEdit={includedInEditMode}
+                disableEdit={includedInEditMode || disableSearch}
                 onEditModeSearch={(editMode, id) =>
                   onEditModeSearch(editMode, id, setCardsInEditMode, cardsInEditMode)
                 }

--- a/src/Components/BureauPage/ProjectedVacancy/ProjectedVacancy.jsx
+++ b/src/Components/BureauPage/ProjectedVacancy/ProjectedVacancy.jsx
@@ -355,8 +355,8 @@ const ProjectedVacancy = ({ isAO }) => {
           title={'Edit Mode (Search and Adding to Proposed Cycle Disabled)'}
           customClassName="mb-10"
           messages={[{
-            body: 'Discard or save your edits before searching or adding to proposed cycle. ' +
-              'Filters and included checkbox inputs are disabled if any cards are in Edit Mode.',
+            body: 'Discard or save your edits before searching, adding to proposed cycle, or editing other projected vacancies. ' +
+              'Filters, "Included" checkboxes, and other edit buttons are disabled if one card is in Edit Mode.',
           }]}
         />
       }

--- a/src/Components/BureauPage/ProjectedVacancy/ProjectedVacancy.jsx
+++ b/src/Components/BureauPage/ProjectedVacancy/ProjectedVacancy.jsx
@@ -119,7 +119,7 @@ const ProjectedVacancy = ({ isAO }) => {
     let overlay;
     if (resultsLoading) {
       overlay = <Spinner type="standard-center" class="homepage-position-results" size="big" />;
-    } else if (positionsData?.length > 500) {
+    } else if (positionsData?.length >= 500) {
       overlay = <Alert type="error" title="Result Load Reached Limit" messages={[{ body: 'The number of searched projected vacancies is too high to be displayed. Please refine the filter criteria.' }]} />;
     } else if (resultsErrored) {
       overlay = <Alert type="error" title="Error displaying Projected Vacancies" messages={[{ body: 'Please try again.' }]} />;

--- a/src/Components/PositionExpandableContent/PositionExpandableContent.jsx
+++ b/src/Components/PositionExpandableContent/PositionExpandableContent.jsx
@@ -36,6 +36,7 @@ const PositionExpandableContent = ({
   const onCancel = () => {
     form.handleCancel();
     if (setEditMode) setEditMode(false);
+    swal.close();
   };
 
   const getBody = () => {

--- a/src/Components/ProjectedVacancyCard/ProjectedVacancyCard.jsx
+++ b/src/Components/ProjectedVacancyCard/ProjectedVacancyCard.jsx
@@ -101,6 +101,8 @@ const ProjectedVacancyCard = (props) => {
         future_vacancy_status_code: status,
         future_vacancy_override_tour_end_date: overrideTED ?
           overrideTED.toISOString().substring(0, 10) : null,
+        future_vacancy_exclude_import_indicator: status === 'A' ? 'N' :
+          result?.future_vacancy_exclude_import_indicator,
       }],
       language_offsets: {
         position_seq_num: result?.position_seq_num,


### PR DESCRIPTION
Updates:
- Manually syncing up exclude/include indicator with status so that edit saves can be successful
  - Just kidding it looks like there's more complex business rule logic in the background. Please ignore this AC.
- Ensure cancel modal is closed when either option is clicked
- Display more informative error message for PV list payloads too high to support retrieving each card's language offsets (resulting in page erroring out)
- Disable edit buttons when one card is already in edit mode

[TM-5975](https://metaphase.atlassian.net/browse/TM-5975)


[TM-5975]: https://metaphase.atlassian.net/browse/TM-5975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ