### PR TITLE
Employee Name Hyperlink

### DIFF
--- a/src/Components/Agenda/EmployeeAgendaSearchCard/EmployeeAgendaSearchCard.jsx
+++ b/src/Components/Agenda/EmployeeAgendaSearchCard/EmployeeAgendaSearchCard.jsx
@@ -4,7 +4,7 @@ import FA from 'react-fontawesome';
 import { Tooltip } from 'react-tippy';
 import { Handshake } from 'Components/Ribbon';
 import LinkButton from 'Components/LinkButton';
-import { get, isNil } from 'lodash';
+import { get } from 'lodash';
 import { checkFlag } from 'flags';
 import BoxShadow from 'Components/BoxShadow';
 import { formatDate } from 'utilities';
@@ -46,17 +46,16 @@ const EmployeeAgendaSearchCard = ({ isCDO, result, viewType }) => {
   const agendaIDExist = !!agendaID;
 
   // handles error where some employees have no Profile
-  const employeeHasCDO = !isNil(get(person, 'cdo'));
   const currentPost = (currentCity || currentCountry || currentOrg) ? `${currentCity} ${currentCountry} ${currentOrg}` : FALLBACK;
   const hsPost = (hsCity || hsCountry || hsOrg) ? `${hsCity} ${hsCountry} ${hsOrg}` : FALLBACK;
 
   let profileLink;
   switch (viewType) {
     case 'ao':
-      profileLink = employeeHasCDO ? <Link to={`/profile/public/${perdet}/ao`}>{bidder}</Link> : bidder;
+      profileLink = <Link to={`/profile/public/${perdet}/ao`}>{bidder}</Link>;
       break;
     case 'cdo':
-      profileLink = isCDO && employeeHasCDO ? <Link to={`/profile/public/${perdet}`}>{bidder}</Link> : bidder;
+      profileLink = isCDO ? <Link to={`/profile/public/${perdet}`}>{bidder}</Link> : bidder;
       break;
     default:
       profileLink = bidder;

--- a/src/Components/Agenda/EmployeeAgendaSearchCard/EmployeeAgendaSearchCard.jsx
+++ b/src/Components/Agenda/EmployeeAgendaSearchCard/EmployeeAgendaSearchCard.jsx
@@ -45,7 +45,7 @@ const EmployeeAgendaSearchCard = ({ isCDO, result, viewType }) => {
   const agendaID = get(agenda, 'agendaID');
   const agendaIDExist = !!agendaID;
 
-  // handles error where some employees have no Profile
+
   const currentPost = (currentCity || currentCountry || currentOrg) ? `${currentCity} ${currentCountry} ${currentOrg}` : FALLBACK;
   const hsPost = (hsCity || hsCountry || hsOrg) ? `${hsCity} ${hsCountry} ${hsOrg}` : FALLBACK;
 


### PR DESCRIPTION
Description:

TM-6472: [https://metaphase.atlassian.net/jira/software/c/projects/TM/boards/1?assignee=712020%3A3d9639a5-439c-4e2d-9bce-37b6924384d2&selectedIssue=TM-6472]

Employee cards in CDO/AO -> Employee Agendas were missing hyperlinks for employees whose profile didn't have a CDO listed. All of their names should be a hyperlink. See photos below for changes on local:

Before:
![No CDO, no hyperlink](https://github.com/user-attachments/assets/e641fc87-0d19-4b8f-ba9e-a9d0944a7358)

Now:

![No CDO still a hyperlink](https://github.com/user-attachments/assets/c934415f-99ee-48d1-bd7a-387caecc6278)


