### PR TITLE
Bidding Tool Hotfix

### DIFF
--- a/src/Components/BiddingFunctionsPage/BiddingTool/BiddingToolCard/BiddingToolCard.jsx
+++ b/src/Components/BiddingFunctionsPage/BiddingTool/BiddingToolCard/BiddingToolCard.jsx
@@ -60,13 +60,13 @@ const BiddingToolCard = (props) => {
   }, []);
 
   const initialValues = isCreate ? {
-    location: null,
-    status: null,
-    tod: null,
-    unaccompanied_status: null,
-    housing: null,
-    quarters: null,
-    efm_issues: null,
+    location: locations?.[0]?.code || '',
+    status: statuses?.[0]?.code || '',
+    tod: tods?.[0]?.code || '',
+    unaccompanied_status: unaccompaniedStatuses?.[0]?.code || '',
+    housing: housingTypes?.[0]?.code || '',
+    quarters: quartersTypes?.[0]?.code || '',
+    efm_issues: ehcps?.[0]?.code || '',
 
     snd: 'N',
     hds: 'N',
@@ -76,10 +76,10 @@ const BiddingToolCard = (props) => {
     inside_efm_employment: 'N',
     outside_efm_employment: 'N',
 
-    cola: null,
-    differential_rate: null,
-    danger_pay: null,
-    climate_zone: null,
+    cola: '0',
+    differential_rate: '0',
+    danger_pay: '0',
+    climate_zone: '0',
 
     rr_point: '',
     medical: '',
@@ -156,8 +156,40 @@ const BiddingToolCard = (props) => {
         grade_education: result?.grade_education ?? '',
         efm_employment: result?.efm_employment ?? '',
       });
+    } else {
+      setValues({
+        location: locations?.[0]?.code || '',
+        status: statuses?.[0]?.code || '',
+        tod: tods?.[0]?.code || '',
+        unaccompanied_status: unaccompaniedStatuses?.[0]?.code || '',
+        housing: housingTypes?.[0]?.code || '',
+        quarters: quartersTypes?.[0]?.code || '',
+        efm_issues: ehcps?.[0]?.code || '',
+
+        snd: 'N',
+        hds: 'N',
+        apo_fpo_dpo: 'N',
+        consumable_allowance: 'N',
+        fm_fp: 'N',
+        inside_efm_employment: 'N',
+        outside_efm_employment: 'N',
+
+        cola: '0',
+        differential_rate: '0',
+        danger_pay: '0',
+        climate_zone: '0',
+
+        rr_point: '',
+        medical: '',
+        remarks: '',
+        quarters_remark: '',
+        special_ship_allowance: '',
+        school_year: '',
+        grade_education: '',
+        efm_employment: '',
+      });
     }
-  }, [editMode]);
+  }, [editMode, result]);
 
   // ========================== VIEW MODE ==========================
 
@@ -348,9 +380,10 @@ const BiddingToolCard = (props) => {
             <label htmlFor="gsa-location">GSA Location</label>
             <select
               id="location"
-              defaultValue={values.location}
+              value={values.location}
               onChange={(e) => setValues({ ...values, location: e.target.value })}
             >
+              <option value="" disabled>Select Location</option>
               {locations?.map(b => (
                 <option key={b.code} value={b.code}>{b.state_country}</option>
               ))}
@@ -360,9 +393,10 @@ const BiddingToolCard = (props) => {
             <label htmlFor="status">Status</label>
             <select
               id="status"
-              defaultValue={values.status}
+              value={values.status}
               onChange={(e) => setValues({ ...values, status: e.target.value })}
             >
+              <option value="" disabled>Select Status</option>
               {statuses?.map(b => (
                 <option key={b.code} value={b.code}>{b.description}</option>
               ))}
@@ -388,9 +422,10 @@ const BiddingToolCard = (props) => {
             <label htmlFor="tod">TOD</label>
             <select
               id="tod"
-              defaultValue={values.tod}
+              value={values.tod}
               onChange={(e) => setValues({ ...values, tod: e.target.value })}
             >
+              <option value="" disabled>Select TOD</option>
               {tods?.map(b => (
                 <option key={b.code} value={b.code}>{b.description}</option>
               ))}
@@ -408,9 +443,10 @@ const BiddingToolCard = (props) => {
             <label htmlFor="unaccompanied-status">Unaccompanied Status</label>
             <select
               id="unaccompanied-status"
-              defaultValue={values.unaccompanied_status}
+              value={values.unaccompanied_status}
               onChange={(e) => setValues({ ...values, unaccompanied_status: e.target.value })}
             >
+              <option value="" disabled>Select Unaccompanied Status</option>
               {unaccompaniedStatuses?.map(b => (
                 <option key={b.code} value={b.code}>{b.description}</option>
               ))}
@@ -528,9 +564,10 @@ const BiddingToolCard = (props) => {
             <label htmlFor="housing-type">Housing Type</label>
             <select
               id="housing"
-              defaultValue={values.housing}
+              value={values.housing}
               onChange={(e) => setValues({ ...values, housing: e.target.value })}
             >
+              <option value="" disabled>Select Housing Type</option>
               {housingTypes?.map(b => (
                 <option key={b.code} value={b.code}>{b.description}</option>
               ))}
@@ -540,9 +577,10 @@ const BiddingToolCard = (props) => {
             <label htmlFor="qtrs-type">Qtrs. Type</label>
             <select
               id="quarters"
-              defaultValue={values.quarters}
+              value={values.quarters}
               onChange={(e) => setValues({ ...values, quarters: e.target.value })}
             >
+              <option value="" disabled>Select Quarters Type</option>
               {quartersTypes?.map(b => (
                 <option key={b.code} value={b.code}>{b.description}</option>
               ))}
@@ -654,9 +692,10 @@ const BiddingToolCard = (props) => {
             <label htmlFor="qtrs-type">EFM Issues</label>
             <select
               id="efm-issues"
-              defaultValue={values.efm_issues}
+              value={values.efm_issues}
               onChange={(e) => setValues({ ...values, efm_issues: e.target.value })}
             >
+              <option value="" disabled>Select EFM Issues</option>
               {ehcps.map(b => (
                 <option key={b.code} value={b.code}>{b.description}</option>
               ))}

--- a/src/actions/biddingTool.js
+++ b/src/actions/biddingTool.js
@@ -190,7 +190,11 @@ export function biddingToolCreate(query, onSuccess) {
     })
       .then((response) => {
         dispatch(toastSuccess(CREATE_BIDDING_TOOL_SUCCESS, CREATE_BIDDING_TOOL_SUCCESS_TITLE));
-        history.push(`/profile/biddingtool/${response?.O_LOCATION_CODE}`);
+        if (response?.O_LOCATION_CODE) {
+          history.push(`/profile/biddingtool/${response?.O_LOCATION_CODE}`);
+        } else {
+          history.push('/profile/biddingtool');
+        }
         if (onSuccess) {
           onSuccess();
         }


### PR DESCRIPTION
- Added valid formats for required fields with defaults so that creating a bidding tool doesn't throw a false success

NOTE: When we implement form validation throughout TM, this form will need to make the required fields throw an error before submission if it's empty instead (all dropdowns and numerical inputs)