### PR TITLE
Tm 6408 update remark text in remark pill

### DIFF
--- a/src/Components/Agenda/AgendaItemRow/AgendaItemRow.jsx
+++ b/src/Components/Agenda/AgendaItemRow/AgendaItemRow.jsx
@@ -176,6 +176,7 @@ AgendaItemRow.propTypes = {
         short_desc_text: PropTypes.string,
         text: PropTypes.string,
         active_ind: PropTypes.string,
+        air_remark_text: PropTypes.string,
         type: null,
       }),
     ),

--- a/src/Components/Agenda/RemarksPill/RemarksPill.jsx
+++ b/src/Components/Agenda/RemarksPill/RemarksPill.jsx
@@ -6,7 +6,7 @@ import { EMPTY_FUNCTION } from 'Constants/PropTypes';
 const RemarksPill = props => {
   const { remark, isEditable, updateSelection, fromAIM } = props;
 
-  const getRemarkText = (r) => {
+  const formatRemarkText = (r) => {
     // we can just grab the already merged text from the BE, but it would mean
     // we have to distinguish from the read/create RemarksGlossary renders
     const refInserts = r?.remark_inserts || [];
@@ -21,13 +21,15 @@ const RemarksPill = props => {
     return remarkText;
   };
 
+  const getRemarkText = (r) => r?.active_ind === 'N' ? `(Legacy) ${r?.air_remark_text}` : r?.air_remark_text;
+
   return (
     <div className={`remarks-pill remark-category--${remark?.rc_code}`}>
       {
         fromAIM ?
-          getRemarkText(remark)
+          formatRemarkText(remark)
           :
-          remark?.text
+          getRemarkText(remark)
       }
       { isEditable &&
         <FA name="times" onClick={() => updateSelection(remark)} />
@@ -51,7 +53,8 @@ RemarksPill.propTypes = {
         riinsertiontext: PropTypes.string,
       }),
     ),
-    ari_insertions: PropTypes.shape({}),
+    air_remark_text: PropTypes.string,
+    air_insertions: PropTypes.shape({}),
   }),
   isEditable: PropTypes.bool,
   updateSelection: PropTypes.func,


### PR DESCRIPTION
Dual Merge: 
- [API PR](https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/1052)

[Ticket](https://metaphase.atlassian.net/browse/TM-6408)

Changes the remarks to show the proper description i.e no {} variables like {date} or {blanktextbox}

Verify
- remarks load and look good on Panel Meeting Search page
- remarks load and look good on Panel Meeting Agenda page **These should also show (Legacy) in front of desc