### PR TITLE
Tm 6433 re work panel meeting agendas page

### DIFF
--- a/src/Components/AdministratorPage/PanelAdmin/PanelMeetingMessage.jsx
+++ b/src/Components/AdministratorPage/PanelAdmin/PanelMeetingMessage.jsx
@@ -11,7 +11,7 @@ const PanelMeetingMessage = ({ id, isCreate }) => {
             Go to edit panel
           </Link>
           , or
-          <Link to={`/profile/ao/panelmeetingagendas/${id}/`}>
+          <Link to={`/profile/administrator/panel/${id}`}>
             Go to panel details
           </Link>
           .

--- a/src/Components/Agenda/AgendaItemRow/AgendaItemRow.jsx
+++ b/src/Components/Agenda/AgendaItemRow/AgendaItemRow.jsx
@@ -117,7 +117,7 @@ const AgendaItemRow = props => {
               <div className="remarks-pill-container">
                 {
                   remarks.map(remark => (
-                    <RemarksPill key={remark.text} remark={remark} />
+                    <RemarksPill key={`${perdet$}-${remark.air_remark_text}`} remark={remark} />
                   ))
                 }
                 {agenda?.ahtCode &&

--- a/src/Components/Agenda/AgendaItemRow/AgendaItemRow.jsx
+++ b/src/Components/Agenda/AgendaItemRow/AgendaItemRow.jsx
@@ -198,7 +198,7 @@ AgendaItemRow.propTypes = {
         grade: PropTypes.string,
         action: PropTypes.string,
         travel: PropTypes.string,
-        languages: POS_LANGUAGES, // @TODO: Fix this, console warning getting string, expect array
+        languages: PropTypes.oneOfType([POS_LANGUAGES, PropTypes.string]),
         pay_plan: PropTypes.string,
       }),
     ),

--- a/src/Components/Agenda/AgendaItemRow/AgendaItemRow.jsx
+++ b/src/Components/Agenda/AgendaItemRow/AgendaItemRow.jsx
@@ -214,21 +214,16 @@ AgendaItemRow.propTypes = {
         custom_description: PropTypes.string,
       }),
     ),
-    // @TODO: console warning, getting object not array
-    cdo: PropTypes.arrayOf(
-      PropTypes.shape({
-        first_name: PropTypes.string,
-        last_name: PropTypes.string,
-      }),
-    ),
+    cdo: PropTypes.shape({
+      first_name: PropTypes.string,
+      last_name: PropTypes.string,
+    }),
     pay_plan_code: PropTypes.string,
     grade: PropTypes.string,
     combined_pp_grade: PropTypes.string,
-    org: PropTypes.arrayOf(
-      PropTypes.shape({
-        org_descr: PropTypes.string,
-      }),
-    ),
+    org: PropTypes.shape({
+      org_descr: PropTypes.string,
+    }),
     full_name: PropTypes.string,
     update_date: PropTypes.string,
     modifier_name: PropTypes.number,

