### PR TITLE
Tm 6618 update ability to filter panel meeting agendas UI

### DIFF
--- a/src/Components/Agenda/AgendaItemRow/AgendaItemRow.jsx
+++ b/src/Components/Agenda/AgendaItemRow/AgendaItemRow.jsx
@@ -21,7 +21,6 @@ const AgendaItemRow = props => {
   const userRole = isCDO ? 'cdo' : 'ao';
   const perdet$ = perdet || get(agenda, 'perdet');
   const publicProfileLink = `/profile/public/${perdet$}${!isCDO ? '/ao' : ''}`;
-
   const userName = agenda?.full_name ?? '';
   const userSkill = agenda?.skills?.join(', ') || 'None Listed';
   const userLanguages = agenda?.languages?.length ? agenda.languages.map(
@@ -55,7 +54,7 @@ const AgendaItemRow = props => {
         <div className={`ai-history-row agenda-border-row--${agendaStatus} `}>
           <div className="ai-history-status">
             <div className={`agenda-tag--${agendaStatus} pmi-official-item-number`}>
-              {isPanelMeetingView && agenda?.pmi_official_item_num}
+              {isPanelMeetingView && agenda.pmi_official_item_num ? agenda.pmi_official_item_num : '-'}
             </div>
             <div className={`status-tag agenda-tag--${agendaStatus}`}>
               {get(agenda, 'status_full') || 'Default'}

--- a/src/Components/Panel/PanelMeetingAgendas/PanelMeetingAgendas.jsx
+++ b/src/Components/Panel/PanelMeetingAgendas/PanelMeetingAgendas.jsx
@@ -72,8 +72,6 @@ const PanelMeetingAgendas = (props) => {
   const genericFilters = useSelector(state => state.filters);
 
   const genericFilters$ = get(genericFilters, 'filters') || [];
-  const bureaus = genericFilters$.find(f => get(f, 'item.description') === 'region');
-  const bureausOptions = uniqBy(sortBy(get(bureaus, 'data'), [(b) => b.short_description]));
   const grades = genericFilters$.find(f => get(f, 'item.description') === 'grade');
   const gradesOptions = uniqBy(get(grades, 'data'), 'code');
   const skills = genericFilters$.find(f => get(f, 'item.description') === 'skill');
@@ -96,7 +94,6 @@ const PanelMeetingAgendas = (props) => {
     includes([orgsLoading, remarksLoading, statusLoading,
       actionLoading, categoryLoading], true);
 
-  const [selectedBureaus, setSelectedBureaus] = useState(get(userSelections, 'selectedBureaus') || []);
   const [selectedOrgs, setSelectedOrgs] = useState(get(userSelections, 'selectedOrgs') || []);
   const [selectedCategories, setSelectedCategories] = useState(get(userSelections, 'selectedCategories') || []);
   const [selectedGrades, setSelectedGrades] = useState(get(userSelections, 'selectedGrades') || []);
@@ -115,7 +112,6 @@ const PanelMeetingAgendas = (props) => {
     limit,
     ordering: ['-panel_date', 'agenda_id'],
     pmipmseqnum: pmSeqNums,
-    bureaus: selectedBureaus.map(bureauObject => bureauObject.code),
     orgs: selectedOrgs.map(orgObject => orgObject.code),
     categories: selectedCategories.map(categoryObject => categoryObject.mic_code),
     grades: selectedGrades.map(gradeObject => gradeObject.code),
@@ -128,7 +124,6 @@ const PanelMeetingAgendas = (props) => {
   });
 
   const getCurrentInputs = () => ({
-    selectedBureaus,
     selectedOrgs,
     selectedCategories,
     selectedGrades,
@@ -144,7 +139,6 @@ const PanelMeetingAgendas = (props) => {
 
   const fetchAndSet = () => {
     const filters = [
-      selectedBureaus,
       selectedOrgs,
       selectedCategories,
       selectedGrades,
@@ -171,7 +165,6 @@ const PanelMeetingAgendas = (props) => {
   useEffect(() => {
     fetchAndSet();
   }, [
-    selectedBureaus,
     selectedOrgs,
     selectedCategories,
     selectedGrades,
@@ -231,7 +224,6 @@ const PanelMeetingAgendas = (props) => {
   };
 
   const resetFilters = () => {
-    setSelectedBureaus([]);
     setSelectedOrgs([]);
     setSelectedCategories([]);
     setSelectedGrades([]);
@@ -286,19 +278,6 @@ const PanelMeetingAgendas = (props) => {
               </div>
             </div>
             <div className="usa-width-one-whole position-search--filters--panel-m-agendas">
-              <div className="filter-div">
-                <div className="label">Bureau:</div>
-                <Picky
-                  {...pickyProps}
-                  placeholder="Select Bureau(s)"
-                  value={selectedBureaus}
-                  options={bureausOptions}
-                  onChange={setSelectedBureaus}
-                  valueKey="code"
-                  labelKey="long_description"
-                  disabled={isLoading}
-                />
-              </div>
               <div className="filter-div">
                 <div className="label">Organization:</div>
                 <Picky

--- a/src/Components/Panel/PanelMeetingAgendas/PanelMeetingAgendas.jsx
+++ b/src/Components/Panel/PanelMeetingAgendas/PanelMeetingAgendas.jsx
@@ -279,7 +279,7 @@ const PanelMeetingAgendas = (props) => {
             </div>
             <div className="usa-width-one-whole position-search--filters--panel-m-agendas">
               <div className="filter-div">
-                <div className="label">Organization:</div>
+                <div className="label">Location/Org:</div>
                 <Picky
                   {...pickyProps}
                   placeholder="Select Organization(s)"


### PR DESCRIPTION
Dual Merge: 
- [API PR](https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/1094)

[Ticket](https://metaphase.atlassian.net/browse/TM-6618)

- removed bureau filter
- rename org filter label
- added '-' symbol when pm num is null, so it wasn't just a blank space (can only see this on dev1)