### PR TITLE
make sure editable fields are showing most current data

### DIFF
--- a/src/Components/AdministratorPage/bidAudit/BidAuditCard.jsx
+++ b/src/Components/AdministratorPage/bidAudit/BidAuditCard.jsx
@@ -28,6 +28,8 @@ const BidAuditCard = ({ data, onEditModeSearch, onSubmit }) => {
   const [editMode, setEditMode] = useState(false);
 
   useEffect(() => {
+    setPbDate(posted_by_date ? new Date(posted_by_date) : '');
+    setDescription(audit_desc || '');
     onEditModeSearch(editMode, audit_id);
   }, [editMode]);
 


### PR DESCRIPTION
testing fix - after you update, > hit edit again, the old state shows in the input fields... this will hopefully fix that