--- a/src/Components/AoPage/AoPage.jsx
+++ b/src/Components/AoPage/AoPage.jsx
@@ -21,7 +21,7 @@ const AoPage = () => (
       <Route path="/profile/ao/createagendaitem/:id" render={() => <AgendaItemMaintenanceContainer isCDO={false} />} />
       <Route path="/profile/ao/panelmeetings" render={() => <PanelMeetingSearch isCDO={false} />} />
       <Route path="/profile/ao/availablebidders" render={() => <AvailableBidderContainer isCDO={false} isAO />} />
-      <Route path="/profile/ao/panelmeetingagendas/:pmID" render={() => <PanelMeetingAgendas isAO />} />
+      <Route path="/profile/ao/panelmeetingagendas" render={(props) => <PanelMeetingAgendas {...props} />} />
       <Route path="/profile/ao/projectedvacancy" render={() => <ProjectedVacancy viewType="ao" />} />
       <Route path="/profile/ao/publishablepositions" render={() => <PublishablePositions viewType="ao" />} />
       <Route path="/profile/ao/:id/assignmentsseparations/notification/:noteMemoID" render={(props) => <AssignmentNotification {...props} />} />

--- a/src/Components/CdoPage/CdoPage.jsx
+++ b/src/Components/CdoPage/CdoPage.jsx
@@ -18,7 +18,7 @@ const CdoPage = () => (
       <Route path="/profile/cdo/editagendaitem/:id/:agendaID" render={() => <AgendaItemMaintenanceContainer isCDO />} />
       <Route path="/profile/cdo/createagendaitem/:id" render={() => <AgendaItemMaintenanceContainer isCDO />} />
       <Route path="/profile/cdo/panelmeetings" render={() => <PanelMeetingSearch isCDO />} />
-      <Route path="/profile/cdo/panelmeetingagendas/:pmID" render={() => <PanelMeetingAgendas isCDO />} />
+      <Route path="/profile/cdo/panelmeetingagendas" render={(props) => <PanelMeetingAgendas {...props} isCDO />} />
       <Route path="/profile/cdo/biddingtool/:id" render={() => <BiddingTool />} />
       <Route path="/profile/cdo/biddingtool/" render={() => <BiddingTool />} />
     </Switch>

--- a/src/Components/Panel/Constants.js
+++ b/src/Components/Panel/Constants.js
@@ -7,7 +7,7 @@ export const meetingCategoryMap = {
   X: 'Express',
   V: 'Volunteer Cable',
   A: 'Addendum',
-  C: 'Addendum(Volunteer Cable)',
+  C: 'Addendum (Volunteer Cable)',
   P: 'Position Challenge',
   E: 'Employee Challenge',
 };

--- a/src/Components/Panel/PanelMeetingAgendas/PanelMeetingAgendas.jsx
+++ b/src/Components/Panel/PanelMeetingAgendas/PanelMeetingAgendas.jsx
@@ -21,6 +21,7 @@ import PrintPanelMeetingAgendas from './PrintPanelMeetingAgendas';
 import { PANEL_MEETING } from '../../../Constants/PropTypes';
 import { meetingCategoryMap } from '../Constants';
 import api from '../../../api';
+import { DEFAULT_TEXT } from '../../../Constants/SystemMessages';
 
 const fuseOptions = {
   shouldSort: false,
@@ -496,11 +497,11 @@ const PanelMeetingAgendas = (props) => {
               {
                 agendasByPanelMeeting.map((pm) => {
                   // Find panel meeting date
-                  const panelMeetingDate = pm.panelMeetingDates.find(pmd => pmd.mdt_code === 'MEET');
+                  const panelMeetingDate = pm.panelMeetingDates.find(pmd => pmd.mdt_code === 'MEET') || DEFAULT_TEXT;
                   return (
                     <div className="pma-pm-container" key={pm.pmi_pm_seq_num}>
                       <div className="pm-header">
-                        {pm.pmt_code} {format(new Date(panelMeetingDate.pmd_dttm), 'MM/dd/yy')} - {pm.pms_desc_text}
+                        {get(pm, 'pmt_code')} {panelMeetingDate !== DEFAULT_TEXT ? format(new Date(panelMeetingDate.pmd_dttm), 'MM/dd/yy') : ''} - {get(pm, 'pms_desc_text')}
                       </div>
                       {
                         isAllCategoriesEmpty(pm.agendas) ? (

--- a/src/Components/Panel/PanelMeetingAgendas/PanelMeetingAgendas.jsx
+++ b/src/Components/Panel/PanelMeetingAgendas/PanelMeetingAgendas.jsx
@@ -510,7 +510,7 @@ const PanelMeetingAgendas = (props) => {
                           <div className="pm-agendas-container">
                             {
                               Object.keys(pm.agendas).map((category) => (
-                                <div key={category}>
+                                <div key={category} className="category-container">
                                   <div className="category-header">
                                     {category}
                                   </div>

--- a/src/Components/Panel/PanelMeetingAgendas/PanelMeetingAgendas.jsx
+++ b/src/Components/Panel/PanelMeetingAgendas/PanelMeetingAgendas.jsx
@@ -1,4 +1,4 @@
-import PropTypes, { arrayOf, string } from 'prop-types';
+import PropTypes from 'prop-types';
 import FA from 'react-fontawesome';
 import { useDispatch, useSelector } from 'react-redux';
 import { withRouter } from 'react-router';
@@ -17,6 +17,7 @@ import Spinner from 'Components/Spinner';
 import ScrollUpButton from '../../ScrollUpButton';
 import BackButton from '../../BackButton';
 import AgendaItemRow from '../../Agenda/AgendaItemRow';
+import PrintPanelMeetingAgendas from './PrintPanelMeetingAgendas';
 import { PANEL_MEETING } from '../../../Constants/PropTypes';
 import { meetingCategoryMap } from '../Constants';
 import api from '../../../api';
@@ -91,7 +92,6 @@ const PanelMeetingAgendas = (props) => {
     };
   });
   const isAllCategoriesEmpty = (agenda) => Object.values(agenda).every(category => category.length === 0);
-
   const childRef = useRef();
   const dispatch = useDispatch();
 
@@ -328,13 +328,10 @@ const PanelMeetingAgendas = (props) => {
     if (isLoading) overlay = <Spinner type="bureau-filters" size="small" />;
     if (printView) {
       overlay = (
-        // @TODO update PrintPanelMeetingAgendas
-        // <PrintPanelMeetingAgendas
-        //   panelMeetingData={panelMeetingData}
-        //   closePrintView={() => setPrintView(false)}
-        //   agendas={agendas$}
-        // />
-        <div> PRINT VIEW WIP </div>
+        <PrintPanelMeetingAgendas
+          closePrintView={() => setPrintView(false)}
+          panelMeetingsWithAgendas={agendasByPanelMeeting}
+        />
       );
     }
     return overlay;
@@ -548,8 +545,12 @@ const PanelMeetingAgendas = (props) => {
 
 PanelMeetingAgendas.propTypes = {
   isCDO: PropTypes.bool,
-  location: PropTypes.shape({ pathname: string, state: { panelMeetings: arrayOf(PANEL_MEETING) } }).isRequired,
-};
+  location: PropTypes.shape({
+    pathname: PropTypes.string,
+    state: PropTypes.shape({
+      panelMeetings: PropTypes.arrayOf(PANEL_MEETING),
+    }),
+  }).isRequired };
 
 PanelMeetingAgendas.defaultProps = {
   isCDO: false,

--- a/src/Components/Panel/PanelMeetingAgendas/PanelMeetingAgendas.jsx
+++ b/src/Components/Panel/PanelMeetingAgendas/PanelMeetingAgendas.jsx
@@ -92,6 +92,7 @@ const PanelMeetingAgendas = (props) => {
     };
   });
   const isAllCategoriesEmpty = (agenda) => Object.values(agenda).every(category => category.length === 0);
+
   const childRef = useRef();
   const dispatch = useDispatch();
 
@@ -494,10 +495,6 @@ const PanelMeetingAgendas = (props) => {
               </div>
               {
                 agendasByPanelMeeting.map((pm) => {
-                  // If all categories are empty, skip this pm
-                  if (isAllCategoriesEmpty(pm.agendas)) {
-                    return null;
-                  }
                   // Find panel meeting date
                   const panelMeetingDate = pm.panelMeetingDates.find(pmd => pmd.mdt_code === 'MEET');
                   return (
@@ -505,33 +502,39 @@ const PanelMeetingAgendas = (props) => {
                       <div className="pm-header">
                         {pm.pmt_code} {format(new Date(panelMeetingDate.pmd_dttm), 'MM/dd/yy')} - {pm.pms_desc_text}
                       </div>
-                      <div className="pm-agendas-container">
-                        {
-                          Object.keys(pm.agendas).map((category) => (
-                            <div key={category}>
-                              <div className="category-header">
-                                {category}
-                              </div>
-                              <div className="agenda-item-row-container">
-                                {
-                                  pm.agendas[category].length > 0 ? (
-                                    pm.agendas[category].map(agenda => (
-                                      <AgendaItemRow
-                                        agenda={agenda}
-                                        key={agenda.id}
-                                        isCDO={isCDO}
-                                        isPanelMeetingView
-                                      />
-                                    ))
-                                  ) : (
-                                    <div className="ai-empty-row">(No Agendas)</div>
-                                  )
-                                }
-                              </div>
-                            </div>
-                          ))
-                        }
-                      </div>
+                      {
+                        isAllCategoriesEmpty(pm.agendas) ? (
+                          <div className="pm-empty-row">No agendas</div>
+                        ) : (
+                          <div className="pm-agendas-container">
+                            {
+                              Object.keys(pm.agendas).map((category) => (
+                                <div key={category}>
+                                  <div className="category-header">
+                                    {category}
+                                  </div>
+                                  <div className="agenda-item-row-container">
+                                    {
+                                      pm.agendas[category].length > 0 ? (
+                                        pm.agendas[category].map(agenda => (
+                                          <AgendaItemRow
+                                            agenda={agenda}
+                                            key={agenda.id}
+                                            isCDO={isCDO}
+                                            isPanelMeetingView
+                                          />
+                                        ))
+                                      ) : (
+                                        <div className="ai-empty-row">(No Agendas)</div>
+                                      )
+                                    }
+                                  </div>
+                                </div>
+                              ))
+                            }
+                          </div>
+                        )
+                      }
                     </div>
                   );
                 })

--- a/src/Components/Panel/PanelMeetingAgendas/PrintPanelMeetingAgendas.jsx
+++ b/src/Components/Panel/PanelMeetingAgendas/PrintPanelMeetingAgendas.jsx
@@ -1,16 +1,15 @@
 import PropTypes from 'prop-types';
-import { formatLang, formatMonthYearDate, shortenString } from 'utilities';
 import shortid from 'shortid';
 import FA from 'react-fontawesome';
 import { useDispatch } from 'react-redux';
 import { toastInfo } from 'actions/toast';
+import { formatLang, formatMonthYearDate, shortenString } from 'utilities';
 import InteractiveElement from 'Components/InteractiveElement';
 import PanelMeetingTracker from 'Components/Panel/PanelMeetingTracker';
-import { meetingCategoryMap } from 'Components/Panel/Constants';
 import { formatVice } from 'Components/Agenda/Constants';
 import { dateTernary } from '../../Agenda/Constants';
 
-const PrintPanelMeetingAgendas = ({ panelMeetingData, closePrintView, agendas }) => {
+const PrintPanelMeetingAgendas = ({ panelMeetingsWithAgendas, closePrintView }) => {
   const cancel = () => {
     closePrintView();
   };
@@ -26,26 +25,6 @@ const PrintPanelMeetingAgendas = ({ panelMeetingData, closePrintView, agendas })
     return '';
   };
   const formatStr = (d) => shortenString(d, 50);
-
-  const agendasCategorized = {
-    Review: [],
-    'Off Panel': [],
-    Discuss: [],
-    Separations: [],
-    Express: [],
-    'Volunteer Cable': [],
-    Addendum: [],
-    'Addendum(Volunteer Cable)': [],
-    'Position Challenge': [],
-    'Employee Challenge': [],
-  };
-
-  const categorizeAgendas = () => {
-    agendas.forEach(a => {
-      agendasCategorized[meetingCategoryMap[a?.pmi_mic_code]].push(a);
-    });
-    return agendasCategorized;
-  };
 
   const printableAgendaTable = (agenda) => {
     const { legs } = agenda;
@@ -81,102 +60,105 @@ const PrintPanelMeetingAgendas = ({ panelMeetingData, closePrintView, agendas })
   return (
     <div className="pma-print-view">
       <InteractiveElement className="pma-print-close-icon" onClick={cancel}><FA name="times" /></InteractiveElement>
-      <div className="tracker-container">
-        <PanelMeetingTracker panelMeeting={panelMeetingData?.results?.[0]} printableTracker />
-      </div>
       {
-        Object.keys(categorizeAgendas()).map(header => (
+        panelMeetingsWithAgendas.map(panelMeeting => (
           <>
-            <div className="pma-print-header">{header}</div>
+            <div className="tracker-container" key={panelMeeting.id}>
+              <PanelMeetingTracker panelMeeting={panelMeeting} printableTracker />
+            </div>
             {
-              agendasCategorized[header].map(agenda => {
-                const cdoFirst = agenda?.cdo?.first_name || '';
-                const cdoLast = agenda?.cdo?.last_name || '';
-                const cdoComma = (cdoLast && cdoFirst) ? ',' : '';
-                const cdoFull = `${cdoLast}${cdoComma} ${cdoFirst}`;
-                const cdo = cdoFull !== ' ' ? cdoFull : 'None Listed';
-                const userLanguage = agenda?.languages || 'None Listed';
-                const combinedPPgrade = agenda?.combined_pp_grade;
-                const userSkill = agenda?.skills?.join(', ') || 'None Listed';
-                const agendaStatus = agenda?.status_short || 'None Listed';
-                const name = agenda?.full_name ?? '';
+              Object.keys(panelMeeting.agendas).map(category => (
+                <>
+                  <div className="pma-print-header" key={category}>{category}</div>
+                  {
+                    panelMeeting.agendas[category].map((agenda) => {
+                      const cdoFirst = agenda?.cdo?.first_name || '';
+                      const cdoLast = agenda?.cdo?.last_name || '';
+                      const cdoComma = (cdoLast && cdoFirst) ? ',' : '';
+                      const cdoFull = `${cdoLast}${cdoComma} ${cdoFirst}`;
+                      const cdo = cdoFull !== ' ' ? cdoFull : 'None Listed';
+                      const userLanguage = agenda?.languages || 'None Listed';
+                      const combinedPPgrade = agenda?.combined_pp_grade;
+                      const userSkill = agenda?.skills?.join(', ') || 'None Listed';
+                      const agendaStatus = agenda?.status_short || 'None Listed';
+                      const name = agenda?.full_name ?? '';
+                      const createdByLast = agenda?.creators?.last_name ? `${agenda.creators.last_name},` : '';
+                      const createDate = dateTernary(agenda?.creator_date);
+                      const updateByLast = agenda?.updaters?.last_name ? `${agenda.updaters.last_name},` : '';
+                      const updateDate = dateTernary(agenda?.modifier_date);
+                      const remarks = agenda?.remarks?.map(remark => remark?.text).join('; ') || '';
+                      const combinedTod = agenda?.aiCombinedTodCode === 'X' ? agenda.aiCombinedTodOtherText : agenda.aiCombinedTodDescText;
 
-                const createdByLast = agenda?.creators?.last_name ? `${agenda.creators.last_name},` : '';
-                const createDate = dateTernary(agenda?.creator_date);
-                const updateByLast = agenda?.updaters?.last_name ? `${agenda.updaters.last_name},` : '';
-                const updateDate = dateTernary(agenda?.modifier_date);
-                const remarks = agenda?.remarks?.map(remark => remark?.text).join('; ') || '';
-                const combinedTod = agenda?.aiCombinedTodCode === 'X' ? agenda.aiCombinedTodOtherText : agenda.aiCombinedTodDescText;
-                return (
-                  <div className={`pma-table-wrapper agenda-border-row--${agendaStatus} `}>
-
-                    <div className="pma-print-history-status">
-                      <div className={`agenda-tag--${agendaStatus} pma-print-official-item-number`}>
-                        {agenda?.pmi_official_item_num}
-                      </div>
-                      <div className={`status-tag agenda-tag--${agendaStatus}`}>
-                        {agenda?.status_full || 'Default'}
-                      </div>
-                      <div className={`poly-slash agenda-tag--${agendaStatus}`} />
-                    </div>
-
-                    <div className="pma-print-user-info">
-                      <div className="item"><span className="label">{name}</span></div>
-                      <div className="item">
-                        <span className="label">Languages: </span>
-                        <span>
-                          {
-                            Array.isArray(userLanguage) ?
-                              userLanguage.map(l => (
+                      return (
+                        <div className={`pma-table-wrapper agenda-border-row--${agendaStatus} `}>
+                          <div className="pma-print-history-status">
+                            <div className={`agenda-tag--${agendaStatus} pma-print-official-item-number`}>
+                              {agenda?.pmi_official_item_num}
+                            </div>
+                            <div className={`status-tag agenda-tag--${agendaStatus}`}>
+                              {agenda?.status_full || 'Default'}
+                            </div>
+                            <div className={`poly-slash agenda-tag--${agendaStatus}`} />
+                          </div>
+                          <div className="pma-print-user-info">
+                            <div className="item"><span className="label">{name}</span></div>
+                            <div className="item">
+                              <span className="label">Languages: </span>
+                              <span>
+                                {
+                                  Array.isArray(userLanguage) ?
+                                    userLanguage.map(l => (
                                 `${l.custom_description} ${formatCurrentDate(l.test_date)} `
-                              )).join(', ')
-                              :
-                              userLanguage
-                          }
-                        </span>
-                      </div>
-                      <div className="item"><span className="label">PP/Grade: </span> {combinedPPgrade}</div>
-                      <div className="item"><span className="label">Skill: </span> {userSkill}</div>
-                      <div className="item"><span className="label">CDO: </span> {cdo}</div>
-                    </div>
-                    <table className="pma-print-table">
-                      <thead>
-                        <tr>
-                          <th>Action</th>
-                          <th>Location/Org</th>
-                          <th>Position Number</th>
-                          <th>Skill/Title</th>
-                          <th>Lang</th>
-                          <th>ETA</th>
-                          <th>TED</th>
-                          <th>TOD</th>
-                          <th>Travel</th>
-                          <th>Vice</th>
-                          <th>PP/Grade</th>
-                        </tr>
-                      </thead>
-                      { printableAgendaTable(agenda) }
-                    </table>
-                    <div className="pma-footer-wrapper">
-                      <div className="pma-cdo-remarks-wrapper">
-                        <div className="item"><span className="label">Remarks: </span> {remarks}</div>
-                        <div className="item"><span className="label">Combined TOD: </span> {combinedTod}</div>
-                      </div>
-                      <div className="pma-created-modified-wrapper">
-                        <div className="pma-date-stamp-wrapper">
-                          <span className="stamp">Created: {createdByLast} {agenda?.creators?.first_name || ''}</span>
-                          <span className="date">{createDate}</span>
+                                    )).join(', ')
+                                    :
+                                    userLanguage
+                                }
+                              </span>
+                            </div>
+                            <div className="item"><span className="label">PP/Grade: </span> {combinedPPgrade}</div>
+                            <div className="item"><span className="label">Skill: </span> {userSkill}</div>
+                            <div className="item"><span className="label">CDO: </span> {cdo}</div>
+                          </div>
+                          <table className="pma-print-table">
+                            <thead>
+                              <tr>
+                                <th>Action</th>
+                                <th>Location/Org</th>
+                                <th>Position Number</th>
+                                <th>Skill/Title</th>
+                                <th>Lang</th>
+                                <th>ETA</th>
+                                <th>TED</th>
+                                <th>TOD</th>
+                                <th>Travel</th>
+                                <th>Vice</th>
+                                <th>PP/Grade</th>
+                              </tr>
+                            </thead>
+                            { printableAgendaTable(agenda) }
+                          </table>
+                          <div className="pma-footer-wrapper">
+                            <div className="pma-cdo-remarks-wrapper">
+                              <div className="item"><span className="label">Remarks: </span> {remarks}</div>
+                              <div className="item"><span className="label">Combined TOD: </span> {combinedTod}</div>
+                            </div>
+                            <div className="pma-created-modified-wrapper">
+                              <div className="pma-date-stamp-wrapper">
+                                <span className="stamp">Created: {createdByLast} {agenda?.creators?.first_name || ''}</span>
+                                <span className="date">{createDate}</span>
+                              </div>
+                              <div className="pma-date-stamp-wrapper">
+                                <span className="stamp">Modified: {updateByLast} {agenda?.creators?.last_name || ''}</span>
+                                <span className="date">{updateDate}</span>
+                              </div>
+                            </div>
+                          </div>
                         </div>
-                        <div className="pma-date-stamp-wrapper">
-                          <span className="stamp">Modified: {updateByLast} {agenda?.creators?.last_name || ''}</span>
-                          <span className="date">{updateDate}</span>
-                        </div>
-                      </div>
-                    </div>
-
-                  </div>
-                );
-              })
+                      );
+                    })
+                  }
+                </>
+              ))
             }
           </>
         ))
@@ -186,9 +168,8 @@ const PrintPanelMeetingAgendas = ({ panelMeetingData, closePrintView, agendas })
 };
 
 PrintPanelMeetingAgendas.propTypes = {
-  panelMeetingData: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  panelMeetingsWithAgendas: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   closePrintView: PropTypes.func.isRequired,
-  agendas: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
 };
 
 export default PrintPanelMeetingAgendas;

--- a/src/Components/Panel/PanelMeetingSearch/PanelMeetingSearch.jsx
+++ b/src/Components/Panel/PanelMeetingSearch/PanelMeetingSearch.jsx
@@ -23,7 +23,6 @@ import TMDatePicker from 'Components/TMDatePicker';
 import ScrollUpButton from '../../ScrollUpButton';
 import { userHasPermissions } from '../../../utilities';
 import CheckBox from '../../CheckBox';
-import { PREVENT_DEFAULT } from '../../../Constants/PropTypes';
 
 const usePanelAdmin = () => checkFlag('flags.panel_admin');
 const usePanelAdminPanelMeeting = () => checkFlag('flags.panel_admin_panel_meeting');
@@ -42,12 +41,12 @@ const PanelMeetingSearch = ({ isCDO }) => {
   const panelMeetings$ = useSelector(state => state.panelMeetings);
   const panelMeetingsIsLoading = useSelector(state => state.panelMeetingsFetchDataLoading);
   const panelMeetingsHasErrored = useSelector(state => state.panelMeetingsFetchDataErrored);
+
   const userSelections = useSelector(state => state.panelMeetingsSelections);
   const userProfile = useSelector(state => state.userProfile);
   const isFsbidAdmin = userHasPermissions(['fsbid_admin'], userProfile?.permission_groups);
 
   const panelMeetings = get(panelMeetings$, 'results') || [];
-
   const [page, setPage] = useState(get(userSelections, 'page') || 1);
   const [limit, setLimit] = useState(get(userSelections, 'limit') || PANEL_MEETINGS_PAGE_SIZES.defaultSize);
   const [ordering, setOrdering] = useState(get(userSelections, 'ordering') || PANEL_MEETINGS_SORT.defaultSort);
@@ -75,6 +74,8 @@ const PanelMeetingSearch = ({ isCDO }) => {
 
   const pageSizes = PANEL_MEETINGS_PAGE_SIZES;
   const sorts = PANEL_MEETINGS_SORT;
+
+  const userRole = isCDO ? 'cdo' : 'ao';
 
   const getQuery = () => ({
     limit,
@@ -344,13 +345,10 @@ const PanelMeetingSearch = ({ isCDO }) => {
             {
               selectAll &&
                 <div className="view-all">
-                  {/** Disabled link until endpoint is updated */}
                   <Link
-                    className="disabled-link"
-                    to={'/panelmeetings/agendas'}
-                    onClick={() => {
-                      /** @TODO update "to" link and handle click */
-                      PREVENT_DEFAULT();
+                    to={{
+                      pathname: `/profile/${userRole}/panelmeetingagendas`,
+                      state: { panelMeetings },
                     }}
                   >
                     <FA className="icon" name="eye" /> {'View All Panel Agendas'}

--- a/src/Components/Panel/PanelMeetingSearchRow/PanelMeetingSearchRow.jsx
+++ b/src/Components/Panel/PanelMeetingSearchRow/PanelMeetingSearchRow.jsx
@@ -35,7 +35,13 @@ const PanelMeetingSearchRow = ({ isCDO, pm, selectAll }) => {
         <div className="button-box-container">
           {
             showPanelMeetingsAgendas &&
-            <LinkButton className="button-box" toLink={`/profile/${userRole}/panelmeetingagendas/${pmSeqNum}`}>View</LinkButton>
+            <LinkButton
+              className="button-box"
+              toLink={{
+                pathname: `/profile/${userRole}/panelmeetingagendas`,
+                state: { panelMeetings: [pm] },
+              }}
+            >View</LinkButton>
           }
           {
             isSuperUser && showEditPanelMeeting &&

--- a/src/Components/Panel/PanelMeetingSearchRow/PanelMeetingSearchRow.jsx
+++ b/src/Components/Panel/PanelMeetingSearchRow/PanelMeetingSearchRow.jsx
@@ -60,7 +60,7 @@ const PanelMeetingSearchRow = ({ isCDO, pm, selectAll }) => {
         <div className="remarks-pill-container">
           {
             remarks.slice(0, expanded ? remarks.length : 8).map(remark => (
-              <RemarksPill key={remark.text} remark={remark} />
+              <RemarksPill key={`${pmSeqNum}-${remark.air_remark_text}`} remark={remark} />
             ))
           }
         </div>

--- a/src/actions/panelMeetingAgendas.js
+++ b/src/actions/panelMeetingAgendas.js
@@ -2,7 +2,6 @@ import { batch } from 'react-redux';
 import { get } from 'lodash';
 import { convertQueryToString, downloadFromResponse, formatDate } from 'utilities';
 import api from '../api';
-import { meetingCategoryMap } from '../Components/Panel/Constants';
 
 export function panelMeetingAgendasFetchDataErrored(bool) {
   return {
@@ -34,7 +33,7 @@ export function panelMeetingAgendasExport(pmseqnum = '') {
     });
 }
 
-export function panelMeetingAgendasFetchData(query = {}, panelMeetings = []) {
+export function panelMeetingAgendasFetchData(query = {}) {
   return (dispatch) => {
     batch(() => {
       dispatch(panelMeetingAgendasFetchDataLoading(true));
@@ -47,32 +46,8 @@ export function panelMeetingAgendasFetchData(query = {}, panelMeetings = []) {
     api().get(ep)
       .then(({ data }) => {
         const agendas = data.results.results;
-        const agendasByPanelMeeting = panelMeetings.map((pm) => {
-          // Filter agendas by panel meeting sequence number
-          const filteredAgendas = agendas.filter((agenda) => agenda.pmi_pm_seq_num === pm.pmi_pm_seq_num);
-
-          // Initialize an empty object with keys from meetingCategoryMap
-          const categorizedAgendas = Object.keys(meetingCategoryMap).reduce((acc, key) => {
-            acc[meetingCategoryMap[key]] = [];
-            return acc;
-          }, {});
-
-          // Iterate over filteredAgendas and categorize them
-          filteredAgendas.forEach((agenda) => {
-            const category = meetingCategoryMap[agenda.pmi_mic_code];
-            if (category) {
-              categorizedAgendas[category].push(agenda);
-            }
-          });
-
-          return {
-            ...pm,
-            agendas: categorizedAgendas,
-          };
-        });
-
         batch(() => {
-          dispatch(panelMeetingAgendasFetchDataSuccess(agendasByPanelMeeting));
+          dispatch(panelMeetingAgendasFetchDataSuccess(agendas));
           dispatch(panelMeetingAgendasFetchDataErrored(false));
           dispatch(panelMeetingAgendasFetchDataLoading(false));
         });

--- a/src/actions/panelMeetingAgendas.js
+++ b/src/actions/panelMeetingAgendas.js
@@ -45,7 +45,7 @@ export function panelMeetingAgendasFetchData(query = {}) {
     dispatch(panelMeetingAgendasFetchDataLoading(true));
     api().get(ep)
       .then(({ data }) => {
-        const agendas = data.results.results;
+        const agendas = data.results;
         batch(() => {
           dispatch(panelMeetingAgendasFetchDataSuccess(agendas));
           dispatch(panelMeetingAgendasFetchDataErrored(false));

--- a/src/sass/_agendaItemRow.scss
+++ b/src/sass/_agendaItemRow.scss
@@ -161,6 +161,12 @@
     flex-direction: column;
     font-size: 14px;
   }
+  .ai-empty-row {
+    display: flex;
+    align-items: center;
+    padding: 10px 0 10px 0;
+    margin: 0 15px 0 20px;
+  }
 }
 
 .ai-history-cards-container {

--- a/src/sass/_panelMeetingAgendas.scss
+++ b/src/sass/_panelMeetingAgendas.scss
@@ -4,15 +4,7 @@
     color: $color-white;
   }
 
-  .panel-meeting-agendas-rows-container {
-    .pma-category-header{
-      font-family: 'Roboto';
-      font-size: 26px;
-      padding: 10px 0 10px 0;
-      margin: 0 15px 0 20px;
-      border-top: solid 3px $color-gray-light;
-    }
-
+  .panel-meeting-agendas-container {
     .total-results {
       margin: 20px 15px 20px 20px;
       display: flex;
@@ -20,6 +12,33 @@
       align-items: center;
     }
 
+    .pma-pm-container {
+      display: flex;
+      flex-direction: column;
+      margin: 0 20px 0 20px;
+
+      .pm-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 10px 0 10px 0;
+        border-bottom: 2px solid $bg-gray-dark-2;
+        border-top: 2px solid $bg-gray-dark-2;
+      }
+
+      .pm-agendas-container {
+        display: flex;
+        flex-direction: column;
+        padding: 10px 0 10px 0;
+        
+        .category-header{
+          padding: 10px 0 10px 0;
+          margin: 0 15px 0 20px;
+          border-bottom: solid 2px $color-gray-light;
+        }
+      }
+    }
+    
     .ai-history-row {
       .ai-history-row-panel-date {
         display: flex;

--- a/src/sass/_panelMeetingAgendas.scss
+++ b/src/sass/_panelMeetingAgendas.scss
@@ -24,6 +24,7 @@
         padding: 10px 0 10px 0;
         border-bottom: 2px solid $bg-gray-dark-2;
         border-top: 2px solid $bg-gray-dark-2;
+        font-weight: bold;
       }
 
       .pm-empty-row {
@@ -36,11 +37,17 @@
       .pm-agendas-container {
         display: flex;
         flex-direction: column;
-        padding: 10px 0 10px 0;
+        margin: 0 15px 0 20px;
+
+        .category-container {
+          display: flex;
+          flex-direction: column;
+          padding: 10px 0 10px 0;
+        }
         
         .category-header{
-          padding: 10px 0 10px 0;
-          margin: 0 15px 0 20px;
+          display: flex;
+          flex-direction: column;
           border-bottom: solid 2px $color-gray-light;
         }
       }

--- a/src/sass/_panelMeetingAgendas.scss
+++ b/src/sass/_panelMeetingAgendas.scss
@@ -26,6 +26,13 @@
         border-top: 2px solid $bg-gray-dark-2;
       }
 
+      .pm-empty-row {
+        display: flex;
+        align-items: center;
+        padding: 10px 0 10px 0;
+        margin: 0 15px 0 20px;
+      }
+
       .pm-agendas-container {
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
Dual Merge: 
- [API PR](https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/1075)

[Ticket](https://metaphase.atlassian.net/browse/TM-6433)

Panel Agendas page now accepts multiple panel meetings instead of just one -- when you use the select all button on panel meetings search you can view the agendas for all the panel meetings selected now